### PR TITLE
chore: getOnboardingStatusForProject add new onboarding status

### DIFF
--- a/frontend/src/openapi/models/projectOverviewSchemaOnboardingStatusOneOfStatus.ts
+++ b/frontend/src/openapi/models/projectOverviewSchemaOnboardingStatusOneOfStatus.ts
@@ -10,5 +10,6 @@ export type ProjectOverviewSchemaOnboardingStatusOneOfStatus =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ProjectOverviewSchemaOnboardingStatusOneOfStatus = {
     'onboarding-started': 'onboarding-started',
+    'sdk-connected': 'sdk-connected',
     onboarded: 'onboarded',
 } as const;

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -185,7 +185,7 @@ export const createStores = (
         projectFlagCreatorsReadModel: new ProjectFlagCreatorsReadModel(db),
         featureLifecycleStore: new FeatureLifecycleStore(db, eventBus),
         featureStrategiesReadModel: new FeatureStrategiesReadModel(db),
-        onboardingReadModel: createOnboardingReadModel(db),
+        onboardingReadModel: createOnboardingReadModel(db, config.flagResolver),
         onboardingStore: new OnboardingStore(db),
         featureLifecycleReadModel: new FeatureLifecycleReadModel(db),
         largestResourcesReadModel: new LargestResourcesReadModel(db),

--- a/src/lib/features/onboarding/createOnboardingReadModel.ts
+++ b/src/lib/features/onboarding/createOnboardingReadModel.ts
@@ -1,10 +1,16 @@
-import type { Db } from '../../types/index.js';
-import type { IOnboardingReadModel } from '../../types/index.js';
+import type {
+    Db,
+    IFlagResolver,
+    IOnboardingReadModel,
+} from '../../types/index.js';
 import { OnboardingReadModel } from './onboarding-read-model.js';
 import { FakeOnboardingReadModel } from './fake-onboarding-read-model.js';
 
-export const createOnboardingReadModel = (db: Db): IOnboardingReadModel => {
-    return new OnboardingReadModel(db);
+export const createOnboardingReadModel = (
+    db: Db,
+    flagResolver: IFlagResolver,
+): IOnboardingReadModel => {
+    return new OnboardingReadModel(db, flagResolver);
 };
 
 export const createFakeOnboardingReadModel = (): IOnboardingReadModel => {

--- a/src/lib/features/onboarding/fake-onboarding-read-model.ts
+++ b/src/lib/features/onboarding/fake-onboarding-read-model.ts
@@ -19,7 +19,9 @@ export class FakeOnboardingReadModel implements IOnboardingReadModel {
         return Promise.resolve([]);
     }
 
-    async getOnboardingStatusForProject(): Promise<OnboardingStatus | null> {
+    async getOnboardingStatusForProject(
+        _projectId?: string,
+    ): Promise<OnboardingStatus | null> {
         return null;
     }
 }

--- a/src/lib/features/onboarding/fake-onboarding-read-model.ts
+++ b/src/lib/features/onboarding/fake-onboarding-read-model.ts
@@ -19,9 +19,7 @@ export class FakeOnboardingReadModel implements IOnboardingReadModel {
         return Promise.resolve([]);
     }
 
-    async getOnboardingStatusForProject(
-        _projectId?: string,
-    ): Promise<OnboardingStatus | null> {
+    async getOnboardingStatusForProject(): Promise<OnboardingStatus | null> {
         return null;
     }
 }

--- a/src/lib/features/onboarding/onboarding-read-model.ts
+++ b/src/lib/features/onboarding/onboarding-read-model.ts
@@ -119,15 +119,14 @@ export class OnboardingReadModel implements IOnboardingReadModel {
                 return { status: 'onboarded' };
             }
 
-            const toggleResult = await db('events')
-                .whereIn('type', [FEATURE_ENVIRONMENT_ENABLED])
+            const toggleExists = await db('events')
+                .where('type', FEATURE_ENVIRONMENT_ENABLED)
                 .where('project', projectId)
-                .countDistinct('type as count')
+                .select(db.raw('1'))
+                .limit(1)
                 .first();
 
-            const toggleCount = Number(toggleResult?.count ?? 0);
-
-            if (toggleCount >= 1) {
+            if (toggleExists) {
                 return { status: 'onboarded' };
             }
             return { status: 'sdk-connected' };

--- a/src/lib/features/onboarding/onboarding-read-model.ts
+++ b/src/lib/features/onboarding/onboarding-read-model.ts
@@ -1,10 +1,15 @@
 import type { Db } from '../../db/db.js';
+import type { IFlagResolver } from '../../types/index.js';
 import type {
     IOnboardingReadModel,
     InstanceOnboarding,
     ProjectOnboarding,
     OnboardingStatus,
 } from './onboarding-read-model-type.js';
+import {
+    FEATURE_ENVIRONMENT_DISABLED,
+    FEATURE_ENVIRONMENT_ENABLED,
+} from '../../events/index.js';
 
 const instanceEventLookup = {
     'first-user-login': 'firstLogin',
@@ -23,8 +28,11 @@ const projectEventLookup = {
 export class OnboardingReadModel implements IOnboardingReadModel {
     private db: Db;
 
-    constructor(db: Db) {
+    private flagResolver: IFlagResolver;
+
+    constructor(db: Db, flagResolver: IFlagResolver) {
         this.db = db;
+        this.flagResolver = flagResolver;
     }
 
     async getInstanceOnboardingMetrics(): Promise<InstanceOnboarding> {
@@ -83,6 +91,9 @@ export class OnboardingReadModel implements IOnboardingReadModel {
     async getOnboardingStatusForProject(
         projectId: string,
     ): Promise<OnboardingStatus | null> {
+        const useNewSteps = this.flagResolver.isEnabled(
+            'onboardingProjectSetupNewSteps',
+        );
         const projectExists = await this.db('projects')
             .select(1)
             .where('id', projectId)
@@ -107,7 +118,25 @@ export class OnboardingReadModel implements IOnboardingReadModel {
             .first();
 
         if (lastSeen) {
-            return { status: 'onboarded' };
+            if (!useNewSteps) {
+                return { status: 'onboarded' };
+            }
+
+            const toggleResult = await db('events')
+                .whereIn('type', [
+                    FEATURE_ENVIRONMENT_ENABLED,
+                    FEATURE_ENVIRONMENT_DISABLED,
+                ])
+                .where('project', projectId)
+                .countDistinct('type as count')
+                .first();
+
+            const toggleCount = Number(toggleResult?.count ?? 0);
+
+            if (toggleCount >= 1) {
+                return { status: 'onboarded' };
+            }
+            return { status: 'sdk-connected' };
         }
 
         const feature = await this.db('features')

--- a/src/lib/features/onboarding/onboarding-read-model.ts
+++ b/src/lib/features/onboarding/onboarding-read-model.ts
@@ -6,10 +6,7 @@ import type {
     ProjectOnboarding,
     OnboardingStatus,
 } from './onboarding-read-model-type.js';
-import {
-    FEATURE_ENVIRONMENT_DISABLED,
-    FEATURE_ENVIRONMENT_ENABLED,
-} from '../../events/index.js';
+import { FEATURE_ENVIRONMENT_ENABLED } from '../../events/index.js';
 
 const instanceEventLookup = {
     'first-user-login': 'firstLogin',
@@ -123,10 +120,7 @@ export class OnboardingReadModel implements IOnboardingReadModel {
             }
 
             const toggleResult = await db('events')
-                .whereIn('type', [
-                    FEATURE_ENVIRONMENT_ENABLED,
-                    FEATURE_ENVIRONMENT_DISABLED,
-                ])
+                .whereIn('type', [FEATURE_ENVIRONMENT_ENABLED])
                 .where('project', projectId)
                 .countDistinct('type as count')
                 .first();

--- a/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
+++ b/src/lib/features/personal-dashboard/createPersonalDashboardService.ts
@@ -28,7 +28,7 @@ export const createPersonalDashboardService = (
         new PersonalDashboardReadModel(db),
         new ProjectOwnersReadModel(db),
         new ProjectReadModel(db, config.eventBus, config.flagResolver),
-        new OnboardingReadModel(db),
+        new OnboardingReadModel(db, config.flagResolver),
         new EventStore(db, config.getLogger),
         new FeatureEventFormatterMd({
             unleashUrl: config.server.unleashUrl,

--- a/src/lib/features/project/createProjectService.ts
+++ b/src/lib/features/project/createProjectService.ts
@@ -136,7 +136,7 @@ export const createProjectService = (
         config.flagResolver,
     );
 
-    const onboardingReadModel = createOnboardingReadModel(db);
+    const onboardingReadModel = createOnboardingReadModel(db, flagResolver);
 
     return new ProjectService(
         {

--- a/src/lib/features/project/projects.e2e.test.ts
+++ b/src/lib/features/project/projects.e2e.test.ts
@@ -8,6 +8,7 @@ import {
 import getLogger from '../../../test/fixtures/no-logger.js';
 
 import type { IProjectStore } from '../../types/index.js';
+import { DEFAULT_ENV } from '../../server-impl.js';
 
 let app: IUnleashTest;
 let db: ITestDb;
@@ -103,4 +104,70 @@ test('response should include technical debt field', async () => {
     expect(typeof body.projects[0].technicalDebt).toBe('number');
     expect(body.projects[0].technicalDebt).toBeGreaterThanOrEqual(0);
     expect(body.projects[0].technicalDebt).toBeLessThanOrEqual(100);
+});
+
+describe('onboardingStatus with onboardingProjectSetupNewSteps flag enabled', () => {
+    let appWithNewSteps: IUnleashTest;
+    let dbWithNewSteps: ITestDb;
+
+    beforeAll(async () => {
+        dbWithNewSteps = await dbInit(
+            'projects_api_new_onboarding_steps',
+            getLogger,
+        );
+        appWithNewSteps = await setupAppWithCustomConfig(
+            dbWithNewSteps.stores,
+            {
+                experimental: {
+                    flags: {
+                        strictSchemaValidation: true,
+                        onboardingProjectSetupNewSteps: true,
+                    },
+                },
+            },
+            dbWithNewSteps.rawDatabase,
+        );
+    });
+
+    afterEach(async () => {
+        await dbWithNewSteps.stores.featureToggleStore.deleteAll();
+    });
+
+    afterAll(async () => {
+        await appWithNewSteps.destroy();
+        await dbWithNewSteps.destroy();
+    });
+
+    test('returns sdk-connected when SDK is connected but no flag has been enabled in an environment', async () => {
+        await appWithNewSteps.createFeature({ name: 'my-flag' });
+        await dbWithNewSteps.stores.lastSeenStore.setLastSeen([
+            { environment: DEFAULT_ENV, featureName: 'my-flag' },
+        ]);
+
+        const { body } = await appWithNewSteps.request
+            .get('/api/admin/projects/default/overview')
+            .expect(200);
+
+        expect(body.onboardingStatus).toMatchObject({
+            status: 'sdk-connected',
+        });
+    });
+
+    test('returns onboarded when SDK is connected and a flag has been enabled in an environment', async () => {
+        await appWithNewSteps.createFeature({ name: 'my-flag' });
+        await dbWithNewSteps.stores.lastSeenStore.setLastSeen([
+            { environment: DEFAULT_ENV, featureName: 'my-flag' },
+        ]);
+        await appWithNewSteps.request
+            .post(
+                `/api/admin/projects/default/features/my-flag/environments/${DEFAULT_ENV}/on`,
+            )
+            .expect(200);
+
+        const { body } = await appWithNewSteps.request
+            .get('/api/admin/projects/default/overview')
+            .expect(200);
+
+        expect(body.onboardingStatus).toMatchObject({ status: 'onboarded' });
+    });
 });

--- a/src/lib/openapi/spec/project-overview-schema.ts
+++ b/src/lib/openapi/spec/project-overview-schema.ts
@@ -168,7 +168,11 @@ export const projectOverviewSchema = {
                     properties: {
                         status: {
                             type: 'string',
-                            enum: ['onboarding-started', 'onboarded'],
+                            enum: [
+                                'onboarding-started',
+                                'sdk-connected',
+                                'onboarded',
+                            ],
                             example: 'onboarding-started',
                         },
                     },

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -368,7 +368,7 @@ export interface IProjectHealth {
 
 export type ProjectOnboardingStatus =
     | {
-          status: 'onboarding-started' | 'onboarded';
+          status: 'onboarding-started' | 'sdk-connected' | 'onboarded';
       }
     | { status: 'first-flag-created'; feature: string };
 

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -56,7 +56,7 @@ process.nextTick(async () => {
                         safeguards: true,
                         gtmReleaseManagement: true,
                         regexConstraintOperator: true,
-                        onboardingProjectSetupNewSteps: true,
+                        onboardingProjectSetupNewSteps: false,
                         enterpriseEdgeTokensList: true,
                         userTokenWithClientApiLoggingKillSwitch: false,
                         onlyFeatureTokensWithFeatureAPIs: false,


### PR DESCRIPTION
Under a feature flag return new onboarding status. It's not handled yet on the frontend and I depend on it being disabled there. 