### PR TITLE
feat: add plausible tracking for external impact metrics settings

### DIFF
--- a/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.tsx
+++ b/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.tsx
@@ -22,6 +22,7 @@ import { useExternalImpactMetricsSourceApi } from 'hooks/api/actions/useExternal
 import { useTestExternalImpactMetricsSourceApi } from 'hooks/api/actions/useTestExternalImpactMetricsSourceApi/useTestExternalImpactMetricsSourceApi';
 import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
+import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 
 const Layout = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -91,6 +92,7 @@ const ImpactMetricsPage = () => {
     const { testExternalImpactMetricsSource, loading: testing } =
         useTestExternalImpactMetricsSourceApi();
     const { setToastData, setToastApiError } = useToast();
+    const { trackEvent } = usePlausibleTracker();
 
     const currentUrl = source.url ?? '';
 
@@ -113,6 +115,16 @@ const ImpactMetricsPage = () => {
         setTestOutcome(null);
     };
 
+    const handleToggle = (_: unknown, checked: boolean) => {
+        setEnabled(checked);
+        trackEvent('external-impact-metrics', {
+            props: {
+                eventType: 'toggle',
+                enabled: checked ? 'enabled' : 'disabled',
+            },
+        });
+    };
+
     const handleCancel = () => {
         setEnabled(source.enabled);
         setPrometheusUrl(currentUrl);
@@ -120,6 +132,9 @@ const ImpactMetricsPage = () => {
 
     const handleTest = async () => {
         setTestOutcome(null);
+        trackEvent('external-impact-metrics', {
+            props: { eventType: 'test-integration' },
+        });
         try {
             const result = await testExternalImpactMetricsSource(trimmedUrl);
             if (result.error) {
@@ -138,12 +153,18 @@ const ImpactMetricsPage = () => {
                 enabled,
                 ...(trimmedUrl ? { url: trimmedUrl } : {}),
             });
+            trackEvent('external-impact-metrics', {
+                props: { eventType: 'saved', result: 'success' },
+            });
             setToastData({
                 type: 'success',
                 text: 'External metrics source has been saved',
             });
             refetch();
         } catch (error) {
+            trackEvent('external-impact-metrics', {
+                props: { eventType: 'saved', result: 'failed' },
+            });
             setToastApiError(formatUnknownError(error));
         }
     };
@@ -190,7 +211,7 @@ const ImpactMetricsPage = () => {
                         control={
                             <Switch
                                 checked={enabled}
-                                onChange={(_, checked) => setEnabled(checked)}
+                                onChange={handleToggle}
                                 disabled={loading || saving}
                                 name='enabled'
                             />

--- a/frontend/src/hooks/usePlausibleTracker.ts
+++ b/frontend/src/hooks/usePlausibleTracker.ts
@@ -90,7 +90,8 @@ export type CustomEvents =
     | 'signup-dialog'
     | 'signup-dialog-error'
     | 'safeguards'
-    | 'remote-mcp';
+    | 'remote-mcp'
+    | 'external-impact-metrics';
 
 export const usePlausibleTracker = () => {
     const plausible = useContext(PlausibleContext);


### PR DESCRIPTION
Adds Plausible analytics tracking to the Impact Metrics admin page (ImpactMetricsAdmin.tsx). Three interactions are now tracked under the external-impact-metrics event:                                        
   
  - **Toggle**: fires when the enabled/disabled switch is changed, with enabled: 'enabled' | 'disabled' in the payload                                                                                               
  - **Test integration**: fires when the "Test integration" button is clicked
  - **Save**: fires after the save request completes, with result: 'success' | 'failed' in the payload
                                                                                                                                                                                                                  
  Also registers 'external-impact-metrics' as an allowed custom event name in usePlausibleTracker.ts.