### PR TITLE
chore: skeleton design for new Connect SDK dialog

### DIFF
--- a/frontend/src/component/onboarding/dialog/ConnectSdkDialog.tsx
+++ b/frontend/src/component/onboarding/dialog/ConnectSdkDialog.tsx
@@ -18,6 +18,8 @@ import type { Sdk } from './sharedTypes.ts';
 import { ConnectionInformation } from './ConnectionInformation.tsx';
 import { SdkConnection } from './SdkConnection.tsx';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
+import { useUiFlag } from 'hooks/useUiFlag.ts';
+import { ConnectSdkDialog as NewConnectSdkDialog } from './NewConnectSdkDialog.tsx';
 
 interface IConnectSDKDialogProps {
     open: boolean;
@@ -206,5 +208,13 @@ export const ConnectSdkDialog = ({
     open,
     ...props
 }: IConnectSDKDialogProps) => {
+    const onboardingConnectSDKNewDialogEnabled = useUiFlag(
+        'onboardingConnectSDKNewDialog',
+    );
+
+    if (onboardingConnectSDKNewDialogEnabled) {
+        return open ? <NewConnectSdkDialog open={open} {...props} /> : null;
+    }
+
     return open ? <InnerDialog {...props} /> : null;
 };

--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog.tsx
@@ -1,0 +1,140 @@
+import { Box, Dialog, DialogContent, IconButton, styled } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { Truncator } from 'component/common/Truncator/Truncator.tsx';
+
+interface IConnectSDKDialogProps {
+    open: boolean;
+    onClose: () => void;
+    onFinish: (sdkName: string) => void;
+    project: string;
+    environments: string[];
+    feature?: string;
+}
+
+const StyledDialog = styled(Dialog)(({ theme }) => ({
+    '& .MuiDialog-paper': {
+        borderRadius: theme.shape.borderRadiusLarge,
+        maxWidth: theme.spacing(170),
+        width: '100%',
+        overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: theme.palette.background.sidebar,
+    },
+}));
+
+const StyledDialogHeader = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    flexShrink: 0,
+    borderBottom: `1px solid ${theme.palette.divider}`,
+}));
+
+const StyledDialogHeaderMain = styled(Box)(({ theme }) => ({
+    flex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: theme.palette.background.paper,
+    paddingRight: theme.spacing(1.5),
+    '& .closeButton': {
+        display: 'none',
+        [theme.breakpoints.down('md')]: {
+            display: 'flex',
+        },
+    },
+}));
+
+const StyledDialogHeaderTitle = styled('h2')(({ theme }) => ({
+    padding: theme.spacing(1.5, 3),
+    fontWeight: theme.fontWeight.bold,
+    fontSize: theme.fontSizes.bodySize,
+    lineHeight: theme.spacing(2.75),
+}));
+
+const StyledDialogHeaderAside = styled(Box)(({ theme }) => ({
+    width: theme.spacing(26),
+    flexShrink: 0,
+    backgroundColor: theme.palette.background.sidebar,
+    color: theme.palette.primary.contrastText,
+    '& svg': {
+        color: theme.palette.primary.contrastText,
+    },
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'end',
+    paddingRight: theme.spacing(1.5),
+    [theme.breakpoints.down('md')]: {
+        display: 'none',
+    },
+}));
+
+const StyledDialogBody = styled(Box)({
+    display: 'flex',
+    flex: 1,
+    overflow: 'hidden',
+});
+
+const StyledDialogContent = styled(DialogContent)(({ theme }) => ({
+    flex: 1,
+    padding: theme.spacing(3),
+    display: 'flex',
+    flexDirection: 'column',
+    overflowY: 'auto',
+    backgroundColor: theme.palette.background.paper,
+}));
+
+const StyledDialogAside = styled('aside')(({ theme }) => ({
+    width: theme.spacing(26),
+    flexShrink: 0,
+    backgroundColor: theme.palette.background.sidebar,
+    color: theme.palette.primary.contrastText,
+    padding: theme.spacing(3),
+    display: 'flex',
+    flexDirection: 'column',
+    [theme.breakpoints.down('md')]: {
+        display: 'none',
+    },
+}));
+
+const DialogHeader = ({ onClose }: Pick<IConnectSDKDialogProps, 'onClose'>) => {
+    const CloseButton = () => (
+        <IconButton size='small' className='closeButton' onClick={onClose}>
+            <CloseIcon />
+        </IconButton>
+    );
+
+    return (
+        <StyledDialogHeader>
+            <StyledDialogHeaderMain>
+                <StyledDialogHeaderTitle>
+                    <Truncator>Connect SDK</Truncator>
+                </StyledDialogHeaderTitle>
+                <CloseButton />
+            </StyledDialogHeaderMain>
+            <StyledDialogHeaderAside>
+                <CloseButton />
+            </StyledDialogHeaderAside>
+        </StyledDialogHeader>
+    );
+};
+
+const InnerDialog = ({ onClose }: Omit<IConnectSDKDialogProps, 'open'>) => {
+    // TODO: Implement
+    return (
+        <StyledDialog open onClose={onClose}>
+            <DialogHeader onClose={onClose} />
+            <StyledDialogBody>
+                <StyledDialogContent>Main content</StyledDialogContent>
+                <StyledDialogAside>Aside content</StyledDialogAside>
+            </StyledDialogBody>
+        </StyledDialog>
+    );
+};
+
+export const ConnectSdkDialog = ({
+    open,
+    ...props
+}: IConnectSDKDialogProps) => {
+    if (!open) return null;
+    return <InnerDialog {...props} />;
+};


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-456/connect-sdk-dialog-base-design

New "Connect SDK" dialog base design, based on the sketches.

### > md

<img width="1625" height="752" alt="image" src="https://github.com/user-attachments/assets/e3505094-8bf7-4f62-85f9-e49185a563fe" />

### <= md

<img width="824" height="831" alt="image" src="https://github.com/user-attachments/assets/535f73f9-7f12-4e86-9623-4e048c903522" />

### Edge case: Title truncation

<img width="207" height="201" alt="image" src="https://github.com/user-attachments/assets/8593a33f-b395-49ed-bb50-555b9c16cf73" />