### PR TITLE
feat(onboarding): implement new step 3 (turn flag on/off)

### DIFF
--- a/frontend/src/component/onboarding/flow/ProjectOnboarding.tsx
+++ b/frontend/src/component/onboarding/flow/ProjectOnboarding.tsx
@@ -7,11 +7,11 @@ import {
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { ConnectSdkStep } from './steps/ConnectSdkStep.tsx';
-import { ActionBox, type StepState } from './steps/StepLayout.tsx';
+import type { StepState } from './steps/StepLayout.tsx';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
-import { SdkExample } from './SdkExample.tsx';
 import { OnboardingProgress } from './OnboardingProgress.tsx';
 import { CreateFlagStep } from './steps/CreateFlagStep.tsx';
+import { TurnFlagStep } from './steps/TurnFlagStep.tsx';
 
 interface IProjectOnboardingProps {
     projectId: string;
@@ -115,9 +115,10 @@ export const ProjectOnboarding = ({
                         setConnectSdkOpen={setConnectSdkOpen}
                         state={stepState(step, 2)}
                     />
-                    <ActionBox>
-                        <SdkExample />
-                    </ActionBox>
+                    <TurnFlagStep
+                        projectId={projectId}
+                        state={stepState(step, 3)}
+                    />
                 </Actions>
             </StyledAccordionDetails>
         </StyledAccordion>

--- a/frontend/src/component/onboarding/flow/steps/TurnFlagStep.tsx
+++ b/frontend/src/component/onboarding/flow/steps/TurnFlagStep.tsx
@@ -1,0 +1,55 @@
+import { Button } from '@mui/material';
+import ToggleOnIcon from '@mui/icons-material/ToggleOn';
+import CheckIcon from '@mui/icons-material/Check';
+import { Link } from 'react-router-dom';
+import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
+import { StepLayout, type StepState } from './StepLayout.tsx';
+
+interface ITurnFlagStepProps {
+    projectId: string;
+    state: StepState;
+}
+
+export const TurnFlagStep = ({ projectId, state }: ITurnFlagStepProps) => {
+    const { features } = useFeatureSearch({
+        project: `IS:${projectId}`,
+    });
+    const firstFeature = features[0]?.name;
+    const goToFlagHref = firstFeature
+        ? `/projects/${projectId}/features/${firstFeature}`
+        : `/projects/${projectId}`;
+
+    return (
+        <StepLayout
+            stepNumber={3}
+            state={state}
+            icon={<ToggleOnIcon />}
+            title='Turn flag on/off'
+            body='Check that the flag is working by turning it on and off.'
+        >
+            {state === 'done' ? (
+                <Button
+                    variant='outlined'
+                    color='inherit'
+                    startIcon={<CheckIcon />}
+                    disabled
+                >
+                    Done
+                </Button>
+            ) : state === 'active' ? (
+                <Button
+                    variant='contained'
+                    color='primary'
+                    component={Link}
+                    to={goToFlagHref}
+                >
+                    Go to flag
+                </Button>
+            ) : (
+                <Button variant='contained' color='primary' disabled>
+                    Go to flag
+                </Button>
+            )}
+        </StepLayout>
+    );
+};


### PR DESCRIPTION
## Summary

Implements step 3 ("Turn flag on/off") of the new project onboarding flowon top of the shared `StepLayout` shell that landed with step 2.


<img width="1880" height="306" alt="Screenshot from 2026-05-06 14-02-52" src="https://github.com/user-attachments/assets/772dd57c-cbd1-48f7-beef-c925f493817c" />
<img width="1880" height="306" alt="Screenshot from 2026-05-06 14-02-35" src="https://github.com/user-attachments/assets/51ee2f19-2e95-4b2e-807b-968e73540ff1" />

