### PR TITLE
chore: add `nativeButton={false}` to MUI buttons not rendered as buttons

### DIFF
--- a/frontend/src/component/admin/enterprise-edge/EnterpriseEdgeDismissibleAlert.tsx
+++ b/frontend/src/component/admin/enterprise-edge/EnterpriseEdgeDismissibleAlert.tsx
@@ -98,6 +98,7 @@ export const EnterpriseEdgeDismissibleAlert = ({
                         </Typography>
                         <StyledButton
                             component={Link}
+                            nativeButton={false}
                             to='/admin/enterprise-edge'
                             variant='contained'
                         >

--- a/frontend/src/component/admin/enterprise-edge/EnterpriseEdgeExplanation.tsx
+++ b/frontend/src/component/admin/enterprise-edge/EnterpriseEdgeExplanation.tsx
@@ -164,6 +164,7 @@ const EdgeVersionCard = ({
         <StyledLinkContainer>
             <Button
                 component={Link}
+                nativeButton={false}
                 to={docsUrl}
                 size='small'
                 sx={{ fontSize: '14px' }}

--- a/frontend/src/component/admin/groups/Group/Group.tsx
+++ b/frontend/src/component/admin/groups/Group/Group.tsx
@@ -248,6 +248,7 @@ export const Group: FC = () => {
                                     data-testid={UG_EDIT_BTN_ID}
                                     to={`/admin/groups/${groupId}/edit`}
                                     component={Link}
+                                    nativeButton={false}
                                     data-loading
                                     permission={ADMIN}
                                     tooltipProps={{

--- a/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardActions.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupCard/GroupCardActions.tsx
@@ -95,6 +95,7 @@ export const GroupCardActions: FC<IGroupCardActions> = ({
                     <MenuItem
                         onClick={handleClose}
                         component={Link}
+                        nativeButton={false}
                         to={`/admin/groups/${groupId}/edit`}
                     >
                         <ListItemIcon>

--- a/frontend/src/component/admin/groups/GroupsList/GroupEmpty/GroupEmpty.tsx
+++ b/frontend/src/component/admin/groups/GroupsList/GroupEmpty/GroupEmpty.tsx
@@ -25,6 +25,7 @@ export const GroupEmpty = () => {
             <Button
                 to='/admin/groups/create-group'
                 component={Link}
+                nativeButton={false}
                 variant='outlined'
                 color='primary'
             >

--- a/frontend/src/component/application/Application.tsx
+++ b/frontend/src/component/application/Application.tsx
@@ -149,6 +149,7 @@ export const Application = () => {
                                     show={
                                         <IconButton
                                             component={Link}
+                                            nativeButton={false}
                                             href={url}
                                             size='large'
                                         >

--- a/frontend/src/component/changeRequest/ChangeRequestSidebar/EnvironmentChangeRequest/EnvironmentChangeRequest.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequestSidebar/EnvironmentChangeRequest/EnvironmentChangeRequest.tsx
@@ -198,6 +198,7 @@ export const EnvironmentChangeRequest: FC<{
                                         sx={{ marginLeft: 2 }}
                                         variant='outlined'
                                         component={Link}
+                                        nativeButton={false}
                                         to={`/projects/${environmentChangeRequest.project}/change-requests/${environmentChangeRequest.id}`}
                                         onClick={() => {
                                             onClose();

--- a/frontend/src/component/commandBar/CommandPageSuggestions.tsx
+++ b/frontend/src/component/commandBar/CommandPageSuggestions.tsx
@@ -68,6 +68,7 @@ export const CommandPageSuggestions = ({
                     key={`recently-visited-${index}`}
                     dense={true}
                     component={Link}
+                    nativeButton={false}
                     to={item.path}
                     onClick={() => {
                         onItemClick(item);

--- a/frontend/src/component/commandBar/CommandSearchPages.tsx
+++ b/frontend/src/component/commandBar/CommandSearchPages.tsx
@@ -43,6 +43,7 @@ export const CommandSearchPages = ({
                     key={`command-result-group-pages-${index}`}
                     dense={true}
                     component={Link}
+                    nativeButton={false}
                     to={item.link}
                     onClick={() => {
                         onItemClick(item);

--- a/frontend/src/component/commandBar/RecentlyVisited/CommandResultGroup.tsx
+++ b/frontend/src/component/commandBar/RecentlyVisited/CommandResultGroup.tsx
@@ -76,6 +76,7 @@ export const RecentlyVisitedPathButton = ({
             key={keyName}
             dense={true}
             component={Link}
+            nativeButton={false}
             to={path}
             sx={listItemButtonStyle}
             onClick={onItemClick}
@@ -122,6 +123,7 @@ export const RecentlyVisitedProjectButton = ({
             key={keyName}
             dense={true}
             component={Link}
+            nativeButton={false}
             to={`/projects/${projectId}`}
             sx={listItemButtonStyle}
             onClick={onItemClick}
@@ -165,6 +167,7 @@ export const RecentlyVisitedFeatureButton = ({
             key={keyName}
             dense={true}
             component={Link}
+            nativeButton={false}
             to={`/projects/${projectId}/features/${featureId}`}
             sx={listItemButtonStyle}
             onClick={onItemClick}
@@ -230,6 +233,7 @@ export const CommandResultGroup = ({
                         key={`command-result-group-${groupName}-${index}`}
                         dense={true}
                         component={Link}
+                        nativeButton={false}
                         onClick={(e) => {
                             e.stopPropagation();
                             onItemClick(item);

--- a/frontend/src/component/common/PermissionIconButton/PermissionIconButton.tsx
+++ b/frontend/src/component/common/PermissionIconButton/PermissionIconButton.tsx
@@ -26,6 +26,7 @@ interface IPermissionIconButtonProps {
     tooltipProps?: Omit<ITooltipResolverProps, 'children'>;
     sx?: IconButtonProps['sx'];
     size?: 'small' | 'medium' | 'large';
+    nativeButton?: boolean;
 }
 
 interface IButtonProps extends IPermissionIconButtonProps {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCardsReleaseTemplates.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyMenu/FeatureStrategyMenuCards/FeatureStrategyMenuCardsReleaseTemplates.tsx
@@ -148,6 +148,7 @@ export const FeatureStrategyMenuCardsReleaseTemplates = ({
                     {canCreateTemplate ? (
                         <Button
                             component={RouterLink}
+                            nativeButton={false}
                             to='/release-templates/create-template'
                             startIcon={<AddIcon />}
                             onClick={handleLinkClick}

--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListActions/FeatureToggleListActions.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListActions/FeatureToggleListActions.tsx
@@ -98,6 +98,7 @@ export const FeatureToggleListActions: FC<IFeatureFlagListActions> = ({
                         {({ hasAccess }) => (
                             <MenuItem
                                 component={Link}
+                                nativeButton={false}
                                 disabled={!hasAccess}
                                 to={createFeature!.path}
                                 onClick={() => {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/ProjectEnvironmentStrategyDraggableItem.tsx
@@ -47,6 +47,7 @@ const EditControls = ({
                 environmentId={environmentName}
                 projectId={projectId}
                 component={Link}
+                nativeButton={false}
                 onClick={() => {
                     if (scope === 'milestone') {
                         trackEvent('edit-milestone-strategy', {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/FeatureOverviewMetaData.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewMetaData/FeatureOverviewMetaData.tsx
@@ -162,6 +162,7 @@ const FeatureLinks: FC<FeatureLinksProps> = ({ links, project, feature }) => {
                 >
                     <ListItemButton
                         component='a'
+                        nativeButton={false}
                         href={link.url}
                         target='_blank'
                         rel='noopener noreferrer'

--- a/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx
@@ -166,6 +166,7 @@ const HeaderActionsComponent = ({
             projectId={feature.project}
             data-loading
             component={Link}
+            nativeButton={false}
             to={`/projects/${feature.project}/features/${feature.name}/copy`}
             tooltipProps={{
                 title: 'Clone',

--- a/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
+++ b/frontend/src/component/impact-metrics/RegisterMetricDialog/SuccessView.tsx
@@ -114,6 +114,7 @@ export const SuccessView = ({ metricName }: SuccessViewProps) => {
             </TextContent>
             <Button
                 component={Link}
+                nativeButton={false}
                 target='_blank'
                 rel='noopener noreferrer'
                 variant='contained'

--- a/frontend/src/component/integrations/IntegrationForm/IntegrationInstall/IntegrationInstall.tsx
+++ b/frontend/src/component/integrations/IntegrationForm/IntegrationInstall/IntegrationInstall.tsx
@@ -31,6 +31,7 @@ export const IntegrationInstall = ({
                         type='button'
                         variant='contained'
                         component={Link}
+                        nativeButton={false}
                         target='_blank'
                         rel='noopener noreferrer'
                         to={url}

--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminListItem.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminListItem.tsx
@@ -166,6 +166,7 @@ export const AdminListItem: FC<{
             <ListItemButton
                 dense={true}
                 component={Link}
+                nativeButton={false}
                 to={href}
                 sx={listItemButtonStyle}
                 selected={selected}
@@ -194,6 +195,7 @@ export const AdminSubListItem: FC<{
             <ListItemButton
                 dense={true}
                 component={Link}
+                nativeButton={false}
                 to={href}
                 sx={subListItemButtonStyle}
                 selected={selected}

--- a/frontend/src/component/layout/MainLayout/AdminMenu/AdminNavigationItems.tsx
+++ b/frontend/src/component/layout/MainLayout/AdminMenu/AdminNavigationItems.tsx
@@ -106,6 +106,7 @@ export const DashboardLink = ({ onClick }: { onClick: () => void }) => {
                 <ListItemButton
                     dense={true}
                     component={Link}
+                    nativeButton={false}
                     to='/personal'
                     sx={listItemButtonStyle}
                     selected={false}

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/ListItems.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/ListItems.tsx
@@ -68,6 +68,7 @@ export const ExternalFullListItem: FC<{
             <ListItemButton
                 dense={true}
                 component={Link}
+                nativeButton={false}
                 to={href}
                 sx={listItemButtonStyle}
                 rel='noopener noreferrer'
@@ -130,6 +131,7 @@ export const MenuListItem: FC<{
             <ListItemButton
                 dense
                 component={Link}
+                nativeButton={false}
                 to={href}
                 sx={(theme) => ({
                     ...listItemButtonStyle(theme),

--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -148,6 +148,7 @@ const Header = () => {
                         <Tooltip title='Documentation' arrow>
                             <StyledIconButton
                                 component='a'
+                                nativeButton={false}
                                 href='https://docs.getunleash.io/'
                                 target='_blank'
                                 rel='noopener noreferrer'

--- a/frontend/src/component/onboarding/flow/SdkExample.tsx
+++ b/frontend/src/component/onboarding/flow/SdkExample.tsx
@@ -98,6 +98,7 @@ export const SdkExample = () => {
                         to={`${repositoryUrl}/${selectedSdk}`}
                         target='_blank'
                         component={Link}
+                        nativeButton={false}
                         variant='text'
                         color='primary'
                         onClick={trackClick}

--- a/frontend/src/component/onboarding/flow/steps/TurnFlagStep.tsx
+++ b/frontend/src/component/onboarding/flow/steps/TurnFlagStep.tsx
@@ -41,6 +41,7 @@ export const TurnFlagStep = ({ projectId, state }: ITurnFlagStepProps) => {
                     variant='contained'
                     color='primary'
                     component={Link}
+                    nativeButton={false}
                     to={goToFlagHref}
                 >
                     Go to flag

--- a/frontend/src/component/personalDashboard/ConnectSDK.tsx
+++ b/frontend/src/component/personalDashboard/ConnectSDK.tsx
@@ -82,6 +82,7 @@ export const ExistingFlag: FC<{ project: string }> = ({ project }) => {
             <div>
                 <Button
                     component={Link}
+                    nativeButton={false}
                     to={`/projects/${project}`}
                     variant='contained'
                 >
@@ -113,6 +114,7 @@ export const ConnectSDK: FC<{ project: string }> = ({ project }) => {
             <div>
                 <Button
                     component={Link}
+                    nativeButton={false}
                     to={`/projects/${project}`}
                     variant='contained'
                 >

--- a/frontend/src/component/personalDashboard/MyFlags.tsx
+++ b/frontend/src/component/personalDashboard/MyFlags.tsx
@@ -49,6 +49,7 @@ const FlagListItem: FC<{
                     <StyledCardTitle>{flag.name}</StyledCardTitle>
                     <IconButton
                         component={Link}
+                        nativeButton={false}
                         href={flagLink}
                         onClick={() => {
                             trackEvent('personal-dashboard', {

--- a/frontend/src/component/personalDashboard/MyProjects.tsx
+++ b/frontend/src/component/personalDashboard/MyProjects.tsx
@@ -112,6 +112,7 @@ const ProjectListItem: FC<{
                     <StyledCardTitle>{project.name}</StyledCardTitle>
                     <IconButton
                         component={Link}
+                        nativeButton={false}
                         to={`/projects/${project.id}`}
                         size='small'
                         sx={{ ml: 'auto' }}

--- a/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundConnectionFieldset/PlaygroundConnectionFieldset.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundConnectionFieldset/PlaygroundConnectionFieldset.tsx
@@ -306,6 +306,7 @@ export const PlaygroundConnectionFieldset: FC<
                                 size='small'
                                 to={`/projects/${projects[0]}/change-requests/${changeRequest}`}
                                 component={Link}
+                                nativeButton={false}
                             >
                                 View change request
                             </Button>

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ActionsCell.tsx
@@ -146,6 +146,7 @@ export const ActionsCell: FC<IActionsCellProps> = ({
                                 onClick={handleClose}
                                 disabled={!hasAccess}
                                 component={RouterLink}
+                                nativeButton={false}
                                 to={`/projects/${projectId}/features/${featureId}/copy`}
                             >
                                 <ListItemIcon>

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/ProjectEnvironmentDefaultStrategy.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectDefaultStrategySettings/ProjectEnvironment/ProjectEnvironmentDefaultStrategy/ProjectEnvironmentDefaultStrategy.tsx
@@ -74,6 +74,7 @@ export const ProjectEnvironmentDefaultStrategy = ({
                         environmentId={environmentId}
                         projectId={projectId}
                         component={Link}
+                        nativeButton={false}
                         to={editStrategyPath}
                         tooltipProps={{
                             title: `Edit default strategy for "${environmentId}"`,

--- a/frontend/src/component/project/ProjectAccess/ProjectAccessTable/ProjectAccessTable.tsx
+++ b/frontend/src/component/project/ProjectAccess/ProjectAccessTable/ProjectAccessTable.tsx
@@ -215,6 +215,7 @@ export const ProjectAccessTable: FC = () => {
                         <PermissionIconButton
                             data-testid={PA_EDIT_BUTTON_ID}
                             component={Link}
+                            nativeButton={false}
                             permission={[
                                 UPDATE_PROJECT,
                                 PROJECT_USER_ACCESS_WRITE,

--- a/frontend/src/component/releases/ReleaseManagement/EmptyTemplatesListMessage.tsx
+++ b/frontend/src/component/releases/ReleaseManagement/EmptyTemplatesListMessage.tsx
@@ -43,6 +43,7 @@ export const EmptyTemplatesListMessage = () => {
             <Buttons>
                 <Button
                     component={Link}
+                    nativeButton={false}
                     sx={{ whiteSpace: 'nowrap' }}
                     to='https://docs.getunleash.io/reference/release-templates'
                     variant='text'

--- a/frontend/src/component/releases/ReleaseManagement/ReleaseManagement.tsx
+++ b/frontend/src/component/releases/ReleaseManagement/ReleaseManagement.tsx
@@ -110,6 +110,7 @@ export const ReleaseManagement = () => {
                     </Typography>
                     <StyledAlertButton
                         component={Link}
+                        nativeButton={false}
                         variant='outlined'
                         target='_blank'
                         rel='noopener noreferrer'

--- a/frontend/src/component/releases/ReleaseManagement/ReleasePlanTemplateCard/ReleasePlanTemplateCardActions.tsx
+++ b/frontend/src/component/releases/ReleaseManagement/ReleasePlanTemplateCard/ReleasePlanTemplateCardActions.tsx
@@ -113,6 +113,7 @@ export const ReleasePlanTemplateCardActions = ({
                     <MenuItem
                         onClick={handleClose}
                         component={Link}
+                        nativeButton={false}
                         to={`/release-templates/edit/${template.id}`}
                     >
                         <ListItemIcon>

--- a/frontend/src/component/splash/SplashPageOperators.tsx
+++ b/frontend/src/component/splash/SplashPageOperators.tsx
@@ -156,6 +156,7 @@ export const SplashPageOperators = () => {
                             })}
                             variant='contained'
                             component={Link}
+                            nativeButton={false}
                             to='/'
                         >
                             Fine, whatever, I have work to do!

--- a/frontend/src/component/user/ForgottenPassword/ForgottenPassword.tsx
+++ b/frontend/src/component/user/ForgottenPassword/ForgottenPassword.tsx
@@ -175,6 +175,7 @@ const ForgottenPassword = () => {
                     <Button
                         variant='outlined'
                         component={Link}
+                        nativeButton={false}
                         to='/login'
                         fullWidth
                     >

--- a/frontend/src/component/user/ResetPassword/ResetPasswordSuccess.tsx
+++ b/frontend/src/component/user/ResetPassword/ResetPasswordSuccess.tsx
@@ -40,6 +40,7 @@ const ResetPasswordSuccess = () => {
                     variant='contained'
                     color='primary'
                     component={Link}
+                    nativeButton={false}
                     to='/login'
                     fullWidth
                 >

--- a/frontend/src/component/user/SignedOut/SignedOut.tsx
+++ b/frontend/src/component/user/SignedOut/SignedOut.tsx
@@ -44,6 +44,7 @@ const SignedOut = () => {
                     variant='contained'
                     color='primary'
                     component={Link}
+                    nativeButton={false}
                     to='/login'
                     fullWidth
                 >

--- a/frontend/src/component/user/UserProfile/UserProfile.tsx
+++ b/frontend/src/component/user/UserProfile/UserProfile.tsx
@@ -51,6 +51,7 @@ const UserProfile = ({ profile }: IUserProfileProps) => {
                     aria-controls={showProfile ? modalId : undefined}
                     aria-expanded={showProfile}
                     onClick={() => setShowProfile((prev) => !prev)}
+                    nativeButton={false}
                 >
                     <StyledUserAvatar
                         user={profile}

--- a/frontend/src/component/user/common/InvalidToken/InvalidToken.tsx
+++ b/frontend/src/component/user/common/InvalidToken/InvalidToken.tsx
@@ -38,6 +38,7 @@ const InvalidToken: FC = () => {
                             variant='contained'
                             color='primary'
                             component={Link}
+                            nativeButton={false}
                             to='/login'
                         >
                             Login
@@ -66,6 +67,7 @@ const InvalidToken: FC = () => {
                                     variant='contained'
                                     color='primary'
                                     component={Link}
+                                    nativeButton={false}
                                     to='/forgotten-password'
                                     data-testid={INVALID_TOKEN_BUTTON}
                                 >


### PR DESCRIPTION
MUI v9 emits a dev-mode warning whenever a button-like MUI component (`Button`, `IconButton`, `ListItemButton`, `MenuItem`, etc.) is rendered as something other than a `<button>`.
~~The real fix would be to **not** use `component={Link}` on a `Button` at all, and use a real `<Link> `styled like a button instead.~~ Redacted: from the looks of the MUI docs, seems like `nativeButton={false}` is actually the way to go here.

<img width="388" height="98" alt="Screenshot 2026-05-13 at 16 12 29" src="https://github.com/user-attachments/assets/34eeb8b4-7f00-484d-a265-527db3403e1a" />
