### PR TITLE
feat: toggle visibility for external source URL in ImpactMetricsPage

### DIFF
--- a/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.tsx
+++ b/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.tsx
@@ -103,6 +103,8 @@ const ImpactMetricsPage = () => {
     const [showUrl, setShowUrl] = useState(false);
     const [testOutcome, setTestOutcome] = useState<TestOutcome | null>(null);
 
+    const hasCredentials = /\/\/[^/@]+:[^/@]+@/.test(prometheusUrl);
+
     useEffect(() => {
         setEnabled(source.enabled);
         setPrometheusUrl(currentUrl);
@@ -230,10 +232,10 @@ const ImpactMetricsPage = () => {
                         disabled={loading || saving}
                         fullWidth
                         size='small'
-                        type={showUrl ? 'text' : 'password'}
+                        type={hasCredentials && !showUrl ? 'password' : 'text'}
                         slotProps={{
                             input: {
-                                endAdornment: (
+                                endAdornment: hasCredentials ? (
                                     <InputAdornment position='end'>
                                         <IconButton
                                             onClick={() =>
@@ -252,7 +254,7 @@ const ImpactMetricsPage = () => {
                                             )}
                                         </IconButton>
                                     </InputAdornment>
-                                ),
+                                ) : null,
                             },
                         }}
                     />

--- a/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.tsx
+++ b/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.tsx
@@ -4,6 +4,8 @@ import {
     AlertTitle,
     Button,
     FormControlLabel,
+    IconButton,
+    InputAdornment,
     Link,
     styled,
     Switch,
@@ -11,6 +13,8 @@ import {
     Typography,
 } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import { PermissionGuard } from 'component/common/PermissionGuard/PermissionGuard';
 import { ADMIN } from 'component/providers/AccessProvider/permissions';
 import { PageContent } from 'component/common/PageContent/PageContent';
@@ -96,6 +100,7 @@ const ImpactMetricsPage = () => {
 
     const [enabled, setEnabled] = useState(false);
     const [prometheusUrl, setPrometheusUrl] = useState('');
+    const [showUrl, setShowUrl] = useState(false);
     const [testOutcome, setTestOutcome] = useState<TestOutcome | null>(null);
 
     useEffect(() => {
@@ -225,6 +230,31 @@ const ImpactMetricsPage = () => {
                         disabled={loading || saving}
                         fullWidth
                         size='small'
+                        type={showUrl ? 'text' : 'password'}
+                        slotProps={{
+                            input: {
+                                endAdornment: (
+                                    <InputAdornment position='end'>
+                                        <IconButton
+                                            onClick={() =>
+                                                setShowUrl((v) => !v)
+                                            }
+                                            onMouseDown={(e) =>
+                                                e.preventDefault()
+                                            }
+                                            size='small'
+                                            edge='end'
+                                        >
+                                            {showUrl ? (
+                                                <VisibilityOff titleAccess='Hide URL' />
+                                            ) : (
+                                                <Visibility titleAccess='Show URL' />
+                                            )}
+                                        </IconButton>
+                                    </InputAdornment>
+                                ),
+                            },
+                        }}
                     />
                     <Button
                         variant='contained'


### PR DESCRIPTION
## What

Add show/hide toggle to the external source URL field in the Impact Metrics admin page. The URL is masked by default (password input) with an eye icon to reveal it.

## Why

Prevents accidental exposure of sensitive URLs (e.g. Prometheus endpoints with credentials) in the UI.