### PR TITLE
fix: check env permissions on import

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-controller.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-controller.ts
@@ -659,8 +659,8 @@ export default class ProjectFeaturesController extends Controller {
                         projectId,
                         name,
                         req.audit,
-                        replaceGroupId,
                         req.user,
+                        replaceGroupId,
                     ),
             );
 

--- a/src/lib/features/feature-toggle/feature-toggle-controller.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-controller.ts
@@ -660,6 +660,7 @@ export default class ProjectFeaturesController extends Controller {
                         name,
                         req.audit,
                         replaceGroupId,
+                        req.user,
                     ),
             );
 

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -47,6 +47,7 @@ import {
     type StrategyIds,
     SYSTEM_USER_AUDIT,
     type Unsaved,
+    UPDATE_FEATURE_ENVIRONMENT_VARIANTS,
     WeightType,
 } from '../../types/index.js';
 import type { Logger } from '../../logger.js';
@@ -1376,6 +1377,7 @@ export class FeatureToggleService {
         newFeatureName: string,
         auditUser: IAuditUser,
         replaceGroupId: boolean = true,
+        user?: IUser,
     ): Promise<FeatureToggle> {
         const changeRequestEnabled =
             await this.changeRequestAccessReadModel.isChangeRequestsEnabledForProject(
@@ -1395,6 +1397,11 @@ export class FeatureToggleService {
             await this.featureStrategiesStore.getFeatureToggleWithVariantEnvs(
                 featureName,
             );
+        await this.validateCloneFeaturePermissions(
+            projectId,
+            cToggle.environments,
+            user,
+        );
 
         const newToggle = {
             ...cToggle,
@@ -1447,6 +1454,48 @@ export class FeatureToggleService {
         ]);
 
         return created;
+    }
+
+    private async validateCloneFeaturePermissions(
+        projectId: string,
+        environments: FeatureToggleWithEnvironment['environments'],
+        user?: IUser,
+    ): Promise<void> {
+        if (!user) {
+            return;
+        }
+
+        for (const environment of environments) {
+            if (
+                environment.strategies.length > 0 &&
+                !(await this.accessService.hasPermission(
+                    user,
+                    CREATE_FEATURE_STRATEGY,
+                    projectId,
+                    environment.name,
+                ))
+            ) {
+                throw new PermissionError(
+                    CREATE_FEATURE_STRATEGY,
+                    environment.name,
+                );
+            }
+
+            if (
+                environment.variants.length > 0 &&
+                !(await this.accessService.hasPermission(
+                    user,
+                    UPDATE_FEATURE_ENVIRONMENT_VARIANTS,
+                    projectId,
+                    environment.name,
+                ))
+            ) {
+                throw new PermissionError(
+                    UPDATE_FEATURE_ENVIRONMENT_VARIANTS,
+                    environment.name,
+                );
+            }
+        }
     }
 
     async updateFeatureToggle(

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -1377,7 +1377,7 @@ export class FeatureToggleService {
         newFeatureName: string,
         auditUser: IAuditUser,
         replaceGroupId: boolean = true,
-        user?: IUser,
+        user: IUser,
     ): Promise<FeatureToggle> {
         const changeRequestEnabled =
             await this.changeRequestAccessReadModel.isChangeRequestsEnabledForProject(
@@ -1459,12 +1459,8 @@ export class FeatureToggleService {
     private async validateCloneFeaturePermissions(
         projectId: string,
         environments: FeatureToggleWithEnvironment['environments'],
-        user?: IUser,
+        user: IUser,
     ): Promise<void> {
-        if (!user) {
-            return;
-        }
-
         for (const environment of environments) {
             if (
                 environment.strategies.length > 0 &&

--- a/src/lib/features/feature-toggle/feature-toggle-service.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-service.ts
@@ -1376,8 +1376,8 @@ export class FeatureToggleService {
         projectId: string,
         newFeatureName: string,
         auditUser: IAuditUser,
-        replaceGroupId: boolean = true,
         user: IUser,
+        replaceGroupId: boolean = true,
     ): Promise<FeatureToggle> {
         const changeRequestEnabled =
             await this.changeRequestAccessReadModel.isChangeRequestsEnabledForProject(

--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
@@ -363,8 +363,8 @@ test('cloning a feature flag copies variant environments correctly', async () =>
         'default',
         clonedFlagName,
         SYSTEM_USER_AUDIT,
-        true,
         { ...ADMIN_TOKEN_USER, permissions: [ADMIN], isAPI: true },
+        true,
     );
 
     const clonedFlag =
@@ -392,8 +392,8 @@ test('cloning a feature flag not allowed for change requests enabled', async () 
             'default',
             'clonedFlagName',
             SYSTEM_USER_AUDIT,
+            { ...ADMIN_TOKEN_USER, permissions: [ADMIN], isAPI: true },
             true,
-            ADMIN_TOKEN_USER,
         ),
     ).rejects.errorWithMessage(
         new ForbiddenError(
@@ -454,8 +454,8 @@ test('Cloning a feature flag also clones segments correctly', async () => {
         'default',
         clonedFeatureName,
         TEST_AUDIT_USER,
-        true,
         { ...ADMIN_TOKEN_USER, permissions: [ADMIN], isAPI: true },
+        true,
     );
 
     const feature = await service.getFeature({

--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
@@ -14,6 +14,7 @@ import {
     SKIP_CHANGE_REQUEST,
     SYSTEM_USER_AUDIT,
     TEST_AUDIT_USER,
+    ADMIN_TOKEN_USER,
 } from '../../../types/index.js';
 import EnvironmentService from '../../project-environments/environment-service.js';
 import {
@@ -362,6 +363,7 @@ test('cloning a feature flag copies variant environments correctly', async () =>
         clonedFlagName,
         SYSTEM_USER_AUDIT,
         true,
+        ADMIN_TOKEN_USER,
     );
 
     const clonedFlag =
@@ -390,6 +392,7 @@ test('cloning a feature flag not allowed for change requests enabled', async () 
             'clonedFlagName',
             SYSTEM_USER_AUDIT,
             true,
+            ADMIN_TOKEN_USER,
         ),
     ).rejects.errorWithMessage(
         new ForbiddenError(
@@ -451,6 +454,7 @@ test('Cloning a feature flag also clones segments correctly', async () => {
         clonedFeatureName,
         TEST_AUDIT_USER,
         true,
+        ADMIN_TOKEN_USER,
     );
 
     const feature = await service.getFeature({

--- a/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggle-service.e2e.test.ts
@@ -15,6 +15,7 @@ import {
     SYSTEM_USER_AUDIT,
     TEST_AUDIT_USER,
     ADMIN_TOKEN_USER,
+    ADMIN,
 } from '../../../types/index.js';
 import EnvironmentService from '../../project-environments/environment-service.js';
 import {
@@ -363,7 +364,7 @@ test('cloning a feature flag copies variant environments correctly', async () =>
         clonedFlagName,
         SYSTEM_USER_AUDIT,
         true,
-        ADMIN_TOKEN_USER,
+        { ...ADMIN_TOKEN_USER, permissions: [ADMIN], isAPI: true },
     );
 
     const clonedFlag =
@@ -454,7 +455,7 @@ test('Cloning a feature flag also clones segments correctly', async () => {
         clonedFeatureName,
         TEST_AUDIT_USER,
         true,
-        ADMIN_TOKEN_USER,
+        { ...ADMIN_TOKEN_USER, permissions: [ADMIN], isAPI: true },
     );
 
     const feature = await service.getFeature({

--- a/src/lib/features/feature-toggle/tests/feature-toggles.auth.e2e.test.ts
+++ b/src/lib/features/feature-toggle/tests/feature-toggles.auth.e2e.test.ts
@@ -11,6 +11,8 @@ import {
     CREATE_FEATURE_STRATEGY,
     RoleName,
     TEST_AUDIT_USER,
+    UPDATE_FEATURE_ENVIRONMENT_VARIANTS,
+    WeightType,
 } from '../../../types/index.js';
 
 let app: IUnleashTest;
@@ -142,6 +144,120 @@ test('Should not be possible auto-enable feature flag without CREATE_FEATURE_STR
     await app.request
         .post(`${url}/${name}/environments/${DEFAULT_ENV}/on`)
         .expect(403);
+});
+
+test('Should not be possible to clone feature flag strategies without CREATE_FEATURE_STRATEGY permission', async () => {
+    const email = 'user34@mail.com';
+    const url = '/api/admin/projects/default/features';
+    const name = 'auth.flag.clone.strategy';
+    const cloneName = 'auth.flag.clone.strategy.copy';
+    const role = await db.stores.roleStore.getRoleByName(RoleName.EDITOR);
+
+    await app.services.featureToggleService.createFeatureToggle(
+        'default',
+        { name },
+        TEST_AUDIT_USER,
+        true,
+    );
+    await app.services.featureToggleService.createStrategy(
+        {
+            name: 'flexibleRollout',
+            parameters: {
+                groupId: name,
+            },
+        },
+        {
+            projectId: 'default',
+            featureName: name,
+            environment: DEFAULT_ENV,
+        },
+        TEST_AUDIT_USER,
+    );
+    await app.services.userService.createUser(
+        {
+            email,
+            rootRole: RoleName.EDITOR,
+        },
+        TEST_AUDIT_USER,
+    );
+
+    await db.stores.accessStore.removePermissionFromRole(
+        role.id,
+        CREATE_FEATURE_STRATEGY,
+        DEFAULT_ENV,
+    );
+
+    try {
+        await app.request.post('/auth/demo/login').send({
+            email,
+        });
+
+        await app.request
+            .post(`${url}/${name}/clone`)
+            .send({ name: cloneName })
+            .expect(403);
+    } finally {
+        await db.stores.accessStore.addPermissionsToRole(
+            role.id,
+            [CREATE_FEATURE_STRATEGY],
+            DEFAULT_ENV,
+        );
+    }
+});
+
+test('Should not be possible to clone feature flag variants without UPDATE_FEATURE_ENVIRONMENT_VARIANTS permission', async () => {
+    const email = 'user35@mail.com';
+    const url = '/api/admin/projects/default/features';
+    const name = 'auth.flag.clone.variants';
+    const cloneName = 'auth.flag.clone.variants.copy';
+    const role = await db.stores.roleStore.getRoleByName(RoleName.EDITOR);
+
+    await app.services.featureToggleService.createFeatureToggle(
+        'default',
+        {
+            name,
+            variants: [
+                {
+                    name: 'variant-a',
+                    weight: 1000,
+                    weightType: WeightType.FIX,
+                    stickiness: 'default',
+                },
+            ],
+        },
+        TEST_AUDIT_USER,
+        true,
+    );
+    await app.services.userService.createUser(
+        {
+            email,
+            rootRole: RoleName.EDITOR,
+        },
+        TEST_AUDIT_USER,
+    );
+
+    await db.stores.accessStore.removePermissionFromRole(
+        role.id,
+        UPDATE_FEATURE_ENVIRONMENT_VARIANTS,
+        DEFAULT_ENV,
+    );
+
+    try {
+        await app.request.post('/auth/demo/login').send({
+            email,
+        });
+
+        await app.request
+            .post(`${url}/${name}/clone`)
+            .send({ name: cloneName })
+            .expect(403);
+    } finally {
+        await db.stores.accessStore.addPermissionsToRole(
+            role.id,
+            [UPDATE_FEATURE_ENVIRONMENT_VARIANTS],
+            DEFAULT_ENV,
+        );
+    }
 });
 
 test('Should read flag creator and collaborators', async () => {


### PR DESCRIPTION
This allows the backend to reject clone feature operations if that operation would require cloning a sub property that has alternative permissions and the cloning user lacks those permissions. In practice that's basically just strategies but legacy variants can be affected as well.

Ideally this would be reflected on the UI but to do that properly requires some thoughtful UX design and this is being raised as a security vulnerability so quick patch first, thoughtful UX later