### PR TITLE
chore: replace deprecated TextField props

### DIFF
--- a/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
+++ b/frontend/src/component/admin/auth/SamlAuth/SamlAuth.tsx
@@ -208,18 +208,20 @@ export const SamlAuth = () => {
                             value={data.certificate}
                             disabled={!data.enabled || samlConfiguredThroughEnv}
                             style={{ width: '100%' }}
-                            InputProps={{
-                                style: {
-                                    fontSize: '0.6em',
-                                    fontFamily: 'monospace',
-                                },
-                            }}
                             multiline
                             rows={14}
                             maxRows={14}
                             variant='outlined'
                             size='small'
                             required
+                            slotProps={{
+                                input: {
+                                    style: {
+                                        fontSize: '0.6em',
+                                        fontFamily: 'monospace',
+                                    },
+                                },
+                            }}
                         />
                     </Grid>
                 </Grid>
@@ -263,17 +265,19 @@ export const SamlAuth = () => {
                             value={data.spCertificate}
                             disabled={!data.enabled || samlConfiguredThroughEnv}
                             style={{ width: '100%' }}
-                            InputProps={{
-                                style: {
-                                    fontSize: '0.6em',
-                                    fontFamily: 'monospace',
-                                },
-                            }}
                             multiline
                             rows={14}
                             maxRows={14}
                             variant='outlined'
                             size='small'
+                            slotProps={{
+                                input: {
+                                    style: {
+                                        fontSize: '0.6em',
+                                        fontFamily: 'monospace',
+                                    },
+                                },
+                            }}
                         />
                     </Grid>
                 </Grid>

--- a/frontend/src/component/admin/cors/CorsForm.tsx
+++ b/frontend/src/component/admin/cors/CorsForm.tsx
@@ -63,8 +63,13 @@ export const CorsForm = ({ frontendApiOrigins }: ICorsFormProps) => {
                     rows={12}
                     variant='outlined'
                     fullWidth
-                    InputProps={{
-                        style: { fontFamily: 'monospace', fontSize: '0.8em' },
+                    slotProps={{
+                        input: {
+                            style: {
+                                fontFamily: 'monospace',
+                                fontSize: '0.8em',
+                            },
+                        },
                     }}
                 />
                 <UpdateButton permission={[ADMIN, UPDATE_CORS]} />

--- a/frontend/src/component/common/AutocompleteBox/AutocompleteBox.tsx
+++ b/frontend/src/component/common/AutocompleteBox/AutocompleteBox.tsx
@@ -71,10 +71,6 @@ export const AutocompleteBox = ({
         return (
             <TextField
                 {...params}
-                InputProps={{
-                    ...InputProps,
-                    startAdornment,
-                }}
                 variant='outlined'
                 sx={{
                     width,
@@ -98,6 +94,12 @@ export const AutocompleteBox = ({
                     },
                 }}
                 placeholder={label}
+                slotProps={{
+                    input: {
+                        ...InputProps,
+                        startAdornment,
+                    },
+                }}
             />
         );
     };

--- a/frontend/src/component/common/DateTimePicker/DateTimePicker.tsx
+++ b/frontend/src/component/common/DateTimePicker/DateTimePicker.tsx
@@ -51,14 +51,17 @@ export const DateTimePicker = ({
                 const parsedDate = parseValidDate(e.target.value);
                 onChange(parsedDate ?? value);
             }}
-            FormHelperTextProps={{
-                'data-testid': INPUT_ERROR_TEXT,
-            }}
-            inputProps={{
-                min: min ? getDate(min.toISOString()) : min,
-                max: max ? getDate(max.toISOString()) : max,
-            }}
             {...rest}
+            slotProps={{
+                htmlInput: {
+                    min: min ? getDate(min.toISOString()) : min,
+                    max: max ? getDate(max.toISOString()) : max,
+                },
+
+                formHelperText: {
+                    'data-testid': INPUT_ERROR_TEXT,
+                },
+            }}
         />
     );
 };

--- a/frontend/src/component/common/Input/Input.tsx
+++ b/frontend/src/component/common/Input/Input.tsx
@@ -46,14 +46,16 @@ const Input = ({
                 className={className ? className : ''}
                 value={value}
                 onChange={onChange}
-                FormHelperTextProps={{
-                    'data-testid': INPUT_ERROR_TEXT,
-                    title: errorText,
-                    classes: {
-                        root: styles.helperText,
+                {...rest}
+                slotProps={{
+                    formHelperText: {
+                        'data-testid': INPUT_ERROR_TEXT,
+                        title: errorText,
+                        classes: {
+                            root: styles.helperText,
+                        },
                     },
                 }}
-                {...rest}
             />
         </StyledDiv>
     );

--- a/frontend/src/component/context/ContextForm/ContextForm.tsx
+++ b/frontend/src/component/context/ContextForm/ContextForm.tsx
@@ -202,7 +202,9 @@ export const ContextForm: React.FC<IContextForm> = ({
                         onKeyPress={(e) => onKeyDown(e)}
                         onBlur={() => setValueFocused(false)}
                         onFocus={() => setValueFocused(true)}
-                        inputProps={{ maxLength: 100 }}
+                        slotProps={{
+                            htmlInput: { maxLength: 100 },
+                        }}
                     />
                     <TextField
                         label='Value description (optional)'
@@ -214,7 +216,9 @@ export const ContextForm: React.FC<IContextForm> = ({
                         onKeyPress={(e) => onKeyDown(e)}
                         onBlur={() => setValueFocused(false)}
                         onFocus={() => setValueFocused(true)}
-                        inputProps={{ maxLength: 100 }}
+                        slotProps={{
+                            htmlInput: { maxLength: 100 },
+                        }}
                     />
                     <Button
                         sx={{ gridColumn: 2 }}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/ConstraintValueSearch.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/ConstraintValueSearch.tsx
@@ -34,12 +34,14 @@ export const ConstraintValueSearch = ({
                 }}
                 variant='outlined'
                 size='small'
-                InputProps={{
-                    startAdornment: (
-                        <InputAdornment position='start'>
-                            <Search />
-                        </InputAdornment>
-                    ),
+                slotProps={{
+                    input: {
+                        startAdornment: (
+                            <InputAdornment position='start'>
+                                <Search />
+                            </InputAdornment>
+                        ),
+                    },
                 }}
             />
         </div>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/MilestoneProgressionForm/MilestoneProgressionTimeInput.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/MilestoneProgressionForm/MilestoneProgressionTimeInput.tsx
@@ -52,17 +52,19 @@ export const MilestoneProgressionTimeInput = ({
                 value={timeValue}
                 onChange={onTimeValueChange}
                 onPaste={handleNumericPaste}
-                inputProps={{
-                    pattern: '[0-9]*',
-                    'aria-label': 'Time duration value',
-                    'aria-describedby': 'time-unit-select',
-                }}
                 sx={{
                     width: `max(60px, ${String(timeValue).length + 8}ch)`,
                     maxWidth: '300px',
                 }}
                 size='small'
                 disabled={disabled}
+                slotProps={{
+                    htmlInput: {
+                        pattern: '[0-9]*',
+                        'aria-label': 'Time duration value',
+                        'aria-describedby': 'time-unit-select',
+                    },
+                }}
             />
             <StyledSelect
                 value={timeUnit}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/SafeguardForm/SafeguardForm.tsx
@@ -591,9 +591,6 @@ const SafeguardFormBase: FC<SafeguardFormBaseProps> = ({
                             <FormControl variant='outlined' size='small'>
                                 <TextField
                                     type='number'
-                                    inputProps={{
-                                        step: 0.1,
-                                    }}
                                     value={thresholdInputValue}
                                     onChange={handleThresholdInputChange}
                                     onFocus={handleThresholdFocus}
@@ -603,6 +600,11 @@ const SafeguardFormBase: FC<SafeguardFormBaseProps> = ({
                                     variant='outlined'
                                     size='small'
                                     required
+                                    slotProps={{
+                                        htmlInput: {
+                                            step: 0.1,
+                                        },
+                                    }}
                                 />
                             </FormControl>
                         </StyledTopRow>

--- a/frontend/src/component/feedbackNew/FeedbackComponent.tsx
+++ b/frontend/src/component/feedbackNew/FeedbackComponent.tsx
@@ -346,11 +346,13 @@ export const FeedbackComponent = ({
                                                 rows={3}
                                                 variant='outlined'
                                                 size='small'
-                                                InputLabelProps={{
-                                                    style: {
-                                                        fontSize:
-                                                            theme.fontSizes
-                                                                .smallBody,
+                                                slotProps={{
+                                                    inputLabel: {
+                                                        style: {
+                                                            fontSize:
+                                                                theme.fontSizes
+                                                                    .smallBody,
+                                                        },
                                                     },
                                                 }}
                                             />
@@ -364,16 +366,18 @@ export const FeedbackComponent = ({
                                                 multiline
                                                 name='areasForImprovement'
                                                 rows={3}
-                                                InputLabelProps={{
-                                                    style: {
-                                                        fontSize:
-                                                            theme.fontSizes
-                                                                .smallBody,
-                                                    },
-                                                }}
                                                 variant='outlined'
                                                 size='small'
                                                 hidden
+                                                slotProps={{
+                                                    inputLabel: {
+                                                        style: {
+                                                            fontSize:
+                                                                theme.fontSizes
+                                                                    .smallBody,
+                                                        },
+                                                    },
+                                                }}
                                             />
                                         </Box>
                                     </>
@@ -393,11 +397,13 @@ export const FeedbackComponent = ({
                                                 rows={3}
                                                 variant='outlined'
                                                 size='small'
-                                                InputLabelProps={{
-                                                    style: {
-                                                        fontSize:
-                                                            theme.fontSizes
-                                                                .smallBody,
+                                                slotProps={{
+                                                    inputLabel: {
+                                                        style: {
+                                                            fontSize:
+                                                                theme.fontSizes
+                                                                    .smallBody,
+                                                        },
                                                     },
                                                 }}
                                             />
@@ -416,15 +422,17 @@ export const FeedbackComponent = ({
                                                 multiline
                                                 name='areasForImprovement'
                                                 rows={3}
-                                                InputLabelProps={{
-                                                    style: {
-                                                        fontSize:
-                                                            theme.fontSizes
-                                                                .smallBody,
-                                                    },
-                                                }}
                                                 variant='outlined'
                                                 size='small'
+                                                slotProps={{
+                                                    inputLabel: {
+                                                        style: {
+                                                            fontSize:
+                                                                theme.fontSizes
+                                                                    .smallBody,
+                                                        },
+                                                    },
+                                                }}
                                             />
                                         </Box>
                                     </>

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/DefineMetricForm.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/DefineMetricForm.tsx
@@ -137,10 +137,6 @@ export const DefineMetricForm = ({
                     id={metricNameInputId}
                     value={metricName}
                     onChange={(event) => setMetricName(event.target.value)}
-                    inputProps={{
-                        pattern: '^[a-zA-Z_:][a-zA-Z0-9_:]*$',
-                        title: 'The name must contain only alphanumeric characters, underscores, and colons. It must start with a letter.',
-                    }}
                     placeholder='e.g., checkout_error_count'
                     variant='outlined'
                     size='small'
@@ -150,6 +146,12 @@ export const DefineMetricForm = ({
                     sx={{
                         '.MuiFormHelperText-root': {
                             marginInline: 0,
+                        },
+                    }}
+                    slotProps={{
+                        htmlInput: {
+                            pattern: '^[a-zA-Z_:][a-zA-Z0-9_:]*$',
+                            title: 'The name must contain only alphanumeric characters, underscores, and colons. It must start with a letter.',
                         },
                     }}
                 />

--- a/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
@@ -213,10 +213,12 @@ export const PlaygroundCodeFieldset: FC<IPlaygroundCodeFieldsetProps> = ({
                         const dateString = parsedDate?.toISOString();
                         dateString && setContextValue(dateString);
                     }}
-                    InputLabelProps={{
-                        shrink: true,
-                    }}
                     required
+                    slotProps={{
+                        inputLabel: {
+                            shrink: true,
+                        },
+                    }}
                 />
             );
         }

--- a/frontend/src/component/user/DemoAuth/DemoAuth.tsx
+++ b/frontend/src/component/user/DemoAuth/DemoAuth.tsx
@@ -65,7 +65,6 @@ const DemoAuth: VFC<IDemoAuthProps> = ({ authDetails, redirect }) => {
                         value={email}
                         className={styles.emailField}
                         onChange={handleChange}
-                        inputProps={{ 'data-testid': 'email-input-field' }}
                         size='small'
                         variant='outlined'
                         label='Email'
@@ -74,6 +73,9 @@ const DemoAuth: VFC<IDemoAuthProps> = ({ authDetails, redirect }) => {
                         data-testid={LOGIN_EMAIL_ID}
                         required
                         type={email === 'admin' ? 'text' : 'email'}
+                        slotProps={{
+                            htmlInput: { 'data-testid': 'email-input-field' },
+                        }}
                     />
 
                     <Button

--- a/frontend/src/component/user/SimpleAuth/SimpleAuth.tsx
+++ b/frontend/src/component/user/SimpleAuth/SimpleAuth.tsx
@@ -64,7 +64,6 @@ const SimpleAuth: VFC<ISimpleAuthProps> = ({ authDetails, redirect }) => {
                 <TextField
                     value={email}
                     onChange={handleChange}
-                    inputProps={{ 'data-testid': 'email-input-field' }}
                     size='small'
                     variant='outlined'
                     label='Email'
@@ -74,6 +73,9 @@ const SimpleAuth: VFC<ISimpleAuthProps> = ({ authDetails, redirect }) => {
                     type='email'
                     data-testid={LOGIN_EMAIL_ID}
                     autoFocus
+                    slotProps={{
+                        htmlInput: { 'data-testid': 'email-input-field' },
+                    }}
                 />
                 <br />
 


### PR DESCRIPTION
Updates deprecated `TextField` props.

Changes are from running MUI codemod: 
`npx @mui/codemod@latest deprecations/text-field-props frontend`

This does not seem to be strictly needed for the migration to MUI v7, but we've seen issues with e.g. an old `inputProps` breaking a test (see [this commit](https://github.com/Unleash/unleash/pull/11941/changes/24390024e499c5168ac83151d9230149e532f18c)). 
We could also have this as a separate PR against `main` after we merge #11941 if we prefer. 