### PR TITLE
chore: configure the SDK step

### DIFF
--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/ConfigureSdk.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/ConfigureSdk.tsx
@@ -1,0 +1,171 @@
+import { Alert, alpha, styled, Typography } from '@mui/material';
+import { Markdown } from 'component/common/Markdown/Markdown.tsx';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig.ts';
+import { CodeRenderer, codeRenderSnippets } from '../CodeRenderer.tsx';
+import { buildSdkApiUrl } from '../buildSdkApiUrl.ts';
+import type { Sdk } from '../sharedTypes.ts';
+import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview.ts';
+import { useEffect, useState } from 'react';
+import { PulsingAvatar } from 'component/common/PulsingAvatar/PulsingAvatar.tsx';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+
+const StyledSpacedContainer = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(3),
+}));
+
+const StyledSdkConnectionAlert = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'row',
+    gap: theme.spacing(2),
+    padding: theme.spacing(2),
+    fontSize: theme.typography.body2.fontSize,
+    borderRadius: theme.shape.borderRadiusMedium,
+    backgroundColor: theme.palette.secondary.light,
+    border: `1px solid ${theme.palette.secondary.border}`,
+}));
+
+const StyledSdkConnectedAlert = styled(StyledSdkConnectionAlert)(
+    ({ theme }) => ({
+        backgroundColor: theme.palette.success.light,
+        border: `1px solid ${theme.palette.success.border}`,
+    }),
+);
+
+const StyledPulsingAvatar = styled(PulsingAvatar)(({ theme }) => ({
+    marginLeft: theme.spacing(1),
+    marginTop: theme.spacing(1),
+    width: theme.spacing(3),
+    height: theme.spacing(3),
+    '@keyframes pulse': {
+        '0%': {
+            boxShadow: `0 0 0 0px ${alpha(theme.palette.primary.main, 0.4)}`,
+        },
+        '100%': {
+            boxShadow: `0 0 0 16px ${alpha(theme.palette.primary.main, 0.0)}`,
+        },
+    },
+}));
+
+const StyledConnectedIcon = styled(CheckCircleIcon)(({ theme }) => ({
+    marginLeft: theme.spacing(1),
+    marginTop: theme.spacing(1),
+    width: theme.spacing(3),
+    height: theme.spacing(3),
+    color: theme.palette.success.main,
+}));
+
+const StyledTroubleshootingAlert = styled(Alert)(({ theme }) => ({
+    marginTop: theme.spacing(2),
+    padding: theme.spacing(2, 3),
+    '& .MuiAlert-message': {
+        padding: 0,
+    },
+    '& .MuiAlert-icon': {
+        marginRight: theme.spacing(1),
+    },
+}));
+
+interface IConfigureSdkProps {
+    projectId: string;
+    sdk?: Sdk;
+    apiKey?: string;
+    feature?: string;
+    expanded?: boolean;
+    onSdkConnected: () => void;
+}
+
+export const ConfigureSdk = ({
+    projectId,
+    sdk,
+    apiKey,
+    feature,
+    expanded,
+    onSdkConnected,
+}: IConfigureSdkProps) => {
+    const { uiConfig } = useUiConfig();
+    const [flagName, setFlagName] = useState(feature);
+    const [showTroubleshooting, setShowTroubleshooting] = useState(false);
+
+    useEffect(() => {
+        if (feature) {
+            setFlagName(feature);
+        }
+    }, [feature]);
+
+    const { project } = useProjectOverview(projectId, {
+        refreshInterval: 1000,
+    });
+    const onboarded = project.onboardingStatus.status === 'onboarded';
+
+    useEffect(() => {
+        if (onboarded) {
+            onSdkConnected();
+        }
+    }, [onboarded, onSdkConnected]);
+
+    useEffect(() => {
+        if (onboarded || !expanded) return;
+        const timer = setTimeout(() => setShowTroubleshooting(true), 30_000);
+        return () => clearTimeout(timer);
+    }, [onboarded, expanded]);
+
+    if (!sdk || !apiKey) return null;
+
+    const apiUrl = buildSdkApiUrl(uiConfig.unleashUrl, sdk.name);
+
+    const snippet = (codeRenderSnippets[sdk.name] || '')
+        .replace('<YOUR_API_TOKEN>', apiKey)
+        .replace('<YOUR_API_URL>', apiUrl)
+        .replaceAll('<YOUR_FLAG>', flagName || '<YOUR_FLAG>');
+    const [connectSnippet] = snippet.split('---\n');
+
+    return (
+        <StyledSpacedContainer>
+            <div>
+                <Markdown components={{ code: CodeRenderer }}>
+                    {connectSnippet}
+                </Markdown>
+            </div>
+            {onboarded ? (
+                <StyledSdkConnectedAlert>
+                    <div>
+                        <StyledConnectedIcon />
+                    </div>
+                    <div>
+                        <strong>
+                            We received metrics from your application
+                        </strong>
+                        <Typography variant='body2' color='textSecondary'>
+                            Your SDK is connected and evaluating flags.
+                        </Typography>
+                    </div>
+                </StyledSdkConnectedAlert>
+            ) : (
+                <StyledSdkConnectionAlert>
+                    <div>
+                        <StyledPulsingAvatar active>
+                            <MoreHorizIcon />
+                        </StyledPulsingAvatar>
+                    </div>
+                    <div>
+                        <strong>Waiting for SDK data...</strong>
+                        <Typography variant='body2' color='textSecondary'>
+                            Run your app and evaluate your flag. This step
+                            completes on its own.
+                        </Typography>
+                        {showTroubleshooting && (
+                            <StyledTroubleshootingAlert severity='warning'>
+                                Not seeing evaluations after ~30s? Make sure
+                                your app has started and that the client was
+                                initialized with the API key from step 2.
+                            </StyledTroubleshootingAlert>
+                        )}
+                    </div>
+                </StyledSdkConnectionAlert>
+            )}
+        </StyledSpacedContainer>
+    );
+};

