### PR TITLE
refactor: Enable biome "useExhaustiveDependencies" for GenerateApiKey

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -190,7 +190,6 @@
         "frontend/src/component/layout/MainLayout/AdminMenu/AdminNavigationItems.tsx",
         "frontend/src/component/layout/MainLayout/NavigationSidebar/useNavigationMode.ts",
         "frontend/src/component/onboarding/dialog/ConnectSdkDialog.tsx",
-        "frontend/src/component/onboarding/dialog/GenerateApiKey.tsx",
         "frontend/src/component/personalDashboard/FlagMetricsChart.tsx",
         "frontend/src/component/personalDashboard/PersonalDashboard.tsx",
         "frontend/src/component/personalDashboard/WelcomeDialogProvider.tsx",

--- a/frontend/src/component/onboarding/dialog/GenerateApiKey.tsx
+++ b/frontend/src/component/onboarding/dialog/GenerateApiKey.tsx
@@ -208,7 +208,7 @@ export const GenerateApiKey = ({
 
     useEffect(() => {
         onApiKey(currentEnvironmentToken?.secret || null);
-    }, [currentEnvironmentToken]);
+    }, [onApiKey, currentEnvironmentToken]);
 
     const parsedToken = parseToken(currentEnvironmentToken?.secret);
 


### PR DESCRIPTION
Enable biome `"useExhaustiveDependencies"` for `frontend/src/component/onboarding/dialog/GenerateApiKey.tsx`

Manually tested it and it seems to work just fine