### PR TITLE
feat: integrate LogRocket session replay behind a feature flag

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,13 +47,13 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",
+    "@base-ui/react": "^1.4.1",
     "@biomejs/biome": "^2.4.14",
     "@codemirror/lang-json": "6.0.2",
     "@emotion/babel-plugin": "^11.13.5",
     "@emotion/cache": "11.14.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "11.14.1",
-    "@base-ui/react": "^1.4.1",
     "@mui/icons-material": "7.3.10",
     "@mui/lab": "7.0.1-beta.24",
     "@mui/material": "7.3.10",
@@ -172,6 +172,7 @@
     "chartjs-plugin-datalabels": "^2.2.0",
     "json-2-csv": "^5.5.10",
     "json-diff-react": "^1.0.1",
+    "logrocket": "^12.1.1",
     "re2js": "2.3.1"
   },
   "packageManager": "pnpm@11.0.5"

--- a/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
+++ b/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
@@ -1,0 +1,51 @@
+import type React from 'react';
+import { type FC, useEffect, useRef } from 'react';
+import LogRocket from 'logrocket';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import { useUiFlag } from 'hooks/useUiFlag';
+import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
+
+export const LogRocketProvider: FC<{ children?: React.ReactNode }> = ({
+    children,
+}) => {
+    const { uiConfig } = useUiConfig();
+    const { user } = useAuthUser();
+    const isEnabled = useUiFlag('logRocketEnabled');
+    const initialized = useRef(false);
+    const identified = useRef(false);
+
+    const appId = uiConfig?.logRocketAppId;
+    const instanceId = uiConfig?.versionInfo?.instanceId;
+
+    useEffect(() => {
+        if (!isEnabled || !appId || initialized.current) return;
+        try {
+            LogRocket.init(appId);
+            initialized.current = true;
+        } catch (error) {
+            console.warn(error);
+        }
+    }, [isEnabled, appId]);
+
+    useEffect(() => {
+        if (
+            !initialized.current ||
+            identified.current ||
+            !user?.id ||
+            !instanceId
+        ) {
+            return;
+        }
+        try {
+            LogRocket.identify(`${instanceId}:${user.id}`, {
+                instanceId,
+                userId: String(user.id),
+            });
+            identified.current = true;
+        } catch (error) {
+            console.warn(error);
+        }
+    }, [user?.id, instanceId]);
+
+    return <>{children}</>;
+};

