### PR TITLE
chore: New SelectSdk step

### DIFF
--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/SelectSdk.story.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/SelectSdk.story.tsx
@@ -1,0 +1,11 @@
+import type { Story, StoryMeta } from 'component/stories/types';
+import { SelectSdk } from './SelectSdk';
+
+export const meta: StoryMeta = {
+    title: 'Onboarding / SelectSdk',
+    background: 'paper',
+};
+
+export const WithSelection: Story = () => (
+    <SelectSdk onSelect={(sdk) => console.log('Selected SDK:', sdk)} />
+);

--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/SelectSdk.test.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/SelectSdk.test.tsx
@@ -1,0 +1,21 @@
+import { expect, test, vi } from 'vitest';
+import { render } from 'utils/testRenderer';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SelectSdk } from './SelectSdk';
+
+test('renders SDK buttons and calls onSelect on click', async () => {
+    const onSelect = vi.fn();
+    render(<SelectSdk onSelect={onSelect} />);
+
+    expect(
+        screen.getByRole('button', { name: /node\.js/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /react/i })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /node\.js/i }));
+    expect(onSelect).toHaveBeenCalledWith({ name: 'Node.js', type: 'client' });
+
+    await userEvent.click(screen.getByRole('button', { name: /react/i }));
+    expect(onSelect).toHaveBeenCalledWith({ name: 'React', type: 'frontend' });
+});

