### PR TITLE
fix: allow LogRocket CDN and ingest domains in CSP

### DIFF
--- a/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
+++ b/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
@@ -25,7 +25,12 @@ export const LogRocketProvider: FC<{ children?: React.ReactNode }> = ({
         if (!isEnabled || !appId || !isEnterprisePayg) return;
 
         try {
-            LogRocket.init(appId);
+            LogRocket.init(appId, {
+                dom: {
+                    textSanitizer: true,
+                    inputSanitizer: 'lipsum',
+                },
+            });
             initialized.current = true;
         } catch (error) {
             console.warn(error);

--- a/src/lib/middleware/secure-headers.ts
+++ b/src/lib/middleware/secure-headers.ts
@@ -3,6 +3,37 @@ import type { RequestHandler } from 'express';
 import type { IUnleashConfig } from '../types/index.js';
 import { hoursToSeconds } from 'date-fns';
 
+const LOGROCKET_SCRIPT_SRC = [
+    'https://cdn.logrocket.io',
+    'https://cdn.lr-ingest.io',
+    'https://cdn.lr-in.com',
+    'https://cdn.lr-in-prod.com',
+    'https://cdn.lr-ingest.com',
+    'https://cdn.ingest-lr.com',
+    'https://cdn.lr-intake.com',
+    'https://cdn.intake-lr.com',
+    'https://cdn.logr-ingest.com',
+    'https://cdn.lrkt-in.com',
+    'https://cdn.lgrckt-in.com',
+    'https://cdn.logr-in.com',
+];
+
+const LOGROCKET_CONNECT_SRC = [
+    'https://*.logrocket.io',
+    'https://*.logrocket.com',
+    'https://*.lr-ingest.io',
+    'https://*.lr-in.com',
+    'https://*.lr-in-prod.com',
+    'https://*.lr-ingest.com',
+    'https://*.ingest-lr.com',
+    'https://*.lr-intake.com',
+    'https://*.intake-lr.com',
+    'https://*.logr-ingest.com',
+    'https://*.lrkt-in.com',
+    'https://*.lgrckt-in.com',
+    'https://*.logr-in.com',
+];
+
 const secureHeaders: (config: IUnleashConfig) => RequestHandler = (config) => {
     if (config.secureHeaders) {
         const includeUnsafeInline = !config.flagResolver.isEnabled(
@@ -44,6 +75,7 @@ const secureHeaders: (config: IUnleashConfig) => RequestHandler = (config) => {
                     scriptSrc: [
                         "'self'",
                         'cdn.getunleash.io',
+                        ...LOGROCKET_SCRIPT_SRC,
                         ...config.additionalCspAllowedDomains.scriptSrc,
                     ],
                     imgSrc: [
@@ -61,8 +93,11 @@ const secureHeaders: (config: IUnleashConfig) => RequestHandler = (config) => {
                         'europe-west3-metrics-304612.cloudfunctions.net',
                         'app.unleash-hosted.com',
                         'hosted.edge.getunleash.io',
+                        ...LOGROCKET_CONNECT_SRC,
                         ...config.additionalCspAllowedDomains.connectSrc,
                     ],
+                    workerSrc: ["'self'", 'blob:'],
+                    childSrc: ["'self'", 'blob:'],
                     mediaSrc: [
                         "'self'",
                         'cdn.getunleash.io',

--- a/src/lib/middleware/secure-headers.ts
+++ b/src/lib/middleware/secure-headers.ts
@@ -39,6 +39,12 @@ const secureHeaders: (config: IUnleashConfig) => RequestHandler = (config) => {
         const includeUnsafeInline = !config.flagResolver.isEnabled(
             'removeUnsafeInlineStyleSrc',
         );
+        const logRocketEnabled = Boolean(config.server.logRocketAppId);
+        const logRocketScriptSrc = logRocketEnabled ? LOGROCKET_SCRIPT_SRC : [];
+        const logRocketConnectSrc = logRocketEnabled
+            ? LOGROCKET_CONNECT_SRC
+            : [];
+        const workerSrc = logRocketEnabled ? ["'self'", 'blob:'] : ["'self'"];
         const styleSrc = ["'self'"];
         if (includeUnsafeInline) {
             styleSrc.push("'unsafe-inline'");
@@ -75,7 +81,7 @@ const secureHeaders: (config: IUnleashConfig) => RequestHandler = (config) => {
                     scriptSrc: [
                         "'self'",
                         'cdn.getunleash.io',
-                        ...LOGROCKET_SCRIPT_SRC,
+                        ...logRocketScriptSrc,
                         ...config.additionalCspAllowedDomains.scriptSrc,
                     ],
                     imgSrc: [
@@ -93,11 +99,11 @@ const secureHeaders: (config: IUnleashConfig) => RequestHandler = (config) => {
                         'europe-west3-metrics-304612.cloudfunctions.net',
                         'app.unleash-hosted.com',
                         'hosted.edge.getunleash.io',
-                        ...LOGROCKET_CONNECT_SRC,
+                        ...logRocketConnectSrc,
                         ...config.additionalCspAllowedDomains.connectSrc,
                     ],
-                    workerSrc: ["'self'", 'blob:'],
-                    childSrc: ["'self'", 'blob:'],
+                    workerSrc,
+                    childSrc: workerSrc,
                     mediaSrc: [
                         "'self'",
                         'cdn.getunleash.io',


### PR DESCRIPTION
## Summary

Follow-up to #11973. The LogRocket SDK was being blocked by Content Security Policy:

```
Refused to load the script 'https://cdn.logr-in.com/logger-1.min.js' because it
violates the following Content Security Policy directive:
"script-src 'self' cdn.getunleash.io".
```

Adds LogRocket's documented CDN, ingest, and worker domains to the relevant CSP directives so the SDK can load and ship session data when enabled. The domains have no effect for instances that don't enable LogRocket, they're allowlisted hosts, not preloads.

Source list comes verbatim from LogRocket's [CSP docs](https://docs.logrocket.com/reference/web-content-security-policy):

- `script-src`: 12 literal `cdn.*` hosts
- `connect-src`: 13 wildcard `*.*` hosts (regional ingest endpoints)
- `worker-src` and `child-src`: `'self' blob:` (LogRocket spawns blob-URL workers)