### PR TITLE
fix: treat missing lifecycle as initial stage in implement flag banner

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
@@ -20,7 +20,9 @@ export const FeatureImplementFlagBanner = ({
     const [dialogOpen, setDialogOpen] = useState(false);
 
     const isOnboarded = project.onboardingStatus.status === 'onboarded';
-    const isInitialStage = !loading && feature.lifecycle?.stage === 'initial';
+    const isInitialStage =
+        !loading &&
+        (!feature.lifecycle || feature.lifecycle.stage === 'initial');
     const showBanner = isOnboarded && isInitialStage;
 
     if (!showBanner && !dialogOpen) {


### PR DESCRIPTION
A missing `lifecycle` is now treated the same as an explicit `'initial'` stage, so onboarded projects still see the implementation guidance for flags that haven't received any evaluations yet.