### PR TITLE
fix(onboarding): avoid all-done flash and align step 3 copy

### DIFF
--- a/frontend/src/component/onboarding/flow/ProjectOnboarding.tsx
+++ b/frontend/src/component/onboarding/flow/ProjectOnboarding.tsx
@@ -69,7 +69,10 @@ export const ProjectOnboarding = ({
     refetchFeatures,
 }: IProjectOnboardingProps) => {
     const { project, refetch, loading } = useProjectOverview(projectId);
-    const status = loading ? undefined : project.onboardingStatus?.status;
+
+    if (loading) return null;
+
+    const status = project.onboardingStatus?.status;
     const isFirstFlagCreated = status === 'first-flag-created';
     const isSDKConnected = status === 'sdk-connected';
     const isOnboarded = status === 'onboarded';

--- a/frontend/src/component/onboarding/flow/ProjectOnboarding.tsx
+++ b/frontend/src/component/onboarding/flow/ProjectOnboarding.tsx
@@ -68,11 +68,11 @@ export const ProjectOnboarding = ({
     setOnboardingFlow,
     refetchFeatures,
 }: IProjectOnboardingProps) => {
-    const { project, refetch } = useProjectOverview(projectId);
-    const isFirstFlagCreated =
-        project.onboardingStatus?.status === 'first-flag-created';
-    const isSDKConnected = project.onboardingStatus?.status === 'sdk-connected';
-    const isOnboarded = project.onboardingStatus?.status === 'onboarded';
+    const { project, refetch, loading } = useProjectOverview(projectId);
+    const status = loading ? undefined : project.onboardingStatus?.status;
+    const isFirstFlagCreated = status === 'first-flag-created';
+    const isSDKConnected = status === 'sdk-connected';
+    const isOnboarded = status === 'onboarded';
 
     let step = 0;
     if (isOnboarded) {

--- a/frontend/src/component/onboarding/flow/steps/TurnFlagStep.tsx
+++ b/frontend/src/component/onboarding/flow/steps/TurnFlagStep.tsx
@@ -24,8 +24,8 @@ export const TurnFlagStep = ({ projectId, state }: ITurnFlagStepProps) => {
             stepNumber={3}
             state={state}
             icon={<ToggleOnIcon />}
-            title='Turn flag on/off'
-            body='Check that the flag is working by turning it on and off.'
+            title='Turn flag on'
+            body='Check that the flag is working by turning it on.'
         >
             {state === 'done' ? (
                 <Button


### PR DESCRIPTION
Two small fixes

 - **No "all-done" flash on load.** `useProjectOverview`'s `fallbackProject` has `status: 'onboarded'`, which made all three steps render as done during the initial SWR fetch. Hide the accordion while `loading` is true.    
  - **Step 3 copy.** Title `Turn flag on/off` → `Turn flag on`. Body updated to match, we no longer ask the user to also turn it off. 