### PR TITLE
feat: add safeguard actions explanations

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.test.tsx
@@ -224,7 +224,7 @@ describe('AddSafeguard', () => {
         await user.click(addButton);
 
         await screen.findByText('Disable environment');
-        await screen.findByText('Pause release plan');
+        await screen.findByText('Pause release plan automation');
     });
 
     test('should call onSelect with chosen type', async () => {
@@ -257,7 +257,9 @@ describe('AddSafeguard', () => {
         const addButton = await screen.findByText('Add safeguard');
         await user.click(addButton);
 
-        const pauseItem = await screen.findByText('Pause release plan');
+        const pauseItem = await screen.findByText(
+            'Pause release plan automation',
+        );
         expect(pauseItem.closest('li')).toHaveAttribute(
             'aria-disabled',
             'true',
@@ -580,7 +582,7 @@ describe('Safeguard', () => {
 
         const { onSafeguardChange } = renderSection();
 
-        await selectSafeguardType(user, 'Pause release plan');
+        await selectSafeguardType(user, 'Pause release plan automation');
         await screen.findByText('Pause automation when');
 
         const saveButton = await screen.findByText('Save');
@@ -671,7 +673,7 @@ describe('Safeguard', () => {
 
         const { onSafeguardChange } = renderSection();
 
-        await selectSafeguardType(user, 'Pause release plan');
+        await selectSafeguardType(user, 'Pause release plan automation');
         await screen.findByText('Pause automation when');
 
         const saveButton = await screen.findByText('Save');

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.test.tsx
@@ -260,7 +260,7 @@ describe('AddSafeguard', () => {
         const pauseItem = await screen.findByText(
             'Pause release plan automation',
         );
-        expect(pauseItem.closest('li')).toHaveAttribute(
+        expect(pauseItem.closest('[role="menuitem"]')).toHaveAttribute(
             'aria-disabled',
             'true',
         );

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.test.tsx
@@ -224,7 +224,7 @@ describe('AddSafeguard', () => {
         await user.click(addButton);
 
         await screen.findByText('Disable environment');
-        await screen.findByText('Pause automation');
+        await screen.findByText('Pause release plan');
     });
 
     test('should call onSelect with chosen type', async () => {
@@ -257,7 +257,7 @@ describe('AddSafeguard', () => {
         const addButton = await screen.findByText('Add safeguard');
         await user.click(addButton);
 
-        const pauseItem = await screen.findByText('Pause automation');
+        const pauseItem = await screen.findByText('Pause release plan');
         expect(pauseItem.closest('li')).toHaveAttribute(
             'aria-disabled',
             'true',
@@ -580,7 +580,7 @@ describe('Safeguard', () => {
 
         const { onSafeguardChange } = renderSection();
 
-        await selectSafeguardType(user, 'Pause automation');
+        await selectSafeguardType(user, 'Pause release plan');
         await screen.findByText('Pause automation when');
 
         const saveButton = await screen.findByText('Save');
@@ -671,7 +671,7 @@ describe('Safeguard', () => {
 
         const { onSafeguardChange } = renderSection();
 
-        await selectSafeguardType(user, 'Pause automation');
+        await selectSafeguardType(user, 'Pause release plan');
         await screen.findByText('Pause automation when');
 
         const saveButton = await screen.findByText('Save');

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.tsx
@@ -170,7 +170,7 @@ export const AddSafeguard = ({
                         >
                             <Box>
                                 <Typography variant='body2'>
-                                    Pause release plan
+                                    Pause release plan automation
                                 </Typography>
                                 <StyledOptionDescription variant='caption'>
                                     If your chosen metric crosses its threshold,

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import {
     Box,
+    ListSubheader,
     menuClasses,
     styled,
     Menu,
@@ -64,13 +65,15 @@ const StyledSafeguardMenu = styled(Menu)(({ theme }) => ({
     },
 }));
 
-const StyledMenuHeader = styled(Typography)(({ theme }) => ({
-    display: 'block',
+const StyledMenuHeader = styled(ListSubheader)(({ theme }) => ({
     padding: theme.spacing(1, 2, 0.5, 2),
+    lineHeight: 1.6,
     textTransform: 'uppercase',
     letterSpacing: 0.5,
+    fontSize: theme.typography.caption.fontSize,
     fontWeight: theme.typography.fontWeightBold,
     color: theme.palette.text.secondary,
+    backgroundColor: 'transparent',
 }));
 
 const StyledSafeguardOptionItem = styled(MenuItem)(({ theme }) => ({
@@ -120,7 +123,7 @@ export const AddSafeguard = ({
                 open={Boolean(anchorEl)}
                 onClose={() => setAnchorEl(null)}
             >
-                <StyledMenuHeader variant='caption'>
+                <StyledMenuHeader disableSticky>
                     Select safeguard action
                 </StyledMenuHeader>
                 <StyledSafeguardOptionItem

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.tsx
@@ -76,12 +76,17 @@ const StyledMenuHeader = styled(ListSubheader)(({ theme }) => ({
     backgroundColor: 'transparent',
 }));
 
-const StyledSafeguardOptionItem = styled(MenuItem)(({ theme }) => ({
+const optionItemSx = {
     whiteSpace: 'normal',
     alignItems: 'flex-start',
-    paddingTop: theme.spacing(1.25),
-    paddingBottom: theme.spacing(1.25),
-}));
+    py: 1.25,
+} as const;
+
+const DisabledItemWrapper = styled('li')({
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+});
 
 const StyledOptionDescription = styled(Typography)(({ theme }) => ({
     display: 'block',
@@ -126,7 +131,8 @@ export const AddSafeguard = ({
                 <StyledMenuHeader disableSticky>
                     Select safeguard action
                 </StyledMenuHeader>
-                <StyledSafeguardOptionItem
+                <MenuItem
+                    sx={optionItemSx}
                     onClick={() => {
                         trackEvent('safeguards', {
                             props: {
@@ -148,7 +154,7 @@ export const AddSafeguard = ({
                             users stop seeing the flag immediately.
                         </StyledOptionDescription>
                     </Box>
-                </StyledSafeguardOptionItem>
+                </MenuItem>
                 <Tooltip
                     title={
                         releasePlan
@@ -158,8 +164,10 @@ export const AddSafeguard = ({
                     placement='right'
                     arrow
                 >
-                    <span>
-                        <StyledSafeguardOptionItem
+                    <DisabledItemWrapper>
+                        <MenuItem
+                            component='div'
+                            sx={optionItemSx}
                             disabled={!releasePlan}
                             onClick={() => {
                                 trackEvent('safeguards', {
@@ -182,8 +190,8 @@ export const AddSafeguard = ({
                                     current milestone keeps serving traffic.
                                 </StyledOptionDescription>
                             </Box>
-                        </StyledSafeguardOptionItem>
-                    </span>
+                        </MenuItem>
+                    </DisabledItemWrapper>
                 </Tooltip>
             </StyledSafeguardMenu>
         </StyledSafeguardContainer>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.tsx
@@ -1,5 +1,12 @@
 import { useMemo, useState } from 'react';
-import { styled, Menu, MenuItem, Tooltip } from '@mui/material';
+import {
+    Box,
+    styled,
+    Menu,
+    MenuItem,
+    Tooltip,
+    Typography,
+} from '@mui/material';
 import Add from '@mui/icons-material/Add';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import useToast from 'hooks/useToast';
@@ -83,7 +90,23 @@ export const AddSafeguard = ({
                 anchorEl={anchorEl}
                 open={Boolean(anchorEl)}
                 onClose={() => setAnchorEl(null)}
+                slotProps={{ paper: { sx: { maxWidth: 360 } } }}
             >
+                <Typography
+                    variant='caption'
+                    color='text.secondary'
+                    sx={{
+                        display: 'block',
+                        px: 2,
+                        pt: 1,
+                        pb: 0.5,
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.5,
+                        fontWeight: 600,
+                    }}
+                >
+                    Select safeguard action
+                </Typography>
                 <MenuItem
                     onClick={() => {
                         trackEvent('safeguards', {
@@ -95,8 +118,26 @@ export const AddSafeguard = ({
                         onSelect('featureEnvironment');
                         setAnchorEl(null);
                     }}
+                    sx={{
+                        whiteSpace: 'normal',
+                        alignItems: 'flex-start',
+                        py: 1.25,
+                    }}
                 >
-                    Disable environment
+                    <Box>
+                        <Typography variant='body2'>
+                            Disable environment
+                        </Typography>
+                        <Typography
+                            variant='caption'
+                            color='text.secondary'
+                            sx={{ display: 'block', mt: 0.25 }}
+                        >
+                            If your chosen metric crosses its threshold, this
+                            flag is turned off in this environment. Existing
+                            users stop seeing the flag immediately.
+                        </Typography>
+                    </Box>
                 </MenuItem>
                 <Tooltip
                     title={
@@ -120,8 +161,26 @@ export const AddSafeguard = ({
                                 onSelect('releasePlan');
                                 setAnchorEl(null);
                             }}
+                            sx={{
+                                whiteSpace: 'normal',
+                                alignItems: 'flex-start',
+                                py: 1.25,
+                            }}
                         >
-                            Pause automation
+                            <Box>
+                                <Typography variant='body2'>
+                                    Pause release plan
+                                </Typography>
+                                <Typography
+                                    variant='caption'
+                                    color='text.secondary'
+                                    sx={{ display: 'block', mt: 0.25 }}
+                                >
+                                    If your chosen metric crosses its threshold,
+                                    automatic milestone progression stops. The
+                                    current milestone keeps serving traffic.
+                                </Typography>
+                            </Box>
                         </MenuItem>
                     </span>
                 </Tooltip>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.tsx
@@ -57,6 +57,34 @@ const StyledAddSafeguardContent = styled('div')(({ theme }) => ({
     paddingRight: theme.spacing(2),
 }));
 
+const StyledSafeguardMenu = styled(Menu)(({ theme }) => ({
+    '& .MuiPaper-root': {
+        maxWidth: theme.spacing(45),
+    },
+}));
+
+const StyledMenuHeader = styled(Typography)(({ theme }) => ({
+    display: 'block',
+    padding: theme.spacing(1, 2, 0.5, 2),
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    fontWeight: theme.typography.fontWeightBold,
+    color: theme.palette.text.secondary,
+}));
+
+const StyledSafeguardOptionItem = styled(MenuItem)(({ theme }) => ({
+    whiteSpace: 'normal',
+    alignItems: 'flex-start',
+    paddingTop: theme.spacing(1.25),
+    paddingBottom: theme.spacing(1.25),
+}));
+
+const StyledOptionDescription = styled(Typography)(({ theme }) => ({
+    display: 'block',
+    marginTop: theme.spacing(0.25),
+    color: theme.palette.text.secondary,
+}));
+
 export const AddSafeguard = ({
     onSelect,
     releasePlan,
@@ -86,28 +114,15 @@ export const AddSafeguard = ({
                     Add safeguard
                 </StyledActionButton>
             </StyledAddSafeguardContent>
-            <Menu
+            <StyledSafeguardMenu
                 anchorEl={anchorEl}
                 open={Boolean(anchorEl)}
                 onClose={() => setAnchorEl(null)}
-                slotProps={{ paper: { sx: { maxWidth: 360 } } }}
             >
-                <Typography
-                    variant='caption'
-                    color='text.secondary'
-                    sx={{
-                        display: 'block',
-                        px: 2,
-                        pt: 1,
-                        pb: 0.5,
-                        textTransform: 'uppercase',
-                        letterSpacing: 0.5,
-                        fontWeight: 600,
-                    }}
-                >
+                <StyledMenuHeader variant='caption'>
                     Select safeguard action
-                </Typography>
-                <MenuItem
+                </StyledMenuHeader>
+                <StyledSafeguardOptionItem
                     onClick={() => {
                         trackEvent('safeguards', {
                             props: {
@@ -118,27 +133,18 @@ export const AddSafeguard = ({
                         onSelect('featureEnvironment');
                         setAnchorEl(null);
                     }}
-                    sx={{
-                        whiteSpace: 'normal',
-                        alignItems: 'flex-start',
-                        py: 1.25,
-                    }}
                 >
                     <Box>
                         <Typography variant='body2'>
                             Disable environment
                         </Typography>
-                        <Typography
-                            variant='caption'
-                            color='text.secondary'
-                            sx={{ display: 'block', mt: 0.25 }}
-                        >
+                        <StyledOptionDescription variant='caption'>
                             If your chosen metric crosses its threshold, this
                             flag is turned off in this environment. Existing
                             users stop seeing the flag immediately.
-                        </Typography>
+                        </StyledOptionDescription>
                     </Box>
-                </MenuItem>
+                </StyledSafeguardOptionItem>
                 <Tooltip
                     title={
                         releasePlan
@@ -149,7 +155,7 @@ export const AddSafeguard = ({
                     arrow
                 >
                     <span>
-                        <MenuItem
+                        <StyledSafeguardOptionItem
                             disabled={!releasePlan}
                             onClick={() => {
                                 trackEvent('safeguards', {
@@ -161,30 +167,21 @@ export const AddSafeguard = ({
                                 onSelect('releasePlan');
                                 setAnchorEl(null);
                             }}
-                            sx={{
-                                whiteSpace: 'normal',
-                                alignItems: 'flex-start',
-                                py: 1.25,
-                            }}
                         >
                             <Box>
                                 <Typography variant='body2'>
                                     Pause release plan
                                 </Typography>
-                                <Typography
-                                    variant='caption'
-                                    color='text.secondary'
-                                    sx={{ display: 'block', mt: 0.25 }}
-                                >
+                                <StyledOptionDescription variant='caption'>
                                     If your chosen metric crosses its threshold,
                                     automatic milestone progression stops. The
                                     current milestone keeps serving traffic.
-                                </Typography>
+                                </StyledOptionDescription>
                             </Box>
-                        </MenuItem>
+                        </StyledSafeguardOptionItem>
                     </span>
                 </Tooltip>
-            </Menu>
+            </StyledSafeguardMenu>
         </StyledSafeguardContainer>
     );
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/Safeguard.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import {
     Box,
+    menuClasses,
     styled,
     Menu,
     MenuItem,
@@ -58,7 +59,7 @@ const StyledAddSafeguardContent = styled('div')(({ theme }) => ({
 }));
 
 const StyledSafeguardMenu = styled(Menu)(({ theme }) => ({
-    '& .MuiPaper-root': {
+    [`& .${menuClasses.paper}`]: {
         maxWidth: theme.spacing(45),
     },
 }));


### PR DESCRIPTION
This PR adds clearer labels for safeguard selection: 

<img width="863" height="405" alt="Skjermbilde 2026-05-07 kl  09 49 51" src="https://github.com/user-attachments/assets/4cf65bfb-8b08-45cf-91ea-6c7765836234" />
