### PR TITLE
chore: new project onboarding header progress

### DIFF
--- a/frontend/src/component/onboarding/flow/OnboardingProgress.test.tsx
+++ b/frontend/src/component/onboarding/flow/OnboardingProgress.test.tsx
@@ -1,0 +1,37 @@
+import { vi } from 'vitest';
+import { render } from 'utils/testRenderer';
+import { screen, fireEvent } from '@testing-library/react';
+import { OnboardingProgress } from './OnboardingProgress.tsx';
+
+const renderProgress = (step: number, maxSteps = 3, onDismiss = vi.fn()) =>
+    render(
+        <OnboardingProgress
+            step={step}
+            maxSteps={maxSteps}
+            onDismiss={onDismiss}
+        />,
+    );
+
+test('shows step count', () => {
+    renderProgress(1);
+    expect(screen.getByText('1/3 Completed')).toBeInTheDocument();
+});
+
+test('shows progress bar when not yet onboarded', () => {
+    renderProgress(1);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull();
+});
+
+test('shows dismiss button when onboarded', () => {
+    renderProgress(3);
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).toBeNull();
+});
+
+test('calls onDismiss when dismiss button is clicked', () => {
+    const onDismiss = vi.fn();
+    renderProgress(3, 3, onDismiss);
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+});

--- a/frontend/src/component/onboarding/flow/OnboardingProgress.tsx
+++ b/frontend/src/component/onboarding/flow/OnboardingProgress.tsx
@@ -1,0 +1,50 @@
+import { Button, LinearProgress, styled } from '@mui/material';
+
+const ProgressContainer = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+}));
+
+const StyledLinearProgress = styled(LinearProgress)(({ theme }) => ({
+    width: '100px',
+    height: theme.spacing(0.5),
+    borderRadius: theme.shape.borderRadiusLarge,
+}));
+
+interface IOnboardingProgressProps {
+    step: number;
+    maxSteps: number;
+    onDismiss: () => void;
+}
+
+export const OnboardingProgress = ({
+    step,
+    maxSteps,
+    onDismiss,
+}: IOnboardingProgressProps) => {
+    const isOnboarded = step >= maxSteps;
+    const fakeSomeProgressToMakeItLookBetter = 10;
+    const progress =
+        (step / maxSteps) * 100 + fakeSomeProgressToMakeItLookBetter;
+    return (
+        <ProgressContainer>
+            {step}/{maxSteps} Completed
+            {isOnboarded ? (
+                <Button
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        onDismiss();
+                    }}
+                    variant='outlined'
+                    component='span'
+                >
+                    Dismiss
+                </Button>
+            ) : (
+                <StyledLinearProgress variant='determinate' value={progress} />
+            )}
+        </ProgressContainer>
+    );
+};

--- a/frontend/src/component/onboarding/flow/ProjectOnboarding.tsx
+++ b/frontend/src/component/onboarding/flow/ProjectOnboarding.tsx
@@ -2,7 +2,6 @@ import {
     Accordion,
     AccordionDetails,
     AccordionSummary,
-    Button,
     styled,
     Typography,
 } from '@mui/material';
@@ -16,6 +15,7 @@ import { FlagCreationButton } from '../../project/Project/PaginatedProjectFeatur
 import ResponsiveButton from 'component/common/ResponsiveButton/ResponsiveButton';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 import { SdkExample } from './SdkExample.tsx';
+import { OnboardingProgress } from './OnboardingProgress.tsx';
 
 interface IProjectOnboardingProps {
     projectId: string;
@@ -121,6 +121,8 @@ const SuccessContainer = styled('div')(({ theme }) => ({
     padding: theme.spacing(2, 2, 2, 2),
 }));
 
+const NUMBER_OF_STEPS = 3;
+
 export const ProjectOnboarding = ({
     projectId,
     setConnectSdkOpen,
@@ -130,7 +132,16 @@ export const ProjectOnboarding = ({
     const { project } = useProjectOverview(projectId);
     const isFirstFlagCreated =
         project.onboardingStatus?.status === 'first-flag-created';
+    const isSDKConnected = project.onboardingStatus?.status === 'sdk-connected';
     const isOndoarded = project.onboardingStatus?.status === 'onboarded';
+
+    const step = isOndoarded
+        ? NUMBER_OF_STEPS
+        : isSDKConnected
+          ? 2
+          : isFirstFlagCreated
+            ? 1
+            : 0;
 
     const closeOnboardingFlow = () => {
         setOnboardingFlow('closed');
@@ -145,19 +156,11 @@ export const ProjectOnboarding = ({
             >
                 <TitleRow>
                     <Typography fontWeight='bold'>Project setup</Typography>
-
-                    {isOndoarded && (
-                        <Button
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                closeOnboardingFlow();
-                            }}
-                            variant='outlined'
-                            component='span'
-                        >
-                            Dismiss
-                        </Button>
-                    )}
+                    <OnboardingProgress
+                        step={step}
+                        maxSteps={NUMBER_OF_STEPS}
+                        onDismiss={closeOnboardingFlow}
+                    />
                 </TitleRow>
             </StyledAccordionSummary>
             <StyledAccordionDetails>


### PR DESCRIPTION
<img width="920" height="97" alt="Screenshot 2026-05-05 at 14 40 17" src="https://github.com/user-attachments/assets/7c4ce78e-d826-412d-9861-17203dad7db7" />

I'm missing Storybook 😞, but the other versions of the progress should look like this: 
<img width="299" height="225" alt="Screenshot 2026-05-05 at 14 27 14" src="https://github.com/user-attachments/assets/f8f50bd0-502e-447d-9ff1-2b832a5a3a75" />
