### PR TITLE
chore: update deprecated MUI Switch `inputProps`

### DIFF
--- a/frontend/src/component/project/Project/CreateProject/CreateProjectForm/ConfigButtons/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProjectForm/ConfigButtons/ChangeRequestTable.tsx
@@ -138,19 +138,21 @@ export const ChangeRequestTable = (props: TableProps) => {
                         <StyledBox data-loading>
                             <Switch
                                 checked={value}
-                                inputProps={{
-                                    'aria-label': `${
-                                        value ? 'Disable' : 'Enable'
-                                    } change requests for ${
-                                        original.environment
-                                    }`,
-                                }}
                                 disabled={!original.configurable}
                                 onClick={onToggleEnvironment(
                                     original.environment,
                                     original.changeRequestEnabled,
                                     original.requiredApprovals,
                                 )}
+                                slotProps={{
+                                    input: {
+                                        'aria-label': `${
+                                            value ? 'Disable' : 'Enable'
+                                        } change requests for ${
+                                            original.environment
+                                        }`,
+                                    },
+                                }}
                             />
                         </StyledBox>
                     );


### PR DESCRIPTION
Part of the work to migrate to the latest MUI version.
The result of running the following codemods (only one `Switch` component needed updating):

```
npx @mui/codemod@latest deprecations/button-classes frontend/src
npx @mui/codemod@latest deprecations/button-group-classes frontend/src
npx @mui/codemod@latest deprecations/checkbox-props frontend/src
npx @mui/codemod@latest deprecations/radio-props frontend/src
npx @mui/codemod@latest deprecations/switch-props frontend/src
npx @mui/codemod@latest deprecations/toggle-button-group-classes frontend/src
```