### PR TITLE
connect sdk click on an open header should expand next step if it's enabled

### DIFF
--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
@@ -206,6 +206,19 @@ const InnerDialog = ({
 
     const complete = currentStep >= steps.length && sdk;
 
+    const handleStepExpand = (stepIndex: number) => {
+        const nextStep = stepIndex + 1;
+        if (
+            expandedStep === stepIndex &&
+            nextStep < steps.length &&
+            nextStep <= currentStep
+        ) {
+            setExpandedStep(nextStep);
+        } else if (expandedStep !== stepIndex) {
+            setExpandedStep(stepIndex);
+        }
+    };
+
     return (
         <StyledDialog open onClose={onClose}>
             <DialogHeader onClose={onClose} />
@@ -223,18 +236,7 @@ const InnerDialog = ({
                                 isExpanded={expandedStep === index}
                                 isCompleted={isCompleted}
                                 isDisabled={isDisabled}
-                                onExpand={() => {
-                                    const nextStep = index + 1;
-                                    if (
-                                        expandedStep === index &&
-                                        nextStep < steps.length &&
-                                        nextStep <= currentStep
-                                    ) {
-                                        setExpandedStep(nextStep);
-                                    } else {
-                                        setExpandedStep(index);
-                                    }
-                                }}
+                                onExpand={() => handleStepExpand(index)}
                                 summary={isCompleted && summary}
                             >
                                 {content}

--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
@@ -223,7 +223,18 @@ const InnerDialog = ({
                                 isExpanded={expandedStep === index}
                                 isCompleted={isCompleted}
                                 isDisabled={isDisabled}
-                                onExpand={() => setExpandedStep(index)}
+                                onExpand={() => {
+                                    const nextStep = index + 1;
+                                    if (
+                                        expandedStep === index &&
+                                        nextStep < steps.length &&
+                                        nextStep <= currentStep
+                                    ) {
+                                        setExpandedStep(nextStep);
+                                    } else {
+                                        setExpandedStep(index);
+                                    }
+                                }}
                                 summary={isCompleted && summary}
                             >
                                 {content}


### PR DESCRIPTION
Make UX of going back to previous steps a LOT nicer. 