--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/SelectSdk.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/SelectSdk.tsx
@@ -1,0 +1,119 @@
+import { Avatar, Box, Button, styled } from '@mui/material';
+import type { FC } from 'react';
+import { formatAssetPath } from 'utils/formatPath';
+import { clientSdks, type Sdk, serverSdks } from '../sharedTypes.ts';
+
+const SpacedContainer = styled('div')(({ theme }) => ({
+    padding: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(3),
+    backgroundColor: theme.palette.background.paper,
+}));
+
+export const SectionHeader = styled('div')(({ theme }) => ({
+    fontWeight: theme.typography.fontWeightBold,
+    fontSize: theme.typography.body1.fontSize,
+}));
+
+const SecondarySectionHeader = styled('div')(({ theme }) => ({
+    marginTop: theme.spacing(0.5),
+    marginBottom: theme.spacing(2),
+    fontSize: theme.typography.body1.fontSize,
+}));
+
+const SdkListSection = styled('div')(({ theme }) => ({
+    padding: 0,
+    display: 'flex',
+    columnGap: theme.spacing(1.5),
+    rowGap: theme.spacing(1.5),
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    flexWrap: 'wrap',
+}));
+
+const SdkButton = styled(Button)(({ theme }) => ({
+    fontSize: theme.typography.body2.fontSize,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(1, 1.5),
+    minWidth: '240px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+}));
+
+const SdkTileContent = styled('div')(({ theme }) => ({
+    color: theme.palette.text.primary,
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+}));
+
+const SelectLabel = styled('span')(({ theme }) => ({
+    color: theme.palette.primary.main,
+    fontSize: theme.typography.body2.fontSize,
+    fontWeight: 700,
+}));
+
+const StyledAvatar = styled(Avatar)(({ theme }) => ({
+    width: theme.spacing(3),
+    height: theme.spacing(3),
+}));
+
+interface ISelectSdkProps {
+    onSelect: (sdk: Sdk) => void;
+}
+export const SelectSdk: FC<ISelectSdkProps> = ({ onSelect }) => {
+    return (
+        <SpacedContainer>
+            <Box>
+                <SectionHeader>Server side SDKs</SectionHeader>
+                <SecondarySectionHeader>
+                    Server side SDK's need a backend API key.
+                </SecondarySectionHeader>
+                <SdkListSection>
+                    {serverSdks.map((sdk) => (
+                        <SdkButton
+                            key={sdk.name}
+                            onClick={() =>
+                                onSelect({ name: sdk.name, type: 'client' })
+                            }
+                            variant='outlined'
+                        >
+                            <StyledAvatar src={formatAssetPath(sdk.icon)} />
+                            <SdkTileContent>
+                                <b>{sdk.name}</b>
+                                <SelectLabel>Select</SelectLabel>
+                            </SdkTileContent>
+                        </SdkButton>
+                    ))}
+                </SdkListSection>
+            </Box>
+            <Box>
+                <SectionHeader>Frontend SDKs</SectionHeader>
+                <SecondarySectionHeader>
+                    Frontend SDK's need a frontend API key.
+                </SecondarySectionHeader>
+                <SdkListSection>
+                    {clientSdks.map((sdk) => (
+                        <SdkButton
+                            key={sdk.name}
+                            onClick={() =>
+                                onSelect({ name: sdk.name, type: 'frontend' })
+                            }
+                            variant='outlined'
+                        >
+                            <StyledAvatar src={formatAssetPath(sdk.icon)} />
+                            <SdkTileContent>
+                                <b>{sdk.name}</b>
+                                <SelectLabel>Select</SelectLabel>
+                            </SdkTileContent>
+                        </SdkButton>
+                    ))}
+                </SdkListSection>
+            </Box>
+        </SpacedContainer>
+    );
+};

--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/SelectSdk.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/SelectSdk.tsx
@@ -4,7 +4,6 @@ import { formatAssetPath } from 'utils/formatPath';
 import { clientSdks, type Sdk, serverSdks } from '../sharedTypes.ts';
 
 const SpacedContainer = styled('div')(({ theme }) => ({
-    padding: 0,
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(3),
@@ -23,7 +22,6 @@ const SecondarySectionHeader = styled('div')(({ theme }) => ({
 }));
 
 const SdkListSection = styled('div')(({ theme }) => ({
-    padding: 0,
     display: 'flex',
     columnGap: theme.spacing(1.5),
     rowGap: theme.spacing(1.5),
@@ -71,7 +69,7 @@ export const SelectSdk: FC<ISelectSdkProps> = ({ onSelect }) => {
             <Box>
                 <SectionHeader>Server side SDKs</SectionHeader>
                 <SecondarySectionHeader>
-                    Server side SDK's need a backend API key.
+                    Server side SDKs need a backend API key.
                 </SecondarySectionHeader>
                 <SdkListSection>
                     {serverSdks.map((sdk) => (
@@ -80,9 +78,12 @@ export const SelectSdk: FC<ISelectSdkProps> = ({ onSelect }) => {
                             onClick={() =>
                                 onSelect({ name: sdk.name, type: 'client' })
                             }
-                            variant='outlined'
+                            variant='text'
                         >
-                            <StyledAvatar src={formatAssetPath(sdk.icon)} />
+                            <StyledAvatar
+                                src={formatAssetPath(sdk.icon)}
+                                alt=''
+                            />
                             <SdkTileContent>
                                 <b>{sdk.name}</b>
                                 <SelectLabel>Select</SelectLabel>
@@ -94,7 +95,7 @@ export const SelectSdk: FC<ISelectSdkProps> = ({ onSelect }) => {
             <Box>
                 <SectionHeader>Frontend SDKs</SectionHeader>
                 <SecondarySectionHeader>
-                    Frontend SDK's need a frontend API key.
+                    Frontend SDKs need a frontend API key.
                 </SecondarySectionHeader>
                 <SdkListSection>
                     {clientSdks.map((sdk) => (
@@ -103,9 +104,12 @@ export const SelectSdk: FC<ISelectSdkProps> = ({ onSelect }) => {
                             onClick={() =>
                                 onSelect({ name: sdk.name, type: 'frontend' })
                             }
-                            variant='outlined'
+                            variant='text'
                         >
-                            <StyledAvatar src={formatAssetPath(sdk.icon)} />
+                            <StyledAvatar
+                                src={formatAssetPath(sdk.icon)}
+                                alt=''
+                            />
                             <SdkTileContent>
                                 <b>{sdk.name}</b>
                                 <SelectLabel>Select</SelectLabel>


### PR DESCRIPTION
Based on the old step (so reusing data)

- I assume padding will be shared for all steps, but It's going to be easy to change later. 

<img width="1106" height="692" alt="Screenshot 2026-05-08 at 16 56 05" src="https://github.com/user-attachments/assets/9c3746dd-bbd2-4be4-af40-04cbf8bc0651" />

