### PR TITLE
chore: replace deprecated @mui/base with @base-ui/react

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,7 @@
     "@emotion/cache": "11.14.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "11.14.1",
-    "@mui/base": "5.0.0-beta.70",
+    "@base-ui/react": "^1.4.1",
     "@mui/icons-material": "7.3.10",
     "@mui/lab": "7.0.1-beta.24",
     "@mui/material": "7.3.10",

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeTabComponents.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeTabComponents.tsx
@@ -1,64 +1,55 @@
-import {
-    Tab as MuiTab,
-    TabPanel as MuiTabPanel,
-    Tabs as MuiTabs,
-    TabsList as MuiTabsList,
-} from '@mui/base'; // TODO: migrate off deprecated @mui/base
+import { Tabs as BaseTabs } from '@base-ui/react/tabs';
 import { Button, type ButtonProps, styled } from '@mui/material';
 import type { PropsWithChildren } from 'react';
 
-export const TabList = styled(MuiTabsList)(({ theme }) => ({
+const StyledTabList = styled(BaseTabs.List)(({ theme }) => ({
     display: 'inline-flex',
     flexDirection: 'row',
     gap: theme.spacing(0.5),
 }));
 
+export const TabList = ({ children }: PropsWithChildren) => (
+    <StyledTabList activateOnFocus>{children}</StyledTabList>
+);
+
 const StyledButton = styled(Button)(({ theme }) => ({
-    whiteSpace: 'nowrap',
-    color: theme.palette.text.secondary,
-    fontWeight: 'normal',
     '&[aria-selected="true"]': {
-        fontWeight: 'bold',
-        color: theme.palette.primary.main,
         background: theme.palette.background.elevation1,
     },
 }));
 
-export const Tab = styled(({ children }: ButtonProps) => (
-    <MuiTab slots={{ root: StyledButton }}>{children}</MuiTab>
-))(({ theme }) => ({
-    position: 'absolute',
-    top: theme.spacing(-0.5),
-    left: theme.spacing(2),
-    transform: 'translateY(-50%)',
-    padding: theme.spacing(0.75, 1),
-    lineHeight: 1,
-    fontSize: theme.fontSizes.smallerBody,
-    color: theme.palette.text.primary,
-    background: theme.palette.background.application,
-    borderRadius: theme.shape.borderRadiusExtraLarge,
-    zIndex: theme.zIndex.fab,
-    textTransform: 'uppercase',
-}));
+export const Tab = ({
+    children,
+    value,
+    ...rest
+}: ButtonProps & { value: 'change' | 'diff' }) => (
+    <BaseTabs.Tab
+        value={value}
+        render={({ color: _color, ...props }) => (
+            <StyledButton {...props} {...rest}>
+                {children}
+            </StyledButton>
+        )}
+    />
+);
 
 export const Tabs = ({
     className,
     children,
 }: PropsWithChildren<{ className?: string }>) => (
-    <MuiTabs
+    <BaseTabs.Root
         aria-label='View rendered change or JSON diff'
-        selectionFollowsFocus
-        defaultValue={0}
+        defaultValue='change'
         className={className}
     >
         {children}
-    </MuiTabs>
+    </BaseTabs.Root>
 );
 
-export const TabPanel = styled(MuiTabPanel, {
-    shouldForwardProp: (prop) => prop !== 'variant',
-})<{ variant?: 'diff' | 'change' }>(({ theme, variant }) =>
-    variant === 'diff'
+export const TabPanel = styled(BaseTabs.Panel)<{
+    value: 'change' | 'diff';
+}>(({ theme, value }) =>
+    value === 'diff'
         ? {
               padding: theme.spacing(2),
               borderRadius: theme.shape.borderRadiusLarge,

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ConsolidatedReleasePlanChanges.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ConsolidatedReleasePlanChanges.tsx
@@ -192,12 +192,12 @@ export const ConsolidatedReleasePlanChanges: FC<{
                 </ChangeItemInfo>
                 <div>
                     <TabList>
-                        <Tab>View change</Tab>
-                        <Tab>View diff</Tab>
+                        <Tab value='change'>View change</Tab>
+                        <Tab value='diff'>View diff</Tab>
                     </TabList>
                 </div>
             </ChangeItemWrapper>
-            <TabPanel>
+            <TabPanel value='change'>
                 {readonly ? (
                     <ReadonlyMilestoneListRenderer
                         plan={modifiedPlan}
@@ -214,7 +214,7 @@ export const ConsolidatedReleasePlanChanges: FC<{
                     />
                 )}
             </TabPanel>
-            <TabPanel variant='diff'>
+            <TabPanel value='diff'>
                 <EventDiff
                     entry={{
                         preData: basePlan,

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EnvironmentStrategyExecutionOrder/EnvironmentStrategyExecutionOrder.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EnvironmentStrategyExecutionOrder/EnvironmentStrategyExecutionOrder.tsx
@@ -103,13 +103,13 @@ export const EnvironmentStrategyExecutionOrder = ({
                     </NewChangeItemInfo>
                     <div>
                         <TabList>
-                            <Tab>View change</Tab>
-                            <Tab>View diff</Tab>
+                            <Tab value='change'>View change</Tab>
+                            <Tab value='diff'>View diff</Tab>
                         </TabList>
                         {actions}
                     </div>
                 </ChangeItemWrapper>
-                <TabPanel>
+                <TabPanel value='change'>
                     <StyledStrategyExecutionWrapper>
                         {updatedStrategies.map((strategy, index) => (
                             <StyledStrategyContainer key={strategy.id}>
@@ -121,7 +121,7 @@ export const EnvironmentStrategyExecutionOrder = ({
                         ))}
                     </StyledStrategyExecutionWrapper>
                 </TabPanel>
-                <TabPanel variant='diff'>
+                <TabPanel value='diff'>
                     <EnvironmentStrategyOrderDiff
                         preData={preData}
                         data={data}

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ReleasePlanChange.tsx
@@ -160,13 +160,13 @@ const StartMilestone: FC<{
                 </ChangeItemInfo>
                 <div>
                     <TabList>
-                        <Tab>View change</Tab>
-                        <Tab>View diff</Tab>
+                        <Tab value='change'>View change</Tab>
+                        <Tab value='diff'>View diff</Tab>
                     </TabList>
                     {actions}
                 </div>
             </ChangeItemWrapper>
-            <TabPanel>
+            <TabPanel value='change'>
                 <ReleasePlanMilestone
                     readonly
                     milestone={newMilestone}
@@ -186,7 +186,7 @@ const StartMilestone: FC<{
                     )}
                 />
             </TabPanel>
-            <TabPanel variant='diff'>
+            <TabPanel value='diff'>
                 <EventDiff
                     entry={{
                         preData: previousMilestone,
@@ -347,16 +347,16 @@ const AddReleasePlan: FC<{
                 </ChangeItemInfo>
                 <div>
                     <TabList>
-                        <Tab>View change</Tab>
-                        <Tab>View diff</Tab>
+                        <Tab value='change'>View change</Tab>
+                        <Tab value='diff'>View diff</Tab>
                     </TabList>
                     {actions}
                 </div>
             </ChangeItemWrapper>
-            <TabPanel>
+            <TabPanel value='change'>
                 <ReleasePlan plan={planPreview} readonly />
             </TabPanel>
-            <TabPanel variant='diff'>
+            <TabPanel value='diff'>
                 <EventDiff
                     entry={{
                         preData: currentReleasePlan,

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SafeguardChangeViews.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SafeguardChangeViews.tsx
@@ -56,13 +56,13 @@ export const SafeguardChangeView: FC<{
                 </ChangeItemInfo>
                 <div>
                     <TabList>
-                        <Tab>View change</Tab>
-                        <Tab>View diff</Tab>
+                        <Tab value='change'>View change</Tab>
+                        <Tab value='diff'>View diff</Tab>
                     </TabList>
                     {actions}
                 </div>
             </ChangeItemWrapper>
-            <TabPanel>
+            <TabPanel value='change'>
                 {readonly ? (
                     <ReadonlySafeguardDisplay
                         safeguard={safeguard}
@@ -83,7 +83,7 @@ export const SafeguardChangeView: FC<{
                     />
                 )}
             </TabPanel>
-            <TabPanel variant='diff'>
+            <TabPanel value='diff'>
                 <EventDiff
                     entry={{
                         preData: omitIfDefined(currentSafeguard, [
@@ -128,13 +128,13 @@ export const SafeguardDeleteView: FC<{
                 </ChangeItemInfo>
                 <div>
                     <TabList>
-                        <Tab>View change</Tab>
-                        <Tab>View diff</Tab>
+                        <Tab value='change'>View change</Tab>
+                        <Tab value='diff'>View diff</Tab>
                     </TabList>
                     {actions}
                 </div>
             </ChangeItemWrapper>
-            <TabPanel>
+            <TabPanel value='change'>
                 {readonly ? (
                     <ReadonlySafeguardDisplay
                         safeguard={safeguard}
@@ -155,7 +155,7 @@ export const SafeguardDeleteView: FC<{
                     />
                 )}
             </TabPanel>
-            <TabPanel variant='diff'>
+            <TabPanel value='diff'>
                 <EventDiff
                     entry={{
                         preData: safeguard,

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SegmentChangeDetails.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/SegmentChangeDetails.tsx
@@ -58,8 +58,8 @@ export const SegmentChangeDetails: FC<{
     const actionsWithTabs = (
         <ActionsContainer>
             <TabList>
-                <Tab>View change</Tab>
-                <Tab>View diff</Tab>
+                <Tab value='change'>View change</Tab>
+                <Tab value='diff'>View diff</Tab>
             </TabList>
             {actions}
         </ActionsContainer>
@@ -81,8 +81,8 @@ export const SegmentChangeDetails: FC<{
                             {actionsWithTabs}
                         </ChangeItemWrapper>
 
-                        <TabPanel sx={{ display: 'contents' }} />
-                        <TabPanel sx={{ mt: 1 }} variant='diff'>
+                        <TabPanel value='change' sx={{ display: 'contents' }} />
+                        <TabPanel value='diff' sx={{ mt: 1 }}>
                             <SegmentDiff
                                 change={change}
                                 currentSegment={referenceSegment}
@@ -111,12 +111,12 @@ export const SegmentChangeDetails: FC<{
                             {actionsWithTabs}
                         </ChangeItemWrapper>
 
-                        <TabPanel>
+                        <TabPanel value='change'>
                             <ViewableConstraintsList
                                 constraints={change.payload.constraints}
                             />
                         </TabPanel>
-                        <TabPanel variant='diff'>
+                        <TabPanel value='diff'>
                             <SegmentDiff
                                 change={change}
                                 currentSegment={referenceSegment}

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/StrategyChange.tsx
@@ -123,12 +123,12 @@ const DeleteStrategy: FC<{
                 </ChangeItemInfo>
                 {actions}
             </ChangeItemWrapper>
-            <TabPanel>
+            <TabPanel value='change'>
                 {referenceStrategy && (
                     <StrategyExecution strategy={referenceStrategy} />
                 )}
             </TabPanel>
-            <TabPanel variant='diff'>
+            <TabPanel value='diff'>
                 <StrategyDiff
                     change={change}
                     currentStrategy={referenceStrategy}
@@ -274,13 +274,13 @@ const UpdateStrategy: FC<{
                 referenceStrategy={referenceStrategy}
                 actions={actions}
             />
-            <TabPanel>
+            <TabPanel value='change'>
                 <StrategyChangeDetails
                     change={change}
                     referenceStrategy={referenceStrategy}
                 />
             </TabPanel>
-            <TabPanel variant='diff'>
+            <TabPanel value='diff'>
                 <StrategyDiff
                     change={change}
                     currentStrategy={referenceStrategy}
@@ -309,7 +309,7 @@ const AddStrategy: FC<{
             </ChangeItemInfo>
             {actions}
         </ChangeItemWrapper>
-        <TabPanel>
+        <TabPanel value='change'>
             <StrategyExecution strategy={change.payload} />
             {change.payload.variants?.length ? (
                 <StyledBox>
@@ -322,7 +322,7 @@ const AddStrategy: FC<{
                 </StyledBox>
             ) : null}
         </TabPanel>
-        <TabPanel variant='diff'>
+        <TabPanel value='diff'>
             <StrategyDiff change={change} currentStrategy={undefined} />
         </TabPanel>
     </>
@@ -386,8 +386,8 @@ export const StrategyChange: FC<{
     const actionsWithTabs = (
         <ActionsContainer>
             <TabList>
-                <Tab>View change</Tab>
-                <Tab>View diff</Tab>
+                <Tab value='change'>View change</Tab>
+                <Tab value='diff'>View diff</Tab>
             </TabList>
             {actions}
         </ActionsContainer>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,6 +387,9 @@ importers:
       '@babel/core':
         specifier: ^7.29.0
         version: 7.29.0
+      '@base-ui/react':
+        specifier: ^1.4.1
+        version: 1.4.1(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@biomejs/biome':
         specifier: ^2.4.14
         version: 2.4.14
@@ -405,9 +408,6 @@ importers:
       '@emotion/styled':
         specifier: 11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
-      '@mui/base':
-        specifier: 5.0.0-beta.70
-        version: 5.0.0-beta.70(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/icons-material':
         specifier: 7.3.10
         version: 7.3.10(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
@@ -802,6 +802,33 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.4.1':
+    resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': 18.3.28
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.2.8':
+    resolution: {integrity: sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==}
+    peerDependencies:
+      '@types/react': 18.3.28
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -1344,18 +1371,6 @@ packages:
   '@mswjs/interceptors@0.41.8':
     resolution: {integrity: sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==}
     engines: {node: '>=18'}
-
-  '@mui/base@5.0.0-beta.70':
-    resolution: {integrity: sha512-Tb/BIhJzb0pa5zv/wu7OdokY9ZKEDqcu1BDFnohyvGCoHuSXbEr90rPq1qeNW3XvTBIbNWHEF7gqge+xpUo6tQ==}
-    engines: {node: '>=14.0.0'}
-    deprecated: This package has been replaced by @base-ui/react
-    peerDependencies:
-      '@types/react': 18.3.28
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   '@mui/core-downloads-tracker@7.3.10':
     resolution: {integrity: sha512-vrOpWRmPJSuwLo23J62wggEm/jvGdzqctej+UOCtgDUz6nZJQuj3ByPccVyaa7eQmwAzUwKN56FQPMKkqbj1GA==}
@@ -5544,6 +5559,9 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
   resize-observer-polyfill@1.5.0:
     resolution: {integrity: sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg==}
 
@@ -6835,6 +6853,30 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@base-ui/react@1.4.1(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.8(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      date-fns: 4.1.0
+
+  '@base-ui/utils@0.2.8(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.4.14':
@@ -7361,20 +7403,6 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
-
-  '@mui/base@5.0.0-beta.70(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mui/types': 7.2.24(@types/react@18.3.28)
-      '@mui/utils': 6.4.9(@types/react@18.3.28)(react@18.3.1)
-      '@popperjs/core': 2.11.8
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.28
 
   '@mui/core-downloads-tracker@7.3.10': {}
 
@@ -11921,6 +11949,8 @@ snapshots:
   require-main-filename@2.0.0: {}
 
   requires-port@1.0.0: {}
+
+  reselect@5.1.1: {}
 
   resize-observer-polyfill@1.5.0: {}
 


### PR DESCRIPTION

`@mui/base` is officially deprecated and replaced by @base-ui/react.
It was kept as a direct dep on the previous v7 PR purely to unblock the version bump. This PR removes it and migrates away from it.

Only one file uses `@mui/base`: [ChangeTabComponents.tsx](frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ChangeTabComponents.tsx) — the unstyled Tabs primitives wrapped with MUI's `styled()` to render the View change / View diff toggle on change-request cards.

Six consumer files import the wrappers (`Tab`, `TabPanel`, `Tabs`, `TabList`) and needed minor updates because Base UI requires explicit `value` props on every Tab and Panel (making `variant` redundant).

<img width="1419" height="852" alt="Screenshot 2026-05-06 at 16 23 17" src="https://github.com/user-attachments/assets/827c7d1d-f3f6-41fe-8817-2a47460de76e" />

=======================

<img width="1419" height="852" alt="Screenshot 2026-05-06 at 16 23 28" src="https://github.com/user-attachments/assets/660c6e9d-4c5d-4609-ba53-25777ff6fe22" />
