### PR TITLE
chore: update more deprecated MUI props

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ConflictWarning.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/ConflictWarning.tsx
@@ -12,7 +12,7 @@ export const ConflictWarning: React.FC<{
                 sx={{
                     px: 3,
                     mb: 2,
-                    '&.MuiAlert-standardWarning': {
+                    '&.MuiAlert-standard.MuiAlert-colorWarning': {
                         borderStyle: 'none',
                     },
                     borderRadius: '0px',

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/FeatureChange.tsx
@@ -43,7 +43,7 @@ const StyledSingleChangeBox = styled(Box)(({ theme }) => ({
 const StyledAlert = styled(Alert)(({ theme }) => ({
     borderRadius: 0,
     padding: theme.spacing(1, 2),
-    '&.MuiAlert-standardWarning': {
+    '&.MuiAlert-standard.MuiAlert-colorWarning': {
         borderStyle: 'none none solid none',
     },
 }));

--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -314,8 +314,10 @@ export const CommandBar = () => {
                     id='command-bar-input'
                     inputRef={searchInputRef}
                     placeholder={placeholder}
-                    inputProps={{
-                        'data-testid': SEARCH_INPUT,
+                    slotProps={{
+                        input: {
+                            'data-testid': SEARCH_INPUT,
+                        } as React.InputHTMLAttributes<HTMLInputElement>,
                     }}
                     autoComplete='off'
                     value={value}

--- a/frontend/src/component/common/DateTimePicker/DateTimePicker.tsx
+++ b/frontend/src/component/common/DateTimePicker/DateTimePicker.tsx
@@ -33,6 +33,7 @@ export const DateTimePicker = ({
     max,
     value,
     onChange,
+    slotProps,
     ...rest
 }: IDateTimePickerProps) => {
     const getDate = type === 'datetime' ? formatDateTime : formatDate;
@@ -61,6 +62,7 @@ export const DateTimePicker = ({
                 formHelperText: {
                     'data-testid': INPUT_ERROR_TEXT,
                 },
+                ...slotProps,
             }}
         />
     );

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/DropdownList.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/DropdownList.tsx
@@ -86,12 +86,14 @@ export function DropdownList<T = string>({
                 hideLabel
                 placeholder={search.placeholder}
                 autoFocus
-                InputProps={{
-                    startAdornment: (
-                        <InputAdornment position='start'>
-                            <Search fontSize='small' />
-                        </InputAdornment>
-                    ),
+                slotProps={{
+                    input: {
+                        startAdornment: (
+                            <InputAdornment position='start'>
+                                <Search fontSize='small' />
+                            </InputAdornment>
+                        ),
+                    },
                 }}
                 inputRef={(el) => {
                     listRefs.current[0] = el;
@@ -132,8 +134,10 @@ export function DropdownList<T = string>({
                                         option.value,
                                     )}
                                     tabIndex={-1}
-                                    inputProps={{
-                                        'aria-labelledby': labelId,
+                                    slotProps={{
+                                        input: {
+                                            'aria-labelledby': labelId,
+                                        },
                                     }}
                                     size='small'
                                     disableRipple

--- a/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/DialogFormTemplate.tsx
@@ -76,11 +76,17 @@ export const DialogFormTemplate: React.FC<FormProps> = ({
                             delete errors.name;
                         }}
                         autoFocus
-                        InputProps={{
-                            style: { fontSize: theme.typography.h1.fontSize },
-                        }}
-                        InputLabelProps={{
-                            style: { fontSize: theme.typography.h1.fontSize },
+                        slotProps={{
+                            input: {
+                                style: {
+                                    fontSize: theme.typography.h1.fontSize,
+                                },
+                            },
+                            inputLabel: {
+                                style: {
+                                    fontSize: theme.typography.h1.fontSize,
+                                },
+                            },
                         }}
                         data-testid='FORM_NAME_INPUT'
                         size='medium'
@@ -99,11 +105,17 @@ export const DialogFormTemplate: React.FC<FormProps> = ({
                         maxRows={3}
                         value={description}
                         onChange={(e) => setDescription(e.target.value)}
-                        InputProps={{
-                            style: { fontSize: theme.typography.h2.fontSize },
-                        }}
-                        InputLabelProps={{
-                            style: { fontSize: theme.typography.h2.fontSize },
+                        slotProps={{
+                            input: {
+                                style: {
+                                    fontSize: theme.typography.h2.fontSize,
+                                },
+                            },
+                            inputLabel: {
+                                style: {
+                                    fontSize: theme.typography.h2.fontSize,
+                                },
+                            },
                         }}
                         data-testid='FORM_DESCRIPTION_INPUT'
                     />

--- a/frontend/src/component/common/Input/Input.tsx
+++ b/frontend/src/component/common/Input/Input.tsx
@@ -30,6 +30,7 @@ const Input = ({
     value,
     onChange,
     size = 'small',
+    slotProps,
     ...rest
 }: IInputProps) => {
     const { classes: styles } = useStyles();
@@ -55,6 +56,7 @@ const Input = ({
                             root: styles.helperText,
                         },
                     },
+                    ...slotProps,
                 }}
             />
         </StyledDiv>

--- a/frontend/src/component/common/MultipleRoleSelect/MultipleRoleSelect.tsx
+++ b/frontend/src/component/common/MultipleRoleSelect/MultipleRoleSelect.tsx
@@ -54,6 +54,7 @@ export const MultipleRoleSelect = ({
     value,
     setValue,
     required,
+    slotProps,
     ...rest
 }: IMultipleRoleSelectProps) => {
     const renderRoleOption = (
@@ -90,6 +91,7 @@ export const MultipleRoleSelect = ({
                             },
                         },
                     },
+                    ...slotProps,
                 }}
                 multiple
                 disableCloseOnSelect

--- a/frontend/src/component/common/PasswordField/PasswordField.tsx
+++ b/frontend/src/component/common/PasswordField/PasswordField.tsx
@@ -26,21 +26,23 @@ const PasswordField: VFC<TextFieldProps> = ({ ...rest }) => {
             variant='outlined'
             size='small'
             type={showPassword ? 'text' : 'password'}
-            InputProps={{
-                style: {
-                    paddingRight: '0px',
+            slotProps={{
+                input: {
+                    style: {
+                        paddingRight: '0px',
+                    },
+                    endAdornment: (
+                        <InputAdornment position='end'>
+                            <IconButton
+                                onClick={handleClickShowPassword}
+                                onMouseDown={handleMouseDownPassword}
+                                size='large'
+                            >
+                                <IconComponent titleAccess={iconTitle} />
+                            </IconButton>
+                        </InputAdornment>
+                    ),
                 },
-                endAdornment: (
-                    <InputAdornment position='end'>
-                        <IconButton
-                            onClick={handleClickShowPassword}
-                            onMouseDown={handleMouseDownPassword}
-                            size='large'
-                        >
-                            <IconComponent titleAccess={iconTitle} />
-                        </IconButton>
-                    </InputAdornment>
-                ),
             }}
             {...rest}
         />

--- a/frontend/src/component/common/Search/Search.tsx
+++ b/frontend/src/component/common/Search/Search.tsx
@@ -201,9 +201,11 @@ export const Search = ({
                 <StyledInputBase
                     inputRef={searchInputRef}
                     placeholder={placeholder}
-                    inputProps={{
-                        'aria-label': placeholder,
-                        'data-testid': SEARCH_INPUT,
+                    slotProps={{
+                        input: {
+                            'aria-label': placeholder,
+                            'data-testid': SEARCH_INPUT,
+                        } as React.InputHTMLAttributes<HTMLInputElement>,
                     }}
                     value={value}
                     onChange={(e) => onSearchChange(e.target.value)}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/AddRegexValueEditor/AddRegexValueEditor.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/AddRegexValueEditor/AddRegexValueEditor.tsx
@@ -184,8 +184,10 @@ const RegexTestInputItem: FC<RegexTestInputItemProps> = memo(
                         fullWidth
                         value={input.testString}
                         id={`test-input-${input.id}`}
-                        inputProps={{
-                            'aria-describedby': 'test-strings-description',
+                        slotProps={{
+                            htmlInput: {
+                                'aria-describedby': 'test-strings-description',
+                            },
                         }}
                         inputRef={setInputRef}
                         onChange={handleChange}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/AddSingleValueChip.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/AddSingleValueChip.tsx
@@ -81,7 +81,7 @@ export const AddSingleValueChip = forwardRef<HTMLDivElement, Props>(
                     onDelete={currentValue ? removeValue : undefined}
                 />
                 <AddValuesPopover
-                    inputProps={{
+                    htmlInputProps={{
                         inputMode: inputType === 'number' ? 'decimal' : 'text',
                     }}
                     initialValue={currentValue}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/AddValuesPopover.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/AddValuesPopover.tsx
@@ -131,9 +131,7 @@ export const AddValuesPopover: FC<AddValuesProps> = ({
                             helperText={error}
                             aria-describedby={helpTextId}
                             slotProps={{
-                                htmlInput: {
-                                    ...htmlInputProps,
-                                },
+                                htmlInput: htmlInputProps,
                             }}
                             data-testid='CONSTRAINT_VALUES_INPUT'
                         />

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/AddValuesPopover.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/AddValuesPopover.tsx
@@ -49,7 +49,7 @@ type AddValuesProps = {
     anchorEl: HTMLElement | null;
     onClose: () => void;
     helpText?: string;
-    inputProps?: InputBaseComponentProps;
+    htmlInputProps?: InputBaseComponentProps;
 };
 
 const HelpText = styled('p')(({ theme }) => ({
@@ -68,7 +68,7 @@ export const AddValuesPopover: FC<AddValuesProps> = ({
     open,
     onClose,
     helpText,
-    inputProps,
+    htmlInputProps,
 }) => {
     const [inputValue, setInputValue] = useState(initialValue || '');
     const [error, setError] = useState('');
@@ -130,8 +130,10 @@ export const AddValuesPopover: FC<AddValuesProps> = ({
                             error={!!error}
                             helperText={error}
                             aria-describedby={helpTextId}
-                            inputProps={{
-                                ...inputProps,
+                            slotProps={{
+                                htmlInput: {
+                                    ...htmlInputProps,
+                                },
                             }}
                             data-testid='CONSTRAINT_VALUES_INPUT'
                         />

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/ConstraintDateInput.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/ConstraintDateInput.tsx
@@ -92,8 +92,10 @@ export const ConstraintDateInput = ({
                         }
                     }
                 }}
-                InputLabelProps={{
-                    shrink: true,
+                slotProps={{
+                    inputLabel: {
+                        shrink: true,
+                    },
                 }}
                 error={Boolean(error)}
                 errorText={error}

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsContent/FeatureMetricsContent.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsContent/FeatureMetricsContent.tsx
@@ -20,11 +20,21 @@ export const FeatureMetricsContent = ({
     if (metrics.length === 0) {
         return (
             <Box mt={6}>
-                <Typography variant='body1' paragraph>
+                <Typography
+                    variant='body1'
+                    sx={{
+                        marginBottom: '16px',
+                    }}
+                >
                     We have yet to receive any metrics for this feature flag in
                     the selected time period.
                 </Typography>
-                <Typography variant='body1' paragraph>
+                <Typography
+                    variant='body1'
+                    sx={{
+                        marginBottom: '16px',
+                    }}
+                >
                     Please note that, since the SDKs send metrics on an
                     interval, it might take some time before metrics appear.
                 </Typography>

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsContent/FeatureMetricsContent.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsContent/FeatureMetricsContent.tsx
@@ -22,18 +22,14 @@ export const FeatureMetricsContent = ({
             <Box mt={6}>
                 <Typography
                     variant='body1'
-                    sx={{
-                        marginBottom: '16px',
-                    }}
+                    sx={(theme) => ({ marginBottom: theme.spacing(2) })}
                 >
                     We have yet to receive any metrics for this feature flag in
                     the selected time period.
                 </Typography>
                 <Typography
                     variant='body1'
-                    sx={{
-                        marginBottom: '16px',
-                    }}
+                    sx={(theme) => ({ marginBottom: theme.spacing(2) })}
                 >
                     Please note that, since the SDKs send metrics on an
                     interval, it might take some time before metrics appear.

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/FeatureOverviewMetaData.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/FeatureOverviewMetaData.tsx
@@ -173,12 +173,14 @@ const FeatureLinks: FC<FeatureLinksProps> = ({ links, project, feature }) => {
                         <ListItemText
                             primary={link.title}
                             secondary={link.url}
-                            secondaryTypographyProps={{
-                                sx: {
-                                    overflow: 'hidden',
-                                    textOverflow: 'ellipsis',
-                                    whiteSpace: 'nowrap',
-                                    display: 'block',
+                            slotProps={{
+                                secondary: {
+                                    sx: {
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                        whiteSpace: 'nowrap',
+                                        display: 'block',
+                                    },
                                 },
                             }}
                         />

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageBulkTagsDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageBulkTagsDialog.tsx
@@ -250,10 +250,7 @@ export const ManageBulkTagsDialog: FC<IManageBulkTagsDialogProps> = ({
             onClose={onClose}
             formId={formId}
         >
-            <Typography
-                paragraph
-                sx={{ marginBottom: (theme) => theme.spacing(2.5) }}
-            >
+            <Typography sx={{ marginBottom: (theme) => theme.spacing(2.5) }}>
                 Tags allow you to group features together
             </Typography>
             <form id={formId} onSubmit={submitAndReset}>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageTagsDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ManageTagsDialog/ManageTagsDialog.tsx
@@ -253,7 +253,6 @@ export const ManageTagsDialog = ({ open, setOpen }: IManageTagsProps) => {
         >
             <>
                 <Typography
-                    paragraph
                     sx={{ marginBottom: (theme) => theme.spacing(2.5) }}
                 >
                     Tags allow you to group features together

--- a/frontend/src/component/feature/StrategyTypes/RolloutSlider/RolloutSlider.tsx
+++ b/frontend/src/component/feature/StrategyTypes/RolloutSlider/RolloutSlider.tsx
@@ -208,17 +208,19 @@ const RolloutSlider = ({
                         onBlur={handleInputBlur}
                         onKeyDown={handleKeyDown}
                         disabled={disabled}
-                        inputProps={{
-                            min: 0,
-                            max: 100,
-                            step: 1,
-                        }}
-                        InputProps={{
-                            endAdornment: (
-                                <InputAdornment position='end'>
-                                    %
-                                </InputAdornment>
-                            ),
+                        slotProps={{
+                            htmlInput: {
+                                min: 0,
+                                max: 100,
+                                step: 1,
+                            },
+                            input: {
+                                endAdornment: (
+                                    <InputAdornment position='end'>
+                                        %
+                                    </InputAdornment>
+                                ),
+                            },
                         }}
                     />
                 </StyledInputBox>

--- a/frontend/src/component/filter/FilterItem/FilterItem.tsx
+++ b/frontend/src/component/filter/FilterItem/FilterItem.tsx
@@ -234,8 +234,10 @@ export const FilterItem: FC<IFilterItemProps> = ({
                                             ) ?? false
                                         }
                                         tabIndex={-1}
-                                        inputProps={{
-                                            'aria-labelledby': labelId,
+                                        slotProps={{
+                                            input: {
+                                                'aria-labelledby': labelId,
+                                            },
                                         }}
                                         size='small'
                                         disableRipple

--- a/frontend/src/component/impact-metrics/ImpactMetricModal/LabelFilter/LabelFilterSection/LabelFilterItem/LabelFilterItem.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricModal/LabelFilter/LabelFilterSection/LabelFilterItem/LabelFilterItem.tsx
@@ -117,10 +117,6 @@ export const LabelFilterItem: FC<LabelFilterItemProps> = ({
                         }
                         variant='outlined'
                         size='small'
-                        slotProps={{
-                            ...params,
-                            htmlInput: { ...params.inputProps },
-                        }}
                     />
                     {isTruncated && (
                         <Alert

--- a/frontend/src/component/impact-metrics/MultimetricChart/FeatureEventOverlay/FeatureEventMarker.tsx
+++ b/frontend/src/component/impact-metrics/MultimetricChart/FeatureEventOverlay/FeatureEventMarker.tsx
@@ -54,7 +54,8 @@ export const FeatureEventMarker: FC<{ group: EventGroup }> = ({ group }) => {
         <Tooltip
             arrow
             placement='top'
-            componentsProps={{
+            title={<FeatureEventTooltip group={group} />}
+            slotProps={{
                 tooltip: {
                     sx: {
                         bgcolor: theme.palette.background.paper,
@@ -75,7 +76,6 @@ export const FeatureEventMarker: FC<{ group: EventGroup }> = ({ group }) => {
                     },
                 },
             }}
-            title={<FeatureEventTooltip group={group} />}
         >
             <StyledMarkerWrapper sx={{ left: `${clampedPct}%` }}>
                 <StyledMarker

--- a/frontend/src/component/integrations/IntegrationForm/IntegrationParameters/IntegrationParameter/IntegrationParameterTextField.tsx
+++ b/frontend/src/component/integrations/IntegrationForm/IntegrationParameters/IntegrationParameter/IntegrationParameterTextField.tsx
@@ -56,8 +56,10 @@ export const IntegrationParameterTextField = ({
             }
             name={definition.name}
             placeholder={definition.placeholder || ''}
-            InputLabelProps={{
-                shrink: true,
+            slotProps={{
+                inputLabel: {
+                    shrink: true,
+                },
             }}
             value={value}
             error={Boolean(error)}

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NewInUnleash/NewInUnleashToast.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NewInUnleash/NewInUnleashToast.tsx
@@ -135,7 +135,9 @@ export const NewInUnleashToast = ({ item }: { item: NewInUnleashItem }) => {
                         markAsSeen(item);
                     }
                 }}
-                TransitionComponent={Slide}
+                slots={{
+                    transition: Slide,
+                }}
             >
                 <NewInUnleashBody>
                     <TextContainer>

--- a/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundConnectionFieldset/PlaygroundConnectionFieldset.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundConnectionFieldset/PlaygroundConnectionFieldset.tsx
@@ -246,21 +246,23 @@ export const PlaygroundConnectionFieldset: FC<
                         errorText={tokenError}
                         placeholder={'Enter your API token'}
                         data-testid={'PLAYGROUND_TOKEN_INPUT'}
-                        InputProps={{
-                            endAdornment: token ? (
-                                <InputAdornment
-                                    position='end'
-                                    data-testid='TOKEN_INPUT_CLEAR_BTN'
-                                >
-                                    <IconButton
-                                        aria-label='clear API token'
-                                        onClick={clearToken}
-                                        edge='end'
+                        slotProps={{
+                            input: {
+                                endAdornment: token ? (
+                                    <InputAdornment
+                                        position='end'
+                                        data-testid='TOKEN_INPUT_CLEAR_BTN'
                                     >
-                                        <SmallClear />
-                                    </IconButton>
-                                </InputAdornment>
-                            ) : null,
+                                        <IconButton
+                                            aria-label='clear API token'
+                                            onClick={clearToken}
+                                            edge='end'
+                                        >
+                                            <SmallClear />
+                                        </IconButton>
+                                    </InputAdornment>
+                                ) : null,
+                            },
                         }}
                         disabled={Boolean(changeRequest)}
                     />
@@ -280,20 +282,22 @@ export const PlaygroundConnectionFieldset: FC<
                                     onChange={() => {}}
                                     type={'text'}
                                     disabled
-                                    InputProps={{
-                                        endAdornment: (
-                                            <InputAdornment position='end'>
-                                                <IconButton
-                                                    aria-label='clear Change request results'
-                                                    onClick={
-                                                        onClearChangeRequest
-                                                    }
-                                                    edge='end'
-                                                >
-                                                    <SmallClear />
-                                                </IconButton>
-                                            </InputAdornment>
-                                        ),
+                                    slotProps={{
+                                        input: {
+                                            endAdornment: (
+                                                <InputAdornment position='end'>
+                                                    <IconButton
+                                                        aria-label='clear Change request results'
+                                                        onClick={
+                                                            onClearChangeRequest
+                                                        }
+                                                        edge='end'
+                                                    >
+                                                        <SmallClear />
+                                                    </IconButton>
+                                                </InputAdornment>
+                                            ),
+                                        },
                                     }}
                                 />
                             </Box>

--- a/frontend/src/component/project/Project/CreateProject/CreateProjectForm/ConfigButtons/ChangeRequestTableConfigButton.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProjectForm/ConfigButtons/ChangeRequestTableConfigButton.tsx
@@ -115,12 +115,14 @@ export const ChangeRequestTableConfigButton: FC<
                 label={search.label}
                 placeholder={search.placeholder}
                 autoFocus
-                InputProps={{
-                    startAdornment: (
-                        <InputAdornment position='start'>
-                            <Search fontSize='small' />
-                        </InputAdornment>
-                    ),
+                slotProps={{
+                    input: {
+                        startAdornment: (
+                            <InputAdornment position='start'>
+                                <Search fontSize='small' />
+                            </InputAdornment>
+                        ),
+                    },
                 }}
                 onKeyDown={toggleTopItem}
             />

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ColumnsMenu/ColumnsMenu.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ColumnsMenu/ColumnsMenu.tsx
@@ -110,8 +110,10 @@ export const ColumnsMenu: FC<IColumnsMenuProps> = ({ columns, onToggle }) => {
                                         edge='start'
                                         checked={column.isVisible}
                                         disableRipple
-                                        inputProps={{
-                                            'aria-labelledby': column.id,
+                                        slotProps={{
+                                            input: {
+                                                'aria-labelledby': column.id,
+                                            },
                                         }}
                                         size='medium'
                                     />

--- a/frontend/src/component/project/Project/ProjectEnterpriseSettingsForm/ProjectEnterpriseSettingsForm.tsx
+++ b/frontend/src/component/project/Project/ProjectEnterpriseSettingsForm/ProjectEnterpriseSettingsForm.tsx
@@ -294,17 +294,19 @@ const ProjectEnterpriseSettingsForm: React.FC<
                         name='feature flag naming pattern'
                         aria-describedby='pattern-naming-description'
                         placeholder='[A-Za-z]+.[A-Za-z]+.[A-Za-z0-9-]+'
-                        InputProps={{
-                            startAdornment: (
-                                <InputAdornment position='start'>
-                                    ^
-                                </InputAdornment>
-                            ),
-                            endAdornment: (
-                                <InputAdornment position='end'>
-                                    $
-                                </InputAdornment>
-                            ),
+                        slotProps={{
+                            input: {
+                                startAdornment: (
+                                    <InputAdornment position='start'>
+                                        ^
+                                    </InputAdornment>
+                                ),
+                                endAdornment: (
+                                    <InputAdornment position='end'>
+                                        $
+                                    </InputAdornment>
+                                ),
+                            },
                         }}
                         type={'text'}
                         value={featureNamingPattern || ''}

--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
@@ -186,7 +186,9 @@ export const ChangeRequestTable: FC = () => {
                                 UPDATE_PROJECT,
                                 PROJECT_CHANGE_REQUEST_WRITE,
                             ]}
-                            inputProps={{ 'aria-label': original.environment }}
+                            slotProps={{
+                                input: { 'aria-label': original.environment },
+                            }}
                             onClick={onRowChange(
                                 original.environment,
                                 original.changeRequestEnabled,

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/TemplateForm.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/TemplateForm.tsx
@@ -104,11 +104,13 @@ export const TemplateForm: React.FC<ITemplateFormProps> = ({
                         delete errors.name;
                     }}
                     autoFocus
-                    InputProps={{
-                        style: { fontSize: theme.typography.h1.fontSize },
-                    }}
-                    InputLabelProps={{
-                        style: { fontSize: theme.typography.h1.fontSize },
+                    slotProps={{
+                        input: {
+                            style: { fontSize: theme.typography.h1.fontSize },
+                        },
+                        inputLabel: {
+                            style: { fontSize: theme.typography.h1.fontSize },
+                        },
                     }}
                     size='medium'
                 />
@@ -117,16 +119,18 @@ export const TemplateForm: React.FC<ITemplateFormProps> = ({
                     multiline
                     value={description}
                     onChange={(e) => setDescription(e.target.value)}
-                    InputProps={{
-                        style: {
-                            fontSize: theme.typography.h2.fontSize,
-                            padding: 0,
+                    slotProps={{
+                        input: {
+                            style: {
+                                fontSize: theme.typography.h2.fontSize,
+                                padding: 0,
+                            },
                         },
-                    }}
-                    InputLabelProps={{
-                        style: {
-                            fontSize: theme.typography.h2.fontSize,
-                            padding: 0,
+                        inputLabel: {
+                            style: {
+                                fontSize: theme.typography.h2.fontSize,
+                                padding: 0,
+                            },
                         },
                     }}
                     size='small'

--- a/frontend/src/component/strategies/StrategiesList/StrategySwitch/StrategySwitch.tsx
+++ b/frontend/src/component/strategies/StrategiesList/StrategySwitch/StrategySwitch.tsx
@@ -44,7 +44,7 @@ export const StrategySwitch: VFC<IStrategySwitchProps> = ({
                     permission={UPDATE_STRATEGY}
                     onClick={onClick}
                     disabled={disabled}
-                    inputProps={{ 'aria-labelledby': id }}
+                    slotProps={{ input: { 'aria-labelledby': id } }}
                 />
             </div>
         </Tooltip>

--- a/frontend/src/themes/dark-theme.ts
+++ b/frontend/src/themes/dark-theme.ts
@@ -361,7 +361,7 @@ export const darkTheme = createTheme({
                     '> .MuiAlert-message': {
                         padding: '3px 0 0 0',
                     },
-                    '&.MuiAlert-standardInfo': {
+                    '&.MuiAlert-standard.MuiAlert-colorInfo': {
                         backgroundColor: theme.palette.info.light,
                         color: theme.palette.info.contrastText,
                         border: `1px solid ${theme.palette.info.border}`,
@@ -369,7 +369,7 @@ export const darkTheme = createTheme({
                             color: theme.palette.info.main,
                         },
                     },
-                    '&.MuiAlert-standardSuccess': {
+                    '&.MuiAlert-standard.MuiAlert-colorSuccess': {
                         backgroundColor: theme.palette.success.light,
                         color: theme.palette.success.contrastText,
                         border: `1px solid ${theme.palette.success.border}`,
@@ -377,7 +377,7 @@ export const darkTheme = createTheme({
                             color: theme.palette.success.main,
                         },
                     },
-                    '&.MuiAlert-standardWarning': {
+                    '&.MuiAlert-standard.MuiAlert-colorWarning': {
                         backgroundColor: theme.palette.warning.light,
                         color: theme.palette.warning.contrastText,
                         border: `1px solid ${theme.palette.warning.border}`,
@@ -385,7 +385,7 @@ export const darkTheme = createTheme({
                             color: theme.palette.warning.main,
                         },
                     },
-                    '&.MuiAlert-standardError': {
+                    '&.MuiAlert-standard.MuiAlert-colorError': {
                         backgroundColor: theme.palette.error.light,
                         color: theme.palette.error.contrastText,
                         border: `1px solid ${theme.palette.error.border}`,

--- a/frontend/src/themes/theme.ts
+++ b/frontend/src/themes/theme.ts
@@ -427,7 +427,7 @@ export const lightTheme = createTheme({
                     '> .MuiAlert-message': {
                         padding: '3px 0 0 0',
                     },
-                    '&.MuiAlert-standardInfo': {
+                    '&.MuiAlert-standard.MuiAlert-colorInfo': {
                         backgroundColor: theme.palette.info.light,
                         color: theme.palette.info.dark,
                         border: `1px solid ${theme.palette.info.border}`,
@@ -435,7 +435,7 @@ export const lightTheme = createTheme({
                             color: theme.palette.info.main,
                         },
                     },
-                    '&.MuiAlert-standardSuccess': {
+                    '&.MuiAlert-standard.MuiAlert-colorSuccess': {
                         backgroundColor: theme.palette.success.light,
                         color: theme.palette.success.dark,
                         border: `1px solid ${theme.palette.success.border}`,
@@ -443,7 +443,7 @@ export const lightTheme = createTheme({
                             color: theme.palette.success.main,
                         },
                     },
-                    '&.MuiAlert-standardWarning': {
+                    '&.MuiAlert-standard.MuiAlert-colorWarning': {
                         backgroundColor: theme.palette.warning.light,
                         color: theme.palette.warning.dark,
                         border: `1px solid ${theme.palette.warning.border}`,
@@ -451,7 +451,7 @@ export const lightTheme = createTheme({
                             color: theme.palette.warning.main,
                         },
                     },
-                    '&.MuiAlert-standardError': {
+                    '&.MuiAlert-standard.MuiAlert-colorError': {
                         backgroundColor: theme.palette.error.light,
                         color: theme.palette.error.dark,
                         border: `1px solid ${theme.palette.error.border}`,


### PR DESCRIPTION
Part of the work to migrate to the latest MUI version.
Updates the remaining MUI deprecated props (should make it somewhat painless to then bump to the latest v9). 
Result of running the following codemods:

### Layout / containers

```
npx @mui/codemod@latest deprecations/accordion-props frontend/src
npx @mui/codemod@latest deprecations/accordion-summary-classes frontend/src
npx @mui/codemod@latest deprecations/divider-props frontend/src
npx @mui/codemod@latest deprecations/card-header-props frontend/src
npx @mui/codemod@latest deprecations/drawer-props frontend/src
npx @mui/codemod@latest deprecations/drawer-classes frontend/src
npx @mui/codemod@latest deprecations/modal-props frontend/src
npx @mui/codemod@latest deprecations/dialog-props frontend/src
npx @mui/codemod@latest deprecations/dialog-classes frontend/src
npx @mui/codemod@latest deprecations/popover-props frontend/src
npx @mui/codemod@latest deprecations/popper-props frontend/src
npx @mui/codemod@latest deprecations/menu-props frontend/src
npx @mui/codemod@latest deprecations/backdrop-props frontend/src
```

### Lists & tables

```
npx @mui/codemod@latest deprecations/list-item-props frontend/src
npx @mui/codemod@latest deprecations/list-item-text-props frontend/src
npx @mui/codemod@latest deprecations/table-pagination-props frontend/src
npx @mui/codemod@latest deprecations/table-sort-label-classes frontend/src
npx @mui/codemod@latest deprecations/pagination-item-props frontend/src
npx @mui/codemod@latest deprecations/pagination-item-classes frontend/src
npx @mui/codemod@latest deprecations/image-list-item-bar-classes frontend/src
```

### Indicators & misc

```
npx @mui/codemod@latest deprecations/alert-props frontend/src
npx @mui/codemod@latest deprecations/alert-classes frontend/src
npx @mui/codemod@latest deprecations/avatar-props frontend/src
npx @mui/codemod@latest deprecations/avatar-group-props frontend/src
npx @mui/codemod@latest deprecations/badge-props frontend/src
npx @mui/codemod@latest deprecations/chip-classes frontend/src
npx @mui/codemod@latest deprecations/circular-progress-classes frontend/src
npx @mui/codemod@latest deprecations/linear-progress-classes frontend/src
npx @mui/codemod@latest deprecations/snackbar-props frontend/src
npx @mui/codemod@latest deprecations/tooltip-props frontend/src
npx @mui/codemod@latest deprecations/typography-props frontend/src
npx @mui/codemod@latest deprecations/rating-props frontend/src
npx @mui/codemod@latest deprecations/select-classes frontend/src
npx @mui/codemod@latest deprecations/slider-props frontend/src
npx @mui/codemod@latest deprecations/slider-classes frontend/src
npx @mui/codemod@latest deprecations/speed-dial-props frontend/src
npx @mui/codemod@latest deprecations/speed-dial-action-props frontend/src
```

Also includes manual changes codemods were not smart enough to catch.

## Manual test plan (generated by Claude)

### Inputs / TextFields (slotProps wrappers — `Input`)

These all use the `Input` wrapper that was silently swallowing slotProps:

- [x] **Create project dialog** (Projects → New project) — name + description fields, error states (clear, type a name with bad chars if naming pattern is set, see helper text), focus/blur transitions
- [x] **Create release plan template** (Release templates → New template) — same fields
- [x] **Project enterprise settings** → Naming pattern field — `^` and `$` adornments visible at start/end
- [x] **Playground page** (`/playground`) — API token field clear button (the X icon)  ⚠️ This was the one we fixed — tabs through and clearing should work
- [x] **Integration form** — any param with a label, label should "shrink" properly when focused
- [x] **Constraint date input** (any feature → constraint with date operator) — date label shrinks correctly
- [ ] 

### Search inputs (`InputBase` slot)

- [x] **Top nav search** (Cmd+K or click search icon) — placeholder visible, keystrokes work
- [x] **Command bar** — same component-shape, similar checks
- [x] **Project columns menu** (any project's flag table → Columns icon) — checkbox aria-labels readable by screen reader (right-click, Inspect, see `aria-labelledby` linked correctly)
- [x] **Dropdown lists with search** (e.g., create project → segments / change requests config buttons) — search works, list filters

### Switches (slotProps.input migration)

- [x] **Strategy on/off switch** (any strategy in feature view) — toggles, label appears in screen reader
- [x] **Project change request configuration** — toggle each environment's CR switch, dialog appears, confirm
- [x] **Project Settings → CR config** — same toggle in the standalone page

### Sliders

- [x] **Rollout % slider** (gradual rollout strategy) — number input shows `%` adornment, min/max/step constraints work (try typing 150 → should clamp, try -5 → should clamp)

### Date pickers (DateTimePicker wrapper)

- [x] Anywhere a date/datetime input shows up (constraints with date operator, schedule a change request, etc.) — calendar opens, value formats correctly, error helperText still has `data-testid` (this is what the merge fix was for — both internal AND any consumer slotProps should apply)

### Autocompletes (`MultipleRoleSelect` etc.)

- [x] **Project members → assign roles** — open the role selector, options grouped (predefined / custom), padding looks right (not collapsed) — that's the internal `paper.sx` styling that almost got lost in the masking fix
- [x] **API token → project selector** — chips render, deselect works (this was where we fixed the `renderValue` single-vs-multi issue earlier in the v7 PR — confirm still good)

### Tabs (Base UI migration)

- [x] **Change request → any change card** — View change / View diff tabs render, click switches, **arrow-key navigation** also switches (that's `activateOnFocus`)
- [x] Try each change type that has tabs: strategy edit, segment edit, release plan add/remove, safeguard, environment strategy execution order

### Dialogs / modals

- [x] **Confirm dialogs** anywhere (delete a flag, archive, etc.) — Esc closes, click outside closes, confirm button works
- [x] **Manage tags dialog** (any feature → Tags) — input renders, autocomplete works

### General regression sweep

- [x] **Top nav** — feature flag list, toggles
- [x] **Admin → Users** — list paginates, search works
- [x] **Admin → API tokens** — create dialog (multiple inputs)
- [x] **Login page** — username + password fields, password visibility toggle (eye icon — that's `PasswordField`)

### Things that should look identical (sanity check, not action)

- [x] No fonts/sizes have changed unexpectedly
- [x] No element has lost its border or background
- [x] No labels are clipped or floating wrong
- [x] Helper text still appears below inputs in the right color when error
- [x] Adornments (icons inside inputs) still positioned correctly

### Failure modes to watch for specifically

- ⚠️ **Field looks naked** (no label, no border) — slotProps may be conflicting and overriding base styles
- ⚠️ **Accessibility regression** — element has no aria-label where it should (use the Inspect tool, look at computed accessible name)
- ⚠️ **Console warning about deprecated prop** — should be zero of these now; if any pop up, the migration missed something