### PR TITLE
chore: connect sdk full page hight

### DIFF
--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
@@ -23,6 +23,7 @@ const StyledDialog = styled(Dialog)(({ theme }) => ({
         borderRadius: theme.shape.borderRadiusLarge,
         maxWidth: theme.spacing(170),
         width: '100%',
+        height: '100%',
         overflow: 'hidden',
         display: 'flex',
         flexDirection: 'column',


### PR DESCRIPTION
full page height as requested by design

it's pretty good and the only step when it's a little funny is the middle one, but IMHO it's still OK. 

<img width="1402" height="949" alt="Screenshot 2026-05-14 at 11 43 42" src="https://github.com/user-attachments/assets/8a8041fa-0684-40ea-9298-a8173873ee0f" />
