### PR TITLE
fix: Grid width on billing page

### DIFF
--- a/frontend/src/component/common/GridRow/GridRow.tsx
+++ b/frontend/src/component/common/GridRow/GridRow.tsx
@@ -6,6 +6,7 @@ import type { FC } from 'react';
 const StyledGrid = styled(Grid)(({ theme }) => ({
     flexWrap: 'nowrap',
     gap: theme.spacing(1),
+    width: '100%',
 }));
 
 export const GridRow: FC<{


### PR DESCRIPTION
Fixes a visual bug introduced by the Grid v1 -> Grid v2 MUI migration.

In Grid v1, `<Grid container>` always had `width: 100%` baked into its styles. That meant a nested `<Grid container item>` (which is what `GridRow` was) was guaranteed to span its parent's full width, so multiple `GridRow`s would always stack.
In Grid v2, the container style is just `{ display: 'flex', flex-wrap: 'wrap', gap: ... }`. 
Without a `size` prop, a Grid (container or not) is just an auto-sized flex item (and two auto-sized rows pack horizontally instead of stacking). 

Audited the rest of the codebase and it looks like the fixes isn't needed elsewhere.

Note: I used hardcoded data, as I don't have access to an instance that has billing enabled and data relevant to this bug (which occurs when a nested `Grid container` doesn't carry a `size` prop).

Before: 

<img width="778" height="392" alt="Screenshot 2026-05-12 at 14 14 37" src="https://github.com/user-attachments/assets/aecc4441-d1ce-4edc-ac0f-567a08739cbe" />


After: 

<img width="684" height="387" alt="Screenshot 2026-05-12 at 14 49 05" src="https://github.com/user-attachments/assets/f4d3e9df-a873-4cf4-8009-16219e9c101a" />
