### PR TITLE
chore: update orval types for sdk-connected onboarding status

### DIFF
--- a/frontend/src/openapi/models/personalDashboardProjectDetailsSchemaOnboardingStatusOneOfStatus.ts
+++ b/frontend/src/openapi/models/personalDashboardProjectDetailsSchemaOnboardingStatusOneOfStatus.ts
@@ -11,5 +11,6 @@ export type PersonalDashboardProjectDetailsSchemaOnboardingStatusOneOfStatus =
 export const PersonalDashboardProjectDetailsSchemaOnboardingStatusOneOfStatus =
     {
         'onboarding-started': 'onboarding-started',
+        'sdk-connected': 'sdk-connected',
         onboarded: 'onboarded',
     } as const;

--- a/frontend/src/openapi/models/projectOverviewSchemaOnboardingStatusOneOfStatus.ts
+++ b/frontend/src/openapi/models/projectOverviewSchemaOnboardingStatusOneOfStatus.ts
@@ -10,5 +10,6 @@ export type ProjectOverviewSchemaOnboardingStatusOneOfStatus =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ProjectOverviewSchemaOnboardingStatusOneOfStatus = {
     'onboarding-started': 'onboarding-started',
+    'sdk-connected': 'sdk-connected',
     onboarded: 'onboarded',
 } as const;


### PR DESCRIPTION
Regenerated Orval types to pick up the new `sdk-connected` value in the project onboarding status enum.
- `ProjectOverviewSchemaOnboardingStatusOneOfStatus`
