### PR TITLE
feat: add save/cancel to remote MCP settings page

### DIFF
--- a/frontend/src/component/admin/remote-mcp/RemoteMcpToggle.test.tsx
+++ b/frontend/src/component/admin/remote-mcp/RemoteMcpToggle.test.tsx
@@ -29,7 +29,7 @@ const setupApi = ({
 };
 
 describe('RemoteMcpToggle', () => {
-    test('renders as disabled when settings return enabled: false', async () => {
+    test('renders initial toggle state from settings', async () => {
         setupApi({ enabled: false });
 
         render(<RemoteMcpToggle />);
@@ -38,39 +38,25 @@ describe('RemoteMcpToggle', () => {
         expect(screen.getByRole('switch')).not.toBeChecked();
     });
 
-    test('renders as enabled when settings return enabled: true', async () => {
-        setupApi({ enabled: true });
-
-        render(<RemoteMcpToggle />);
-
-        expect(await screen.findByText('Enabled')).toBeInTheDocument();
-        expect(screen.getByRole('switch')).toBeChecked();
-    });
-
-    test('sends POST with enabled: true when toggling on', async () => {
+    test('toggling updates the switch without calling the API, save/cancel become active', async () => {
         const { requests } = setupApi({ enabled: false });
 
         render(<RemoteMcpToggle />);
 
         await screen.findByText('Disabled');
+        expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+
         await userEvent.click(screen.getByRole('switch'));
 
-        expect(requests).toEqual([{ enabled: true }]);
+        expect(screen.getByRole('switch')).toBeChecked();
+        expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+        expect(requests).toEqual([]);
     });
 
-    test('sends POST with enabled: false when toggling off', async () => {
-        const { requests } = setupApi({ enabled: true });
-
-        render(<RemoteMcpToggle />);
-
-        await screen.findByText('Enabled');
-        await userEvent.click(screen.getByRole('switch'));
-
-        expect(requests).toEqual([{ enabled: false }]);
-    });
-
-    test('shows success toast after toggling on', async () => {
-        setupApi({ enabled: false });
+    test('save sends correct POST and shows success toast', async () => {
+        const { requests } = setupApi({ enabled: false });
 
         render(
             <>
@@ -81,7 +67,9 @@ describe('RemoteMcpToggle', () => {
 
         await screen.findByText('Disabled');
         await userEvent.click(screen.getByRole('switch'));
+        await userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
+        expect(requests).toEqual([{ enabled: true }]);
         expect(
             await screen.findByText(
                 'Remote MCP server has been successfully enabled',
@@ -89,27 +77,20 @@ describe('RemoteMcpToggle', () => {
         ).toBeInTheDocument();
     });
 
-    test('shows success toast after toggling off', async () => {
-        setupApi({ enabled: true });
+    test('cancel resets the toggle to the server value', async () => {
+        setupApi({ enabled: false });
 
-        render(
-            <>
-                <ToastRenderer />
-                <RemoteMcpToggle />
-            </>,
-        );
+        render(<RemoteMcpToggle />);
 
-        await screen.findByText('Enabled');
+        await screen.findByText('Disabled');
         await userEvent.click(screen.getByRole('switch'));
+        expect(screen.getByRole('switch')).toBeChecked();
 
-        expect(
-            await screen.findByText(
-                'Remote MCP server has been successfully disabled',
-            ),
-        ).toBeInTheDocument();
+        await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(screen.getByRole('switch')).not.toBeChecked();
     });
 
-    test('shows error toast when the API call fails', async () => {
+    test('shows error toast when save fails', async () => {
         setupApi({ enabled: false, postStatus: 500 });
 
         render(
@@ -121,6 +102,7 @@ describe('RemoteMcpToggle', () => {
 
         await screen.findByText('Disabled');
         await userEvent.click(screen.getByRole('switch'));
+        await userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
         expect(
             await screen.findByText('Action could not be performed'),

--- a/frontend/src/component/admin/remote-mcp/RemoteMcpToggle.tsx
+++ b/frontend/src/component/admin/remote-mcp/RemoteMcpToggle.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from 'react';
 import {
     Box,
+    Button,
     FormControlLabel,
     styled,
     Switch,
@@ -44,6 +46,14 @@ const StyledDescription = styled(Typography)(({ theme }) => ({
     fontSize: theme.typography.body2.fontSize,
 }));
 
+const Footer = styled('div')(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: theme.spacing(2),
+    paddingTop: theme.spacing(2),
+    borderTop: `1px solid ${theme.palette.divider}`,
+}));
+
 export const RemoteMcpToggle = () => {
     const { settings, loading, refetch } = useRemoteMcpSettings();
     const { setRemoteMcpSettings, loading: saving } = useRemoteMcpSettingsApi();
@@ -53,16 +63,27 @@ export const RemoteMcpToggle = () => {
     const { setToastData, setToastApiError } = useToast();
     const { trackEvent } = usePlausibleTracker();
 
-    const handleToggle = async () => {
-        const next = !settings.enabled;
+    const [enabled, setEnabled] = useState(settings.enabled);
+
+    useEffect(() => {
+        setEnabled(settings.enabled);
+    }, [settings.enabled]);
+
+    const isDirty = enabled !== settings.enabled;
+
+    const handleCancel = () => {
+        setEnabled(settings.enabled);
+    };
+
+    const handleSave = async () => {
         try {
-            await setRemoteMcpSettings(next);
+            await setRemoteMcpSettings(enabled);
             trackEvent('remote-mcp', {
-                props: { eventType: next ? 'enabled' : 'disabled' },
+                props: { eventType: enabled ? 'enabled' : 'disabled' },
             });
             setToastData({
                 type: 'success',
-                text: `Remote MCP server has been successfully ${next ? 'enabled' : 'disabled'}`,
+                text: `Remote MCP server has been successfully ${enabled ? 'enabled' : 'disabled'}`,
             });
         } catch (error) {
             setToastApiError(formatUnknownError(error));
@@ -72,35 +93,49 @@ export const RemoteMcpToggle = () => {
     };
 
     return (
-        <StyledCard>
-            <StyledCardLeft>
-                <StyledTitle variant='body1'>
-                    Enable Remote MCP Server for this instance
-                </StyledTitle>
-                <StyledDescription>
-                    When enabled, Unleash exposes a Streamable HTTP MCP server
-                    at <code>{unleashUrl}/api/admin/mcp</code>
-                </StyledDescription>
-                <StyledDescription>
-                    Authentication uses standard Unleash PAT tokens — once
-                    enabled, users will be able to exchange their current login
-                    session for a PAT token, valid for 24h.
-                </StyledDescription>
-            </StyledCardLeft>
-            <StyledCardRight>
-                <FormControlLabel
-                    sx={{ margin: 0 }}
-                    control={
-                        <Switch
-                            onChange={handleToggle}
-                            checked={settings.enabled}
-                            disabled={loading || saving}
-                            name='enabled'
-                        />
-                    }
-                    label={settings.enabled ? 'Enabled' : 'Disabled'}
-                />
-            </StyledCardRight>
-        </StyledCard>
+        <>
+            <StyledCard>
+                <StyledCardLeft>
+                    <StyledTitle variant='body1'>
+                        Enable Remote MCP Server for this instance
+                    </StyledTitle>
+                    <StyledDescription>
+                        When enabled, Unleash exposes a Streamable HTTP MCP
+                        server at <code>{unleashUrl}/api/admin/mcp</code>
+                    </StyledDescription>
+                    <StyledDescription>
+                        Authentication uses standard Unleash PAT tokens — once
+                        enabled, users will be able to exchange their current
+                        login session for a PAT token, valid for 24h.
+                    </StyledDescription>
+                </StyledCardLeft>
+                <StyledCardRight>
+                    <FormControlLabel
+                        sx={{ margin: 0 }}
+                        control={
+                            <Switch
+                                onChange={(_, checked) => setEnabled(checked)}
+                                checked={enabled}
+                                disabled={loading || saving}
+                                name='enabled'
+                            />
+                        }
+                        label={enabled ? 'Enabled' : 'Disabled'}
+                    />
+                </StyledCardRight>
+            </StyledCard>
+            <Footer>
+                <Button onClick={handleCancel} disabled={!isDirty || saving}>
+                    Cancel
+                </Button>
+                <Button
+                    variant='contained'
+                    onClick={handleSave}
+                    disabled={!isDirty || saving}
+                >
+                    Save
+                </Button>
+            </Footer>
+        </>
     );
 };


### PR DESCRIPTION
## Summary

- Toggle no longer triggers an immediate API call — state is only persisted when the user clicks **Save**
- **Cancel** resets the toggle back to the current server value
- Save and Cancel buttons are disabled when there are no unsaved changes, matching the pattern used in other settings pages (e.g. Impact Metrics)
- Tests updated to reflect the new save/cancel flow and simplified by removing symmetric duplicate cases

Renders:
<img width="1516" height="502" alt="image" src="https://github.com/user-attachments/assets/8a6d04be-466b-4c72-992a-5ded09a6a481" />
<img width="1523" height="499" alt="image" src="https://github.com/user-attachments/assets/135ed8c6-c31d-463d-800e-89d925335bd7" />

