### PR TITLE
chore: update deprecated MUI PaperProps and renderTags

### DIFF
--- a/frontend/src/component/admin/groups/GroupForm/GroupFormUsersSelect/GroupFormUsersSelect.tsx
+++ b/frontend/src/component/admin/groups/GroupForm/GroupFormUsersSelect/GroupFormUsersSelect.tsx
@@ -58,7 +58,7 @@ const renderOption = (
     </StrechedLi>
 );
 
-const renderTags = (value: IGroupUser[]) => (
+const renderValue = (value: IGroupUser[]) => (
     <StyledTags>
         {value.length > 1
             ? `${value.length} users selected`
@@ -146,7 +146,7 @@ export const GroupFormUsersSelect: VFC<IGroupFormUsersSelectProps> = ({
                 renderInput={(params) => (
                     <TextField {...params} label='Select users' />
                 )}
-                renderTags={(value) => renderTags(value)}
+                renderValue={(value) => renderValue(value)}
                 noOptionsText={isLoading ? 'Loading…' : 'No options'}
             />
         </StyledGroupFormUsersSelect>

--- a/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestRequestedApprovers/ChangeRequestRequestedApprovers.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestOverview/ChangeRequestRequestedApprovers/ChangeRequestRequestedApprovers.tsx
@@ -92,7 +92,7 @@ const renderOption = (
     </StrechedLi>
 );
 
-const renderTags = (value: AvailableReviewerSchema[]) => (
+const renderValue = (value: AvailableReviewerSchema[]) => (
     <StyledTags>
         {value.length > 1
             ? `${value.length} reviewers`
@@ -225,7 +225,7 @@ export const ChangeRequestAddRequestedApprovers: FC<{
                         label={`Reviewers (${reviewers.length})`}
                     />
                 )}
-                renderTags={(value) => renderTags(value)}
+                renderValue={(value) => renderValue(value)}
                 noOptionsText={isLoading ? 'Loading…' : 'No options'}
             />
             <Button

--- a/frontend/src/component/changeRequest/ChangeRequestSidebar/DraftChangeRequestActions/DraftChangeRequestActions.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestSidebar/DraftChangeRequestActions/DraftChangeRequestActions.tsx
@@ -71,7 +71,7 @@ const renderOption = (
     </StrechedLi>
 );
 
-const renderTags = (value: AvailableReviewerSchema[]) => (
+const renderValue = (value: AvailableReviewerSchema[]) => (
     <StyledTags>
         {value.length > 1
             ? `${value.length} reviewers`
@@ -164,7 +164,7 @@ export const DraftChangeRequestActions: FC<{
                         label={`Reviewers (${reviewers.length})`}
                     />
                 )}
-                renderTags={(value) => renderTags(value)}
+                renderValue={(value) => renderValue(value)}
                 noOptionsText={isLoading ? 'Loading…' : 'No options'}
             />
             <SubmitChangeRequestButton

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenu.tsx
@@ -129,11 +129,13 @@ export const FeatureStrategyMenu = ({
                 open={isStrategyMenuDialogOpen}
                 onClose={onClose}
                 maxWidth='md'
-                PaperProps={{
-                    sx: {
-                        borderRadius: '12px',
-                        height: '100%',
-                        width: '100%',
+                slotProps={{
+                    paper: {
+                        sx: {
+                            borderRadius: '12px',
+                            height: '100%',
+                            width: '100%',
+                        },
                     },
                 }}
             >

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsModal/VariantForm/VariantForm.tsx
@@ -411,12 +411,14 @@ export const VariantForm = ({
                                 disabled={!customPercentage}
                                 aria-valuemin={0}
                                 aria-valuemax={100}
-                                InputProps={{
-                                    endAdornment: (
-                                        <InputAdornment position='end'>
-                                            %
-                                        </InputAdornment>
-                                    ),
+                                slotProps={{
+                                    input: {
+                                        endAdornment: (
+                                            <InputAdornment position='end'>
+                                                %
+                                            </InputAdornment>
+                                        ),
+                                    },
                                 }}
                             />
                         </StyledPercentageContainer>

--- a/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/StickinessSelect/StickinessSelect.tsx
+++ b/frontend/src/component/feature/StrategyTypes/FlexibleStrategy/StickinessSelect/StickinessSelect.tsx
@@ -97,9 +97,11 @@ export const StickinessSelect = ({
                         vertical: 'top',
                         horizontal: 'left',
                     },
-                    PaperProps: {
-                        style: {
-                            width: '18%',
+                    slotProps: {
+                        paper: {
+                            style: {
+                                width: '18%',
+                            },
                         },
                     },
                 }}

--- a/frontend/src/component/filter/FilterItem/FilterItem.tsx
+++ b/frontend/src/component/filter/FilterItem/FilterItem.tsx
@@ -194,12 +194,14 @@ export const FilterItem: FC<IFilterItemProps> = ({
                         onChange={(event) => setSearchText(event.target.value)}
                         placeholder='Search'
                         autoFocus
-                        InputProps={{
-                            startAdornment: (
-                                <InputAdornment position='start'>
-                                    <Search fontSize='small' />
-                                </InputAdornment>
-                            ),
+                        slotProps={{
+                            input: {
+                                startAdornment: (
+                                    <InputAdornment position='start'>
+                                        <Search fontSize='small' />
+                                    </InputAdornment>
+                                ),
+                            },
                         }}
                         inputRef={(el) => {
                             listRefs.current[0] = el;

--- a/frontend/src/component/playground/Playground/AdvancedPlaygroundResultsTable/AdvancedPlaygroundEnvironmentCell/AdvancedPlaygroundEnvironmentCell.tsx
+++ b/frontend/src/component/playground/Playground/AdvancedPlaygroundResultsTable/AdvancedPlaygroundEnvironmentCell/AdvancedPlaygroundEnvironmentCell.tsx
@@ -85,17 +85,19 @@ export const AdvancedPlaygroundEnvironmentCell = ({
                 <Popover
                     open={open}
                     id={`${value}-result-details`}
-                    PaperProps={{
-                        sx: {
-                            borderRadius: `${theme.shape.borderRadiusLarge}px`,
-                            padding: theme.spacing(3),
-                        },
-                    }}
                     onClose={onClose}
                     anchorEl={anchor}
                     anchorOrigin={{
                         vertical: 'bottom',
                         horizontal: -320,
+                    }}
+                    slotProps={{
+                        paper: {
+                            sx: {
+                                borderRadius: `${theme.shape.borderRadiusLarge}px`,
+                                padding: theme.spacing(3),
+                            },
+                        },
                     }}
                 >
                     <Typography variant='subtitle2' sx={{ mb: 3 }}>

--- a/frontend/src/component/playground/Playground/AdvancedPlaygroundResultsTable/AdvancedPlaygroundEnvironmentCell/AdvancedPlaygroundEnvironmentDiffCell.tsx
+++ b/frontend/src/component/playground/Playground/AdvancedPlaygroundResultsTable/AdvancedPlaygroundEnvironmentCell/AdvancedPlaygroundEnvironmentDiffCell.tsx
@@ -52,17 +52,19 @@ export const AdvancedPlaygroundEnvironmentDiffCell = ({
                 <Popover
                     open={open}
                     id={`${value}-result-details`}
-                    PaperProps={{
-                        sx: {
-                            borderRadius: `${theme.shape.borderRadiusLarge}px`,
-                            padding: theme.spacing(3),
-                        },
-                    }}
                     onClose={onClose}
                     anchorEl={anchor}
                     anchorOrigin={{
                         vertical: 'bottom',
                         horizontal: -320,
+                    }}
+                    slotProps={{
+                        paper: {
+                            sx: {
+                                borderRadius: `${theme.shape.borderRadiusLarge}px`,
+                                padding: theme.spacing(3),
+                            },
+                        },
                     }}
                 >
                     <Typography variant='subtitle2' sx={{ mb: 3 }}>

--- a/frontend/src/component/playground/Playground/PlaygroundResultsTable/FeatureResultInfoPopoverCell/FeatureResultInfoPopoverCell.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundResultsTable/FeatureResultInfoPopoverCell/FeatureResultInfoPopoverCell.tsx
@@ -35,22 +35,6 @@ export const NewFeatureResultInfoPopoverCell = ({
                 open={open}
                 onClose={() => setOpen(false)}
                 anchorEl={ref.current}
-                PaperProps={{
-                    sx: (theme) => ({
-                        '--popover-inline-padding': theme.spacing(4),
-                        paddingInline: 'var(--popover-inline-padding)',
-                        paddingBlock: theme.spacing(3),
-                        display: 'flex',
-                        flexDirection: 'column',
-                        width: 728,
-                        maxWidth: '100%',
-                        height: 'auto',
-                        gap: theme.spacing(3),
-                        overflowY: 'auto',
-                        backgroundColor: theme.palette.background.elevation1,
-                        borderRadius: theme.shape.borderRadius,
-                    }),
-                }}
                 anchorOrigin={{
                     vertical: 'top',
                     horizontal: 'right',
@@ -58,6 +42,25 @@ export const NewFeatureResultInfoPopoverCell = ({
                 transformOrigin={{
                     vertical: 'center',
                     horizontal: 'left',
+                }}
+                slotProps={{
+                    paper: {
+                        sx: (theme) => ({
+                            '--popover-inline-padding': theme.spacing(4),
+                            paddingInline: 'var(--popover-inline-padding)',
+                            paddingBlock: theme.spacing(3),
+                            display: 'flex',
+                            flexDirection: 'column',
+                            width: 728,
+                            maxWidth: '100%',
+                            height: 'auto',
+                            gap: theme.spacing(3),
+                            overflowY: 'auto',
+                            backgroundColor:
+                                theme.palette.background.elevation1,
+                            borderRadius: theme.shape.borderRadius,
+                        }),
+                    },
                 }}
             >
                 <FeatureDetails

--- a/frontend/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantCell.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantCell.tsx
@@ -52,16 +52,18 @@ export const VariantCell: VFC<IVariantCellProps> = ({
                         <Popover
                             open={open}
                             id={`${feature}-result-variants`}
-                            PaperProps={{
-                                sx: {
-                                    borderRadius: `${theme.shape.borderRadiusLarge}px`,
-                                },
-                            }}
                             onClose={onClose}
                             anchorEl={anchor}
                             anchorOrigin={{
                                 vertical: 'bottom',
                                 horizontal: -320,
+                            }}
+                            slotProps={{
+                                paper: {
+                                    sx: {
+                                        borderRadius: `${theme.shape.borderRadiusLarge}px`,
+                                    },
+                                },
                             }}
                         >
                             <VariantInformation

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ColumnsMenu/ColumnsMenu.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ColumnsMenu/ColumnsMenu.tsx
@@ -75,11 +75,13 @@ export const ColumnsMenu: FC<IColumnsMenuProps> = ({ columns, onToggle }) => {
                     horizontal: 'right',
                 }}
                 disableScrollLock={true}
-                PaperProps={{
-                    sx: (theme) => ({
-                        borderRadius: theme.shape.borderRadius,
-                        paddingBottom: theme.spacing(2),
-                    }),
+                slotProps={{
+                    paper: {
+                        sx: (theme) => ({
+                            borderRadius: theme.shape.borderRadius,
+                            paddingBottom: theme.spacing(2),
+                        }),
+                    },
                 }}
             >
                 <StyledBoxMenuHeader>

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
@@ -109,11 +109,13 @@ export const ActionsCell: VFC<IActionsCellProps> = ({
                 transformOrigin={{ horizontal: 'right', vertical: 'top' }}
                 anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
                 disableScrollLock={true}
-                PaperProps={{
-                    sx: (theme) => ({
-                        borderRadius: `${theme.shape.borderRadius}px`,
-                        padding: theme.spacing(1, 1.5),
-                    }),
+                slotProps={{
+                    paper: {
+                        sx: (theme) => ({
+                            borderRadius: `${theme.shape.borderRadius}px`,
+                            padding: theme.spacing(1, 1.5),
+                        }),
+                    },
                 }}
             >
                 <MenuList aria-labelledby={id}>

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/MoreActions.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ProjectFeaturesBatchActions/MoreActions.tsx
@@ -113,11 +113,13 @@ export const MoreActions: VFC<IMoreActionsProps> = ({
                 transformOrigin={{ horizontal: 'right', vertical: 'top' }}
                 anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
                 disableScrollLock={true}
-                PaperProps={{
-                    sx: (theme) => ({
-                        borderRadius: `${theme.shape.borderRadius}px`,
-                        padding: theme.spacing(1, 1.5),
-                    }),
+                slotProps={{
+                    paper: {
+                        sx: (theme) => ({
+                            borderRadius: `${theme.shape.borderRadius}px`,
+                            padding: theme.spacing(1, 1.5),
+                        }),
+                    },
                 }}
             >
                 <MenuList aria-labelledby={`${menuId}-menu`}>

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsTableActionsCell.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsTableActionsCell.tsx
@@ -76,11 +76,13 @@ export const ProjectActionsTableActionsCell = ({
                 transformOrigin={{ horizontal: 'right', vertical: 'top' }}
                 anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
                 disableScrollLock={true}
-                PaperProps={{
-                    sx: (theme) => ({
-                        borderRadius: `${theme.shape.borderRadius}px`,
-                        padding: theme.spacing(1, 1.5),
-                    }),
+                slotProps={{
+                    paper: {
+                        sx: (theme) => ({
+                            borderRadius: `${theme.shape.borderRadius}px`,
+                            padding: theme.spacing(1, 1.5),
+                        }),
+                    },
                 }}
             >
                 <MenuList aria-labelledby={id}>

--- a/frontend/src/component/project/ProjectAccess/ProjectAccessAssign/ProjectAccessAssign.tsx
+++ b/frontend/src/component/project/ProjectAccess/ProjectAccessAssign/ProjectAccessAssign.tsx
@@ -389,11 +389,11 @@ export const ProjectAccessAssign = ({
                                     renderOption(props, option, selected)
                                 }
                                 getOptionLabel={getOptionLabel}
-                                renderTags={(tagValue, getTagProps) =>
-                                    tagValue.map((option, index) => {
+                                renderValue={(value, getItemProps) =>
+                                    value.map((option, index) => {
                                         return (
                                             <Chip
-                                                {...getTagProps({ index })}
+                                                {...getItemProps({ index })}
                                                 size={autocompleteSize}
                                                 key={`${option.type}:${option.id}`}
                                                 label={getOptionLabel(option)}

--- a/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
+++ b/frontend/src/component/releases/ReleasePlanTemplate/TemplateForm/MilestoneList/MilestoneCard/MilestoneCard.tsx
@@ -362,10 +362,12 @@ export const MilestoneCard = ({
                                 anchorEl={anchor}
                                 onClose={onClose}
                                 onClick={onClose}
-                                PaperProps={{
-                                    sx: (theme) => ({
-                                        paddingBottom: theme.spacing(1),
-                                    }),
+                                slotProps={{
+                                    paper: {
+                                        sx: (theme) => ({
+                                            paddingBottom: theme.spacing(1),
+                                        }),
+                                    },
                                 }}
                             >
                                 <MilestoneStrategyMenuCards
@@ -499,10 +501,12 @@ export const MilestoneCard = ({
                                 anchorEl={anchor}
                                 onClose={onClose}
                                 onClick={onClose}
-                                PaperProps={{
-                                    sx: (theme) => ({
-                                        paddingBottom: theme.spacing(1),
-                                    }),
+                                slotProps={{
+                                    paper: {
+                                        sx: (theme) => ({
+                                            paddingBottom: theme.spacing(1),
+                                        }),
+                                    },
                                 }}
                             >
                                 <MilestoneStrategyMenuCards
@@ -518,11 +522,9 @@ export const MilestoneCard = ({
                     </StyledAccordionDetails>
                 </StyledAccordion>
             </DraggableCardContainer>
-
             <FormHelperText error={Boolean(errors?.[milestone.id])}>
                 {errors?.[milestone.id]}
             </FormHelperText>
-
             <SidebarModal
                 label='Add strategy to template milestone'
                 onClose={() => {

--- a/frontend/src/component/signals/SignalEndpointsTable/SignalEndpointsActionsCell.tsx
+++ b/frontend/src/component/signals/SignalEndpointsTable/SignalEndpointsActionsCell.tsx
@@ -79,11 +79,13 @@ export const SignalEndpointsActionsCell = ({
                 transformOrigin={{ horizontal: 'right', vertical: 'top' }}
                 anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
                 disableScrollLock={true}
-                PaperProps={{
-                    sx: (theme) => ({
-                        borderRadius: `${theme.shape.borderRadius}px`,
-                        padding: theme.spacing(1, 1.5),
-                    }),
+                slotProps={{
+                    paper: {
+                        sx: (theme) => ({
+                            borderRadius: `${theme.shape.borderRadius}px`,
+                            padding: theme.spacing(1, 1.5),
+                        }),
+                    },
                 }}
             >
                 <MenuList aria-labelledby={id}>


### PR DESCRIPTION
Part of the work needed to bump MUI to v9. 

- Migrates from `renderTags` to `renderValue` (some of these were missed by the codemods since they're in Styled- components)
- Migrates remaining `InputProps` (missed by codemods for the same reason)
- Migrates from `PaperProps` to `slotProps`

### Manual test plan 
- [x] **Group form — User picker**
  Navigate: Admin → Users & Access → **Groups** → New group (or edit existing)
  - Field: "Select users"
  - Verify: typing filters users, picking adds to selection, summary shows "1 user selected" → "N users selected"

- [x] **Change request reviewers — when reviewing**
  Navigate: any project with change requests enabled → **Change Requests** → open a draft change request
  - Look for the reviewer requestor input (in the right sidebar / approvers section)
  - Verify: select 1+ reviewers, summary shows "1 reviewer" / "N reviewers"

- [x] **Change request reviewers — when submitting**
  In the same change request → click **Submit for review**
  - The reviewer-selection autocomplete renders before submission
  - Same multi-select behavior

- [x] **Project access assign**
  Navigate: any project → **Access (or Users)** → Add user/group/service account
  - Use the role assignment dialog
  - Field is a multi-select Autocomplete with chips that have **delete** buttons (the `getItemProps` migration powers these)
  - Verify: chips render, X button on each chip removes it, can search + add more

### Dialog `PaperProps` → `slotProps.paper`

- [x] **Add strategy dialog**
  Navigate: any feature flag → an environment → **Add strategy**
  - Modal opens
  - Verify visually: rounded corners (12px), full height/width as before
  - The dialog should look identical to `main`'s version

### Select MenuProps → nested slotProps.paper

- [x] **Stickiness dropdown**
  Navigate: any feature → **Add strategy** → **Gradual Rollout** (or any flexible rollout strategy)
  - In the strategy form, find the **Stickiness** dropdown
  - Open it
  - Verify: dropdown opens *below* the trigger (anchored bottom-left), menu paper is ~18% wide
  - Pick an option, confirm it applies