### PR TITLE
fix: lazy-load LogRocket SDK to avoid eager script injection

### DIFF
--- a/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
+++ b/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
@@ -1,6 +1,5 @@
 import type React from 'react';
 import { type FC, useEffect, useRef } from 'react';
-import LogRocket from 'logrocket';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
@@ -17,45 +16,36 @@ export const LogRocketProvider: FC<{ children?: React.ReactNode }> = ({
     const isEnterprisePayg =
         isEnterprise() && uiConfig?.billing === 'pay-as-you-go';
 
-    const initialized = useRef(false);
-    const identified = useRef(false);
+    const started = useRef(false);
 
     useEffect(() => {
-        if (initialized.current) return;
+        if (started.current) return;
         if (!isEnabled || !appId || !isEnterprisePayg) return;
-
-        try {
-            LogRocket.init(appId, {
-                dom: {
-                    textSanitizer: true,
-                    inputSanitizer: 'lipsum',
-                },
-                shouldCaptureIP: false,
-                network: {
-                    requestSanitizer: () => null,
-                },
-            });
-            initialized.current = true;
-        } catch (error) {
-            console.warn(error);
-        }
-    }, [isEnabled, appId, isEnterprisePayg]);
-
-    useEffect(() => {
-        if (identified.current) return;
-        if (!initialized.current) return;
         if (!userId || !clientId) return;
 
-        try {
-            LogRocket.identify(`${clientId}:${userId}`, {
-                clientId,
-                userId: String(userId),
+        started.current = true;
+        import('logrocket')
+            .then(({ default: LogRocket }) => {
+                LogRocket.init(appId, {
+                    dom: {
+                        textSanitizer: true,
+                        inputSanitizer: 'lipsum',
+                    },
+                    shouldCaptureIP: false,
+                    network: {
+                        requestSanitizer: () => null,
+                    },
+                });
+                LogRocket.identify(`${clientId}:${userId}`, {
+                    clientId,
+                    userId: String(userId),
+                });
+            })
+            .catch((error) => {
+                started.current = false;
+                console.warn(error);
             });
-            identified.current = true;
-        } catch (error) {
-            console.warn(error);
-        }
-    }, [userId, clientId]);
+    }, [isEnabled, appId, isEnterprisePayg, userId, clientId]);
 
     return <>{children}</>;
 };

--- a/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
+++ b/frontend/src/component/providers/LogRocketProvider/LogRocketProvider.tsx
@@ -1,10 +1,12 @@
 import type React from 'react';
-import { type FC, useEffect, useRef } from 'react';
+import { type FC, lazy, Suspense } from 'react';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
 import { useInstanceStatus } from 'hooks/api/getters/useInstanceStatus/useInstanceStatus';
 import { isTrialInstance } from 'utils/instanceTrial';
+
+const LogRocketRunner = lazy(() => import('./LogRocketRunner.tsx'));
 
 export const LogRocketProvider: FC<{ children?: React.ReactNode }> = ({
     children,
@@ -20,36 +22,21 @@ export const LogRocketProvider: FC<{ children?: React.ReactNode }> = ({
         isEnterprise() && uiConfig?.billing === 'pay-as-you-go';
     const isTrial = isTrialInstance(instanceStatus);
 
-    const started = useRef(false);
+    const shouldLoad =
+        isEnabled && isEnterprisePayg && isTrial && appId && clientId && userId;
 
-    useEffect(() => {
-        if (started.current) return;
-        if (!isEnabled || !appId || !isEnterprisePayg || !isTrial) return;
-        if (!userId || !clientId) return;
-
-        started.current = true;
-        import('logrocket')
-            .then(({ default: LogRocket }) => {
-                LogRocket.init(appId, {
-                    dom: {
-                        textSanitizer: true,
-                        inputSanitizer: 'lipsum',
-                    },
-                    shouldCaptureIP: false,
-                    network: {
-                        requestSanitizer: () => null,
-                    },
-                });
-                LogRocket.identify(`${clientId}:${userId}`, {
-                    clientId,
-                    userId: String(userId),
-                });
-            })
-            .catch((error) => {
-                started.current = false;
-                console.warn(error);
-            });
-    }, [isEnabled, appId, isEnterprisePayg, isTrial, userId, clientId]);
-
-    return <>{children}</>;
+    return (
+        <>
+            {shouldLoad ? (
+                <Suspense fallback={null}>
+                    <LogRocketRunner
+                        appId={appId}
+                        clientId={clientId}
+                        userId={userId}
+                    />
+                </Suspense>
+            ) : null}
+            {children}
+        </>
+    );
 };

--- a/frontend/src/component/providers/LogRocketProvider/LogRocketRunner.tsx
+++ b/frontend/src/component/providers/LogRocketProvider/LogRocketRunner.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import LogRocket from 'logrocket';
+
+type Props = {
+    appId: string;
+    clientId: string;
+    userId: number;
+};
+
+const LogRocketRunner = ({ appId, clientId, userId }: Props) => {
+    useEffect(() => {
+        try {
+            LogRocket.init(appId, {
+                dom: {
+                    textSanitizer: true,
+                    inputSanitizer: 'lipsum',
+                },
+                shouldCaptureIP: false,
+                network: {
+                    requestSanitizer: () => null,
+                },
+            });
+            LogRocket.identify(`${clientId}:${userId}`, {
+                clientId,
+                userId: String(userId),
+            });
+        } catch (error) {
+            console.warn(error);
+        }
+    }, []);
+
+    return null;
+};
+
+export default LogRocketRunner;

--- a/frontend/src/component/providers/LogRocketProvider/LogRocketRunner.tsx
+++ b/frontend/src/component/providers/LogRocketProvider/LogRocketRunner.tsx
@@ -27,7 +27,7 @@ const LogRocketRunner = ({ appId, clientId, userId }: Props) => {
         } catch (error) {
             console.warn(error);
         }
-    }, []);
+    }, [appId, clientId, userId]);
 
     return null;
 };


### PR DESCRIPTION
Switch `import LogRocket from 'logrocket'` to a dynamic `import('logrocket')` inside the gated `useEffect`, so the SDK module is only evaluated when LogRocket should actually run. Vite splits it into a separate chunk that's never fetched otherwise.