### PR TITLE
chore: redirect to the feature page

### DIFF
--- a/frontend/src/component/onboarding/flow/OldProjectOnboarding.tsx
+++ b/frontend/src/component/onboarding/flow/OldProjectOnboarding.tsx
@@ -199,7 +199,6 @@ const CreateFlag = ({ projectId, refetchFeatures }: ICreateFlagProps) => {
             </Typography>
             <FlagCreationButton
                 text='Create flag'
-                skipNavigationOnComplete={true}
                 onSuccess={() => {
                     refetch();
                     refetchFeatures();

--- a/frontend/src/component/onboarding/flow/steps/CreateFlagStep.tsx
+++ b/frontend/src/component/onboarding/flow/steps/CreateFlagStep.tsx
@@ -37,7 +37,6 @@ export const CreateFlagStep = ({
             ) : (
                 <FlagCreationButton
                     text='New feature flag'
-                    skipNavigationOnComplete
                     onSuccess={() => {
                         refetchProject();
                         refetchFeatures();

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -37,7 +37,6 @@ import { useLocalStorageState } from 'hooks/useLocalStorageState.ts';
 interface ICreateFeatureDialogProps {
     open: boolean;
     onClose: () => void;
-    skipNavigationOnComplete?: boolean;
     onSuccess?: () => void;
 }
 
@@ -78,7 +77,6 @@ export const CreateFeatureDialog = ({
     open,
     onClose,
     onSuccess,
-    skipNavigationOnComplete,
 }: ICreateFeatureDialogProps) => {
     if (open) {
         // wrap the inner component so that we only fetch data etc
@@ -87,7 +85,6 @@ export const CreateFeatureDialog = ({
             <CreateFeatureDialogContent
                 open={open}
                 onClose={onClose}
-                skipNavigationOnComplete={skipNavigationOnComplete}
                 onSuccess={onSuccess}
             />
         );
@@ -97,7 +94,6 @@ export const CreateFeatureDialog = ({
 const CreateFeatureDialogContent = ({
     open,
     onClose,
-    skipNavigationOnComplete,
     onSuccess,
 }: ICreateFeatureDialogProps) => {
     const { setToastData, setToastApiError } = useToast();
@@ -172,9 +168,7 @@ const CreateFeatureDialogContent = ({
             const payload = getTogglePayload();
             try {
                 await createFeatureToggle(project, payload);
-                if (!skipNavigationOnComplete) {
-                    navigate(`/projects/${project}/features/${name}`);
-                }
+                navigate(`/projects/${project}/features/${name}`);
                 setToastData({
                     text: 'Flag created successfully',
                     type: 'success',

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/FlagCreationButton/FlagCreationButton.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/FlagCreationButton/FlagCreationButton.tsx
@@ -12,7 +12,6 @@ import { NAVIGATE_TO_CREATE_FEATURE } from 'utils/testIds';
 interface IFlagCreationButtonProps {
     text?: string;
     variant?: ButtonProps['variant'];
-    skipNavigationOnComplete?: boolean;
     isLoading?: boolean;
     onSuccess?: () => void;
 }
@@ -24,7 +23,6 @@ const StyledResponsiveButton = styled(ResponsiveButton)(() => ({
 export const FlagCreationButton = ({
     variant,
     text = 'New feature flag',
-    skipNavigationOnComplete,
     isLoading,
     onSuccess,
 }: IFlagCreationButtonProps) => {
@@ -53,7 +51,6 @@ export const FlagCreationButton = ({
             <CreateFeatureDialog
                 open={openCreateDialog}
                 onClose={() => setOpenCreateDialog(false)}
-                skipNavigationOnComplete={skipNavigationOnComplete}
                 onSuccess={onSuccess}
             />
         </>


### PR DESCRIPTION
We always want to redirect to the feature flag details page - even during onboarding. 

But now with https://github.com/Unleash/unleash/pull/11991 enabled for everyone user can move the feature flag page and continue the onboarding there - with the added bonus of actually looking at the flag they created in context. 
This is true even for old onboarding so why not remove this code that disabled the redirect? 