### PR TITLE
fix: add right margin to HelpIcon for visual symmetry

### DIFF
--- a/frontend/src/component/common/HelpIcon/HelpIcon.tsx
+++ b/frontend/src/component/common/HelpIcon/HelpIcon.tsx
@@ -23,6 +23,7 @@ const StyledContainer = styled('span')<{ size: string | undefined }>(
             fontSize: size || theme.fontSizes.mainHeader,
             color: theme.palette.action.active,
             marginLeft: theme.spacing(0.5),
+            marginRight: theme.spacing(0.5),
         },
     }),
 );


### PR DESCRIPTION
## Summary

- The `HelpIcon` SVG had `marginLeft: theme.spacing(0.5)` (4px) but no corresponding right margin, causing the icon to appear visually unbalanced — specifically noticeable on the Remote MCP Server admin settings page.
- Added `marginRight: theme.spacing(0.5)` to match the existing left margin, making the spacing symmetric on both sides.

## Tests
After the change:
<img width="404" height="112" alt="image" src="https://github.com/user-attachments/assets/0b3b4fa4-72bd-4b36-99f7-ad31dbc781db" />

Before:
<img width="207" height="83" alt="image" src="https://github.com/user-attachments/assets/0c39e223-cfb1-439f-af34-17f888460ddf" />