--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
@@ -13,6 +13,7 @@ import { useState } from 'react';
 import { ConnectSdkDialogStep } from './ConnectSdkDialogStep';
 import type { Sdk } from '../sharedTypes';
 import { SelectSdk, SelectSdkSummary } from './SelectSdk';
+import { ConfigureSdk } from './ConfigureSdk';
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
     '& .MuiDialog-paper': {
@@ -136,6 +137,9 @@ type Step = {
 const InnerDialog = ({
     onClose,
     onFinish,
+    project: projectId, // TODO: Cleanup prop names once we remove `onboardingConnectSDKNewDialog`
+    environments,
+    feature,
 }: Omit<IConnectSDKDialogProps, 'open'>) => {
     const [currentStep, setCurrentStep] = useState(0);
     const [expandedStep, setExpandedStep] = useState(0);
@@ -148,6 +152,8 @@ const InnerDialog = ({
         setExpandedStep(1);
     };
 
+    const onSdkConnected = () => setCurrentStep(3);
+
     const steps: Step[] = [
         {
             title: 'Select SDK',
@@ -155,7 +161,19 @@ const InnerDialog = ({
             summary: <SelectSdkSummary sdk={sdk} />,
         },
         { title: 'Generate API key', content: 'TODO: Generate API key' },
-        { title: 'Configure the SDK', content: 'TODO: Configure the SDK' },
+        {
+            title: 'Configure the SDK',
+            content: (
+                <ConfigureSdk
+                    projectId={projectId}
+                    sdk={sdk}
+                    apiKey='TODO: API key from state'
+                    feature={feature}
+                    expanded={expandedStep === 2}
+                    onSdkConnected={onSdkConnected}
+                />
+            ),
+        },
     ];
 
     const complete = currentStep >= steps.length && sdk;


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-463/configure-the-sdk-step

Adds the "Configure the SDK" step to the new "Connect SDK" dialog.

### Configuring

<img width="1396" height="915" alt="image" src="https://github.com/user-attachments/assets/852b1a18-a2c8-4a14-a836-139a28963d88" />

### Done

<img width="1406" height="926" alt="image" src="https://github.com/user-attachments/assets/f6ab9b68-9eb2-44c5-9849-46ef3504f435" />

### Edge case: No connection after 30s

<img width="1414" height="1018" alt="image" src="https://github.com/user-attachments/assets/1979b57a-e453-4584-9f68-117fc4e653d6" />