### PR TITLE
chore: fix new connect SDK flow by using correct onboarding status

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
@@ -17,7 +17,10 @@ export const FeatureConnectSdkBanner = ({
     const { trackEvent } = usePlausibleTracker();
     const [connectSdkOpen, setConnectSdkOpen] = useState(false);
 
-    if (project.onboardingStatus.status === 'onboarded') {
+    if (
+        project.onboardingStatus.status === 'onboarded' ||
+        project.onboardingStatus.status === 'sdk-connected'
+    ) {
         return null;
     }
 

--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/ConfigureSdk.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/ConfigureSdk.tsx
@@ -98,19 +98,19 @@ export const ConfigureSdk = ({
     const { project } = useProjectOverview(projectId, {
         refreshInterval: 1000,
     });
-    const onboarded = project.onboardingStatus.status === 'onboarded';
+    const sdkConnected = project.onboardingStatus.status === 'sdk-connected';
 
     useEffect(() => {
-        if (onboarded) {
+        if (sdkConnected) {
             onSdkConnected();
         }
-    }, [onboarded, onSdkConnected]);
+    }, [sdkConnected, onSdkConnected]);
 
     useEffect(() => {
-        if (onboarded || !expanded) return;
+        if (sdkConnected || !expanded) return;
         const timer = setTimeout(() => setShowTroubleshooting(true), 30_000);
         return () => clearTimeout(timer);
-    }, [onboarded, expanded]);
+    }, [sdkConnected, expanded]);
 
     if (!sdk || !apiKey) return null;
 
@@ -129,7 +129,7 @@ export const ConfigureSdk = ({
                     {connectSnippet}
                 </Markdown>
             </div>
-            {onboarded ? (
+            {sdkConnected ? (
                 <StyledSdkConnectedAlert>
                     <div>
                         <StyledConnectedIcon />


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-500/fix-use-the-correct-onboarding-status-sdk-connected

Fixes a bug where we were considering the `onboarded` onboarding status instead of `sdk-connected`.