### PR TITLE
feat: gate LogRocket on trial instances

### DIFF
--- a/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
+++ b/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
@@ -4,25 +4,29 @@ import LogRocket from 'logrocket';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
+import { useInstanceStatus } from 'hooks/api/getters/useInstanceStatus/useInstanceStatus';
+import { isTrialInstance } from 'utils/instanceTrial';
 
 export const LogRocketProvider: FC<{ children?: React.ReactNode }> = ({
     children,
 }) => {
     const { uiConfig, isEnterprise } = useUiConfig();
     const { user } = useAuthUser();
+    const { instanceStatus } = useInstanceStatus();
     const isEnabled = useUiFlag('logRocketEnabled');
     const appId = uiConfig?.logRocketAppId;
     const clientId = uiConfig?.unleashContext?.properties?.clientId;
     const userId = user?.id;
     const isEnterprisePayg =
         isEnterprise() && uiConfig?.billing === 'pay-as-you-go';
+    const isTrial = isTrialInstance(instanceStatus);
 
     const initialized = useRef(false);
     const identified = useRef(false);
 
     useEffect(() => {
         if (initialized.current) return;
-        if (!isEnabled || !appId || !isEnterprisePayg) return;
+        if (!isEnabled || !appId || !isEnterprisePayg || !isTrial) return;
 
         try {
             LogRocket.init(appId, {
@@ -39,7 +43,7 @@ export const LogRocketProvider: FC<{ children?: React.ReactNode }> = ({
         } catch (error) {
             console.warn(error);
         }
-    }, [isEnabled, appId, isEnterprisePayg]);
+    }, [isEnabled, appId, isEnterprisePayg, isTrial]);
 
     useEffect(() => {
         if (identified.current) return;


### PR DESCRIPTION
Restricts LogRocket session recording to trial customers on enterprise PAYG plans. Previously, all enterprise PAYG instances were recorded, including active paying customers.
