### PR TITLE
fix: restore vite-tsconfig-paths for baseUrl resolution

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -140,6 +140,7 @@
     "vite": "^8.0.10",
     "vite-plugin-env-compatible": "2.0.1",
     "vite-plugin-svgr": "5.2.0",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "4.1.2",
     "whatwg-fetch": "3.6.20"
   },

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -3,6 +3,7 @@ import {
     configDefaults,
     defineConfig as vitestDefineConfig,
 } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import envCompatible from 'vite-plugin-env-compatible';
@@ -65,9 +66,6 @@ export default defineConfig(({ mode }) => {
                 modulePreload: false,
                 cssCodeSplit: false,
                 ...(mode === 'development' ? { sourcemap: true } : {}),
-            },
-            resolve: {
-                tsconfigPaths: true,
             },
             server: {
                 open: true,
@@ -143,6 +141,7 @@ export default defineConfig(({ mode }) => {
                     },
                 },
                 react(),
+                tsconfigPaths(),
                 svgr(),
                 envCompatible(),
                 ...(mode === 'development'

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5703,6 +5703,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globrex@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "globrex@npm:0.1.2"
+  checksum: 10c0/a54c029520cf58bda1d8884f72bd49b4cd74e977883268d931fd83bcbd1a9eb96d57c7dbd4ad80148fb9247467ebfb9b215630b2ed7563b2a8de02e1ff7f89d1
+  languageName: node
+  linkType: hard
+
 "gopd@npm:^1.0.1, gopd@npm:^1.2.0":
   version: 1.2.0
   resolution: "gopd@npm:1.2.0"
@@ -9948,6 +9955,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsconfck@npm:^3.0.3":
+  version: 3.1.6
+  resolution: "tsconfck@npm:3.1.6"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    tsconfck: bin/tsconfck.js
+  checksum: 10c0/269c3c513540be44844117bb9b9258fe6f8aeab026d32aeebf458d5299125f330711429dbb556dbf125a0bc25f4a81e6c24ac96de2740badd295c3fb400f66c4
+  languageName: node
+  linkType: hard
+
 "tslib@npm:1.14.1, tslib@npm:^1.14.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
@@ -10375,6 +10396,7 @@ __metadata:
     vite: "npm:^8.0.10"
     vite-plugin-env-compatible: "npm:2.0.1"
     vite-plugin-svgr: "npm:5.2.0"
+    vite-tsconfig-paths: "npm:^5.1.4"
     vitest: "npm:4.1.2"
     whatwg-fetch: "npm:3.6.20"
   languageName: unknown
@@ -10594,6 +10616,22 @@ __metadata:
   peerDependencies:
     vite: ">=3.0.0"
   checksum: 10c0/818ddea9a25839f9a5e3903f55e738b3de2f76c374148a637e61e31e6a3ada815a061d3e8010306a9f2701827d2f34d8fbc5db47bf1e74059050ad7a57c0f601
+  languageName: node
+  linkType: hard
+
+"vite-tsconfig-paths@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "vite-tsconfig-paths@npm:5.1.4"
+  dependencies:
+    debug: "npm:^4.1.1"
+    globrex: "npm:^0.1.2"
+    tsconfck: "npm:^3.0.3"
+  peerDependencies:
+    vite: "*"
+  peerDependenciesMeta:
+    vite:
+      optional: true
+  checksum: 10c0/6228f23155ea25d92b1e1702284cf8dc52ad3c683c5ca691edd5a4c82d2913e7326d00708cef1cbfde9bb226261df0e0a12e03ef1d43b6a92d8f02b483ef37e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is an attempt to fix the Enterprise build issue due to to theme/app.css not being found. Claude suggests that it may be related to Vite 8's built-in `resolve.tsconfigPaths: true` not handling baseUrl-relative resolution reliably.

I'm not positive that this will fix it, but it's a small change and it goes back to the way we did it before vite8, so it seems worth trying. It's hard to replicate locally, so this is probably the quickest way to validate it. For reference, the handling was updated in https://github.com/Unleash/unleash/pull/11766.

Running the front end with this plugin makes vite emit this:
> The plugin "vite-tsconfig-paths" is detected. Vite now supports tsconfig paths resolution natively via the resolve.tsconfigPaths option. You can remove the plugin and set resolve.tsconfigPaths: true in your Vite config instead.

However, there may still be some issues left to fix (e.g. https://github.com/vitejs/vite/issues/21856 ; upstream PR to fix it https://github.com/oxc-project/oxc-resolver/pull/1080)


Claude's summary:

Vite 8's built-in `resolve.tsconfigPaths: true` only handles `paths` mappings reliably; baseUrl-relative resolution is fragile in some environments (we hit it in enterprise's pnpm-driven prepack of OSS, where `themes/app.css` and similar bare imports failed to resolve).

The pre-Vite-8 `vite-tsconfig-paths` plugin handled both. Re-add it with the same plugin position as before, and drop the built-in flag to avoid two resolvers disagreeing on edge cases. Drop the plugin again once the built-in handler matures.
