### PR TITLE
chore: new connect sdk dialog aside

### DIFF
--- a/frontend/src/component/onboarding/dialog/ConnectSdkDialog.tsx
+++ b/frontend/src/component/onboarding/dialog/ConnectSdkDialog.tsx
@@ -19,7 +19,7 @@ import { ConnectionInformation } from './ConnectionInformation.tsx';
 import { SdkConnection } from './SdkConnection.tsx';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 import { useUiFlag } from 'hooks/useUiFlag.ts';
-import { ConnectSdkDialog as NewConnectSdkDialog } from './NewConnectSdkDialog.tsx';
+import { ConnectSdkDialog as NewConnectSdkDialog } from './NewConnectSdkDialog/NewConnectSdkDialog.tsx';
 
 interface IConnectSDKDialogProps {
     open: boolean;

--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
@@ -1,6 +1,7 @@
 import { Box, Dialog, DialogContent, IconButton, styled } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { Truncator } from 'component/common/Truncator/Truncator.tsx';
+import { NewConnectSdkDialogAside } from './NewConnectSdkDialogAside';
 
 interface IConnectSDKDialogProps {
     open: boolean;
@@ -46,13 +47,13 @@ const StyledDialogHeaderMain = styled(Box)(({ theme }) => ({
 
 const StyledDialogHeaderTitle = styled('h2')(({ theme }) => ({
     padding: theme.spacing(1.5, 3),
-    fontWeight: theme.fontWeight.bold,
-    fontSize: theme.fontSizes.bodySize,
+    fontWeight: theme.typography.fontWeightBold,
+    fontSize: theme.typography.body1.fontSize,
     lineHeight: theme.spacing(2.75),
 }));
 
 const StyledDialogHeaderAside = styled(Box)(({ theme }) => ({
-    width: theme.spacing(26),
+    width: theme.spacing(40),
     flexShrink: 0,
     backgroundColor: theme.palette.background.sidebar,
     color: theme.palette.primary.contrastText,
@@ -84,7 +85,7 @@ const StyledDialogContent = styled(DialogContent)(({ theme }) => ({
 }));
 
 const StyledDialogAside = styled('aside')(({ theme }) => ({
-    width: theme.spacing(26),
+    width: theme.spacing(40),
     flexShrink: 0,
     backgroundColor: theme.palette.background.sidebar,
     color: theme.palette.primary.contrastText,
@@ -125,7 +126,9 @@ const InnerDialog = ({ onClose }: Omit<IConnectSDKDialogProps, 'open'>) => {
             <DialogHeader onClose={onClose} />
             <StyledDialogBody>
                 <StyledDialogContent>Main content</StyledDialogContent>
-                <StyledDialogAside>Aside content</StyledDialogAside>
+                <StyledDialogAside>
+                    <NewConnectSdkDialogAside />
+                </StyledDialogAside>
             </StyledDialogBody>
         </StyledDialog>
     );

--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialogAside.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialogAside.tsx
@@ -1,0 +1,73 @@
+import { Link, styled, Typography } from '@mui/material';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+import GitHubIcon from '@mui/icons-material/GitHub';
+
+const StyledHeader = styled(Typography)(({ theme }) => ({
+    fontSize: theme.typography.body2.fontSize,
+    fontWeight: theme.typography.fontWeightBold,
+    marginBottom: theme.spacing(1.25),
+}));
+
+const StyledResourceHeader = styled(Typography)(({ theme }) => ({
+    fontWeight: theme.typography.fontWeightBold,
+    marginTop: theme.spacing(2.75),
+    marginBottom: theme.spacing(1.75),
+}));
+
+const StyledResourceList = styled('ul')(({ theme }) => ({
+    padding: 0,
+    margin: 0,
+    listStyle: 'none',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+}));
+
+const StyledResourceLink = styled(Link)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    color: 'inherit',
+    fontSize: theme.typography.body2.fontSize,
+    fontWeight: theme.typography.fontWeightBold,
+    paddingLeft: theme.spacing(1),
+    textDecoration: 'none',
+    '&:hover, &:focus': {
+        textDecoration: 'underline',
+    },
+}));
+
+export const NewConnectSdkDialogAside = () => (
+    <>
+        <StyledHeader>Why do I need an SDK?</StyledHeader>
+        <Typography variant='body2'>
+            SDKs serve to bind your application to Unleash. The SDK can connect
+            to Unleash via HTTP and retrieve feature flag configuration that is
+            then cached in your application. Making sure none of your
+            application data ever leaves your servers.
+        </Typography>
+        <StyledResourceHeader>Other resources</StyledResourceHeader>
+        <StyledResourceList>
+            <li>
+                <StyledResourceLink
+                    href='https://docs.getunleash.io/sdks'
+                    target='_blank'
+                    rel='noreferrer'
+                >
+                    <MenuBookIcon fontSize='small' />
+                    SDK overview
+                </StyledResourceLink>
+            </li>
+            <li>
+                <StyledResourceLink
+                    href='https://github.com/Unleash/unleash-sdk-examples'
+                    target='_blank'
+                    rel='noreferrer'
+                >
+                    <GitHubIcon fontSize='small' />
+                    SDK code examples repo
+                </StyledResourceLink>
+            </li>
+        </StyledResourceList>
+    </>
+);


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-459/connect-sdk-dialog-aside-design-and-content

New "Connect SDK" dialog aside.

### Light theme

<img width="1425" height="436" alt="image" src="https://github.com/user-attachments/assets/7b1dcdb6-957a-46d5-b4fa-d7ac1c3794a1" />

### Dark theme

<img width="1399" height="408" alt="image" src="https://github.com/user-attachments/assets/e7bbfc88-57c0-4df1-b1f4-75b4c2b3e5d9" />