### PR TITLE
chore: implement "select sdk" state

### DIFF
--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
@@ -11,6 +11,8 @@ import { Truncator } from 'component/common/Truncator/Truncator.tsx';
 import { NewConnectSdkDialogAside } from './NewConnectSdkDialogAside';
 import { useState } from 'react';
 import { ConnectSdkDialogStep } from './ConnectSdkDialogStep';
+import type { Sdk } from '../sharedTypes';
+import { SelectSdk, SelectSdkSummary } from './SelectSdk';
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
     '& .MuiDialog-paper': {
@@ -127,6 +129,7 @@ const DialogHeader = ({ onClose }: Pick<IConnectSDKDialogProps, 'onClose'>) => {
 
 type Step = {
     title: string;
+    content: React.ReactNode;
     summary?: React.ReactNode;
 };
 
@@ -134,21 +137,35 @@ const InnerDialog = ({
     onClose,
     onFinish,
 }: Omit<IConnectSDKDialogProps, 'open'>) => {
-    const [currentStep] = useState(0);
+    const [currentStep, setCurrentStep] = useState(0);
     const [expandedStep, setExpandedStep] = useState(0);
 
+    const [sdk, setSdk] = useState<Sdk>();
+
+    const onSelectSdk = (selectedSdk: Sdk) => {
+        setSdk(selectedSdk);
+        setCurrentStep(1);
+        setExpandedStep(1);
+    };
+
     const steps: Step[] = [
-        { title: 'Select SDK' },
-        { title: 'Generate API key' },
-        { title: 'Configure the SDK' },
+        {
+            title: 'Select SDK',
+            content: <SelectSdk onSelect={onSelectSdk} />,
+            summary: <SelectSdkSummary sdk={sdk} />,
+        },
+        { title: 'Generate API key', content: 'TODO: Generate API key' },
+        { title: 'Configure the SDK', content: 'TODO: Configure the SDK' },
     ];
+
+    const complete = currentStep >= steps.length && sdk;
 
     return (
         <StyledDialog open onClose={onClose}>
             <DialogHeader onClose={onClose} />
             <StyledDialogBody>
                 <StyledDialogContent>
-                    {steps.map(({ title, summary }, index) => (
+                    {steps.map(({ title, content, summary }, index) => (
                         <ConnectSdkDialogStep
                             key={title}
                             stepNumber={index + 1}
@@ -159,14 +176,16 @@ const InnerDialog = ({
                             onExpand={() => setExpandedStep(index)}
                             summary={summary}
                         >
-                            {title} content
+                            {content}
                         </ConnectSdkDialogStep>
                     ))}
                     <StyledDialogFooter>
                         <Button
                             variant='contained'
-                            disabled={currentStep < steps.length}
-                            onClick={() => onFinish('TODO: sdk from state')}
+                            disabled={!complete}
+                            onClick={
+                                complete ? () => onFinish(sdk.name) : undefined
+                            }
                         >
                             Finish setup
                         </Button>

--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/SelectSdk.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/SelectSdk.tsx
@@ -1,7 +1,7 @@
 import { Avatar, Box, Button, styled } from '@mui/material';
 import type { FC } from 'react';
 import { formatAssetPath } from 'utils/formatPath';
-import { clientSdks, type Sdk, serverSdks } from '../sharedTypes.ts';
+import { allSdks, clientSdks, type Sdk, serverSdks } from '../sharedTypes.ts';
 
 const SpacedContainer = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -58,6 +58,12 @@ const SelectLabel = styled('span')(({ theme }) => ({
 const StyledAvatar = styled(Avatar)(({ theme }) => ({
     width: theme.spacing(3),
     height: theme.spacing(3),
+}));
+
+const StyledSummary = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
 }));
 
 interface ISelectSdkProps {
@@ -119,5 +125,21 @@ export const SelectSdk: FC<ISelectSdkProps> = ({ onSelect }) => {
                 </SdkListSection>
             </Box>
         </SpacedContainer>
+    );
+};
+
+interface ISelectSdkSummaryProps {
+    sdk?: Sdk;
+}
+export const SelectSdkSummary = ({ sdk }: ISelectSdkSummaryProps) => {
+    if (!sdk) return null;
+
+    const sdkIcon = allSdks.find((item) => item.name === sdk.name)?.icon;
+
+    return (
+        <StyledSummary>
+            {sdkIcon && <StyledAvatar src={formatAssetPath(sdkIcon)} alt='' />}
+            {sdk.name}
+        </StyledSummary>
     );
 };


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-480/implement-select-sdk-state

### Select SDK

<img width="1405" height="853" alt="image" src="https://github.com/user-attachments/assets/d15fb627-19e2-4952-9605-d145a2733a67" />

### SDK selected

<img width="1419" height="430" alt="image" src="https://github.com/user-attachments/assets/2e3b620b-424c-4b13-93f3-68a76d72e8d3" />

### Edge case: SDK selected and accordion is expanded

Should we mark the selected SDK or is this fine as is?

<img width="1403" height="848" alt="image" src="https://github.com/user-attachments/assets/5cbc2592-a1d1-4813-ba0c-386d56348436" />