--- a/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
+++ b/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
@@ -12,7 +12,7 @@ export const LogRocketProvider: FC<{ children?: React.ReactNode }> = ({
     const { user } = useAuthUser();
     const isEnabled = useUiFlag('logRocketEnabled');
     const appId = uiConfig?.logRocketAppId;
-    const instanceId = uiConfig?.versionInfo?.instanceId;
+    const clientId = uiConfig?.unleashContext?.properties?.clientId;
     const userId = user?.id;
 
     const initialized = useRef(false);
@@ -33,18 +33,18 @@ export const LogRocketProvider: FC<{ children?: React.ReactNode }> = ({
     useEffect(() => {
         if (identified.current) return;
         if (!initialized.current) return;
-        if (!userId || !instanceId) return;
+        if (!userId || !clientId) return;
 
         try {
-            LogRocket.identify(`${instanceId}:${userId}`, {
-                instanceId,
+            LogRocket.identify(`${clientId}:${userId}`, {
+                clientId,
                 userId: String(userId),
             });
             identified.current = true;
         } catch (error) {
             console.warn(error);
         }
-    }, [userId, instanceId]);
+    }, [userId, clientId]);
 
     return <>{children}</>;
 };

--- a/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
+++ b/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
@@ -11,14 +11,17 @@ export const LogRocketProvider: FC<{ children?: React.ReactNode }> = ({
     const { uiConfig } = useUiConfig();
     const { user } = useAuthUser();
     const isEnabled = useUiFlag('logRocketEnabled');
+    const appId = uiConfig?.logRocketAppId;
+    const instanceId = uiConfig?.versionInfo?.instanceId;
+    const userId = user?.id;
+
     const initialized = useRef(false);
     const identified = useRef(false);
 
-    const appId = uiConfig?.logRocketAppId;
-    const instanceId = uiConfig?.versionInfo?.instanceId;
-
     useEffect(() => {
-        if (!isEnabled || !appId || initialized.current) return;
+        if (initialized.current) return;
+        if (!isEnabled || !appId) return;
+
         try {
             LogRocket.init(appId);
             initialized.current = true;
@@ -28,24 +31,20 @@ export const LogRocketProvider: FC<{ children?: React.ReactNode }> = ({
     }, [isEnabled, appId]);
 
     useEffect(() => {
-        if (
-            !initialized.current ||
-            identified.current ||
-            !user?.id ||
-            !instanceId
-        ) {
-            return;
-        }
+        if (identified.current) return;
+        if (!initialized.current) return;
+        if (!userId || !instanceId) return;
+
         try {
-            LogRocket.identify(`${instanceId}:${user.id}`, {
+            LogRocket.identify(`${instanceId}:${userId}`, {
                 instanceId,
-                userId: String(user.id),
+                userId: String(userId),
             });
             identified.current = true;
         } catch (error) {
             console.warn(error);
         }
-    }, [user?.id, instanceId]);
+    }, [userId, instanceId]);
 
     return <>{children}</>;
 };

--- a/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
+++ b/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
@@ -8,19 +8,21 @@ import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
 export const LogRocketProvider: FC<{ children?: React.ReactNode }> = ({
     children,
 }) => {
-    const { uiConfig } = useUiConfig();
+    const { uiConfig, isEnterprise } = useUiConfig();
     const { user } = useAuthUser();
     const isEnabled = useUiFlag('logRocketEnabled');
     const appId = uiConfig?.logRocketAppId;
     const clientId = uiConfig?.unleashContext?.properties?.clientId;
     const userId = user?.id;
+    const isEnterprisePayg =
+        isEnterprise() && uiConfig?.billing === 'pay-as-you-go';
 
     const initialized = useRef(false);
     const identified = useRef(false);
 
     useEffect(() => {
         if (initialized.current) return;
-        if (!isEnabled || !appId) return;
+        if (!isEnabled || !appId || !isEnterprisePayg) return;
 
         try {
             LogRocket.init(appId);
@@ -28,7 +30,7 @@ export const LogRocketProvider: FC<{ children?: React.ReactNode }> = ({
         } catch (error) {
             console.warn(error);
         }
-    }, [isEnabled, appId]);
+    }, [isEnabled, appId, isEnterprisePayg]);
 
     useEffect(() => {
         if (identified.current) return;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -18,6 +18,7 @@ import { UIProviderContainer } from 'component/providers/UIProvider/UIProviderCo
 import { StickyProvider } from 'component/common/Sticky/StickyProvider';
 import { FeedbackProvider } from 'component/feedbackNew/FeedbackProvider';
 import { PlausibleProvider } from 'component/providers/PlausibleProvider/PlausibleProvider';
+import { LogRocketProvider } from 'component/providers/LogRocketProvider/LogRocketProvider';
 import { LayoutError } from './component/layout/Error/LayoutError.tsx';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useRecordUIErrorApi } from 'hooks/api/actions/useRecordUIErrorApi/useRecordUiErrorApi';
@@ -52,27 +53,29 @@ const ApplicationRoot = () => {
                         <ThemeProvider>
                             <AnnouncerProvider>
                                 <PlausibleProvider>
-                                    <UnleashFlagProvider>
-                                        <ErrorBoundary
-                                            FallbackComponent={LayoutError}
-                                            onError={sendErrorToApi}
-                                        >
-                                            <FeedbackProvider>
-                                                <FeedbackCESProvider>
-                                                    <StickyProvider>
-                                                        <HighlightProvider>
-                                                            <WelcomeDialogProvider>
-                                                                <InstanceStatus>
-                                                                    <ScrollTop />
-                                                                    <App />
-                                                                </InstanceStatus>
-                                                            </WelcomeDialogProvider>
-                                                        </HighlightProvider>
-                                                    </StickyProvider>
-                                                </FeedbackCESProvider>
-                                            </FeedbackProvider>
-                                        </ErrorBoundary>
-                                    </UnleashFlagProvider>
+                                    <LogRocketProvider>
+                                        <UnleashFlagProvider>
+                                            <ErrorBoundary
+                                                FallbackComponent={LayoutError}
+                                                onError={sendErrorToApi}
+                                            >
+                                                <FeedbackProvider>
+                                                    <FeedbackCESProvider>
+                                                        <StickyProvider>
+                                                            <HighlightProvider>
+                                                                <WelcomeDialogProvider>
+                                                                    <InstanceStatus>
+                                                                        <ScrollTop />
+                                                                        <App />
+                                                                    </InstanceStatus>
+                                                                </WelcomeDialogProvider>
+                                                            </HighlightProvider>
+                                                        </StickyProvider>
+                                                    </FeedbackCESProvider>
+                                                </FeedbackProvider>
+                                            </ErrorBoundary>
+                                        </UnleashFlagProvider>
+                                    </LogRocketProvider>
                                 </PlausibleProvider>
                             </AnnouncerProvider>
                         </ThemeProvider>

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -21,6 +21,7 @@ export interface IUiConfig {
     billing?: 'subscription' | 'pay-as-you-go' | 'enterprise-consumption';
     unleashUrl?: string;
     edgeUrl?: string;
+    logRocketAppId?: string;
     version: string;
     versionInfo?: IVersionInfo;
     links: ILinks[];
@@ -96,6 +97,7 @@ export type UiFlags = {
     externalImpactMetrics?: boolean;
     accessOverviewRework?: boolean;
     onboardingConnectSDKNewDialog?: boolean;
+    logRocketEnabled?: boolean;
 };
 
 export interface IVersionInfo {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,9 @@ importers:
       json-diff-react:
         specifier: ^1.0.1
         version: 1.0.1
+      logrocket:
+        specifier: ^12.1.1
+        version: 12.1.1
       re2js:
         specifier: 2.3.1
         version: 2.3.1
@@ -4539,6 +4542,9 @@ packages:
   loglevel@1.9.2:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
+
+  logrocket@12.1.1:
+    resolution: {integrity: sha512-l7z9ii5nNV6NZ3nzEqbB3xJAqFJC6QdRYDK8DeCC6JKwzuI8nyUezUJAotgMyClrqB6eV/Bo0i/KihQlXSRDKw==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -10810,6 +10816,8 @@ snapshots:
   loglevel-plugin-prefix@0.8.4: {}
 
   loglevel@1.9.2: {}
+
+  logrocket@12.1.1: {}
 
   loose-envify@1.4.0:
     dependencies:

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -151,6 +151,7 @@ exports[`should create default config 1`] = `
     "headersTimeout": 61000,
     "host": undefined,
     "keepAliveTimeout": 15000,
+    "logRocketAppId": undefined,
     "pipe": undefined,
     "port": 4242,
     "secret": "super-secret",

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -295,6 +295,7 @@ const defaultServerOption: IServerOption = {
     cdnPrefix: process.env.CDN_PREFIX,
     edgeUrl: process.env.EDGE_URL,
     unleashUrl: process.env.UNLEASH_URL || 'http://localhost:4242',
+    logRocketAppId: process.env.LOGROCKET_APP_ID,
     serverMetrics: true,
     enableHeapSnapshotEnpoint: parseEnvVarBoolean(
         process.env.ENABLE_HEAP_SNAPSHOT_ENPOINT,

--- a/src/lib/openapi/spec/ui-config-schema.ts
+++ b/src/lib/openapi/spec/ui-config-schema.ts
@@ -49,6 +49,12 @@ export const uiConfigSchema = {
             description: 'The URL of the Unleash instance.',
             example: 'https://unleash.mycompany.com/enterprise',
         },
+        logRocketAppId: {
+            type: 'string',
+            description:
+                'The LogRocket app ID used to initialize session replay in the admin UI. Only used when the `logRocketEnabled` flag is on.',
+            example: '1knhci/unleash-sandbox',
+        },
         baseUriPath: {
             type: 'string',
             description:

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -79,7 +79,8 @@ export type IFlagKey =
     | 'elasticEventSync'
     | 'externalImpactMetrics'
     | 'accessOverviewRework'
-    | 'onboardingConnectSDKNewDialog';
+    | 'onboardingConnectSDKNewDialog'
+    | 'logRocketEnabled';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -360,6 +361,10 @@ const flags: IFlags = {
     ),
     onboardingConnectSDKNewDialog: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_ONBOARDING_CONNECT_SDK_NEW_DIALOG,
+        false,
+    ),
+    logRocketEnabled: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_LOGROCKET_ENABLED,
         false,
     ),
 };

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -105,6 +105,7 @@ export interface IServerOption {
     cdnPrefix?: string;
     edgeUrl?: string;
     unleashUrl: string;
+    logRocketAppId?: string;
     serverMetrics: boolean;
     enableHeapSnapshotEnpoint: boolean;
     enableRequestLogger: boolean;

--- a/src/lib/ui-config/ui-config-service.ts
+++ b/src/lib/ui-config/ui-config-service.ts
@@ -115,6 +115,7 @@ export class UiConfigService {
             emailEnabled: this.emailService.isEnabled(),
             edgeUrl: this.config.server.edgeUrl,
             unleashUrl: this.config.server.unleashUrl,
+            logRocketAppId: this.config.server.logRocketAppId,
             baseUriPath: this.config.server.baseUriPath,
             authenticationType: this.config.authentication?.type,
             frontendApiOrigins: frontendSettings.frontendApiOrigins,


### PR DESCRIPTION
- New `LogRocketProvider` mounted in `frontend/src/index.tsx` next to `PlausibleProvider`. Initializes once when both flag and app ID are present.
- User identity is composed as `${instanceId}:${userId}` (with both also passed as traits) so sessions don't collide across Unleash instances in the LogRocket dashboard.

