### PR TITLE
chore: update use of button to chip (finally!)

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/AddValuesChip.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/AddValuesChip.tsx
@@ -2,29 +2,19 @@ import Add from '@mui/icons-material/Add';
 import { styled } from '@mui/material';
 import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { parseParameterStrings } from 'utils/parseParameter';
-import { baseChipStyles } from './ValueList.tsx';
+import { ValueChip } from './ValueList.tsx';
 import { AddValuesPopover, type OnAddActions } from './AddValuesPopover.tsx';
 import type { ConstraintValidatorOutput } from './ConstraintValidatorOutput.ts';
 
-// todo: MUI v6 / v7 upgrade: consider changing this to a Chip to align with the rest of the values and the single value selector. There was a fix introduced in v6 that makes you not lose focus on pressing esc: https://mui.com/material-ui/migration/upgrade-to-v6/#chip talk to Thomas for more info.
-const AddValuesButton = styled('button')(({ theme }) => ({
-    ...baseChipStyles(theme),
+const StyledChip = styled(ValueChip)(({ theme }) => ({
     color: theme.palette.primary.main,
-    svg: {
+    width: 'max-content',
+    '.MuiChip-icon': {
+        transform: 'translateX(50%)',
         fill: theme.palette.primary.main,
         height: theme.fontSizes.smallerBody,
         width: theme.fontSizes.smallerBody,
     },
-    border: 'none',
-    borderRadius: theme.shape.borderRadiusExtraLarge,
-    display: 'flex',
-    flexFlow: 'row nowrap',
-    whiteSpace: 'nowrap',
-    gap: theme.spacing(0.25),
-    alignItems: 'center',
-    padding: theme.spacing(0.5, 1.5, 0.5, 1.5),
-    height: 'auto',
-    cursor: 'pointer',
 }));
 
 interface AddValuesProps {
@@ -33,13 +23,13 @@ interface AddValuesProps {
     validator: (...values: string[]) => ConstraintValidatorOutput;
 }
 
-export const AddValuesChip = forwardRef<HTMLButtonElement, AddValuesProps>(
+export const AddValuesChip = forwardRef<HTMLDivElement, AddValuesProps>(
     ({ onAddValues, helpText, validator }, ref) => {
         const [open, setOpen] = useState(false);
-        const positioningRef = useRef<HTMLButtonElement>(null);
+        const positioningRef = useRef<HTMLDivElement>(null);
         useImperativeHandle(
             ref,
-            () => positioningRef.current as HTMLButtonElement,
+            () => positioningRef.current as HTMLDivElement,
         );
 
         const handleAdd = (
@@ -70,15 +60,13 @@ export const AddValuesChip = forwardRef<HTMLButtonElement, AddValuesProps>(
 
         return (
             <>
-                <AddValuesButton
+                <StyledChip
                     ref={positioningRef}
+                    icon={<Add />}
+                    label='Add values'
                     onClick={() => setOpen(true)}
-                    type='button'
                     data-testid='CONSTRAINT_ADD_VALUES_BUTTON'
-                >
-                    <Add />
-                    <span>Add values</span>
-                </AddValuesButton>
+                />
 
                 <AddValuesPopover
                     onAdd={handleAdd}

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/EditableConstraint.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/EditableConstraint.tsx
@@ -142,7 +142,7 @@ const TopRowInput: FC<{
     clearValues: () => void;
     localConstraint: EditableConstraintType;
     validator: (value: string) => ConstraintValidationResult;
-    addValuesButtonRef: React.RefObject<HTMLButtonElement>;
+    addValuesButtonRef: React.RefObject<HTMLDivElement>;
     editingOpen: boolean;
     setEditingOpen: (open: boolean) => void;
 }> = ({
@@ -351,7 +351,7 @@ export const EditableConstraint: FC<Props> = ({
     const showCaseSensitiveButton =
         isStringOperator(operator) || isRegexOperator(operator);
     const deleteButtonRef = useRef<HTMLButtonElement>(null);
-    const addValuesButtonRef = useRef<HTMLButtonElement>(null);
+    const addValuesButtonRef = useRef<HTMLDivElement>(null);
 
     if (!context) {
         return null;


### PR DESCRIPTION
There was an issue with focus handling for chips in mui v5 that forced us to use a button for this element. Now that we've updated, we can align it with the other chips and use an actual chip element.

Functionally and aesthetically it's completely identical except the fact that you get MUI's bubble animation when you click it with the mouse.
<img width="202" height="86" alt="image" src="https://github.com/user-attachments/assets/988759b2-6d07-4312-8c9a-31802453d997" />
