### PR TITLE
chore: fix connect SDK button only enabled if allowed

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
@@ -50,6 +50,7 @@ export const FeatureConnectSdkBanner = ({
                     onClick={onConnectSdkClick}
                     permission={[UPDATE_PROJECT, CREATE_PROJECT_API_TOKEN]}
                     projectId={projectId}
+                    sx={{ alignSelf: 'auto' }}
                 >
                     Connect SDK
                 </PermissionButton>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
@@ -41,6 +41,7 @@ export const FeatureConnectSdkBanner = ({
                 description='You must connect an SDK to the project before you can implement this flag in your code.'
                 buttonLabel='Connect SDK'
                 onButtonClick={onConnectSdkClick}
+                projectId={projectId}
             />
             <ConnectSdkDialog
                 open={connectSdkOpen}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
@@ -3,6 +3,11 @@ import { ConnectSdkDialog } from 'component/onboarding/dialog/ConnectSdkDialog';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { FeatureFlagSetupBannerCard } from './FeatureFlagSetupBannerCard.tsx';
+import PermissionButton from 'component/common/PermissionButton/PermissionButton';
+import {
+    UPDATE_PROJECT,
+    CREATE_PROJECT_API_TOKEN,
+} from 'component/providers/AccessProvider/permissions';
 
 interface FeatureConnectSdkBannerProps {
     projectId: string;
@@ -39,10 +44,16 @@ export const FeatureConnectSdkBanner = ({
             <FeatureFlagSetupBannerCard
                 title='Connect SDK'
                 description='You must connect an SDK to the project before you can implement this flag in your code.'
-                buttonLabel='Connect SDK'
-                onButtonClick={onConnectSdkClick}
-                projectId={projectId}
-            />
+            >
+                <PermissionButton
+                    variant='contained'
+                    onClick={onConnectSdkClick}
+                    permission={[UPDATE_PROJECT, CREATE_PROJECT_API_TOKEN]}
+                    projectId={projectId}
+                >
+                    Connect SDK
+                </PermissionButton>
+            </FeatureFlagSetupBannerCard>
             <ConnectSdkDialog
                 open={connectSdkOpen}
                 onClose={() => setConnectSdkOpen(false)}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureFlagSetupBannerCard.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureFlagSetupBannerCard.tsx
@@ -1,6 +1,11 @@
 import type { ReactNode } from 'react';
-import { Button, styled, Typography } from '@mui/material';
+import { styled, Typography } from '@mui/material';
 import CodeIcon from '@mui/icons-material/Code';
+import PermissionButton from 'component/common/PermissionButton/PermissionButton';
+import {
+    UPDATE_PROJECT,
+    CREATE_PROJECT_API_TOKEN,
+} from 'component/providers/AccessProvider/permissions';
 
 const BannerCard = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -63,6 +68,7 @@ interface FeatureFlagSetupBannerCardProps {
     description: ReactNode;
     buttonLabel: string;
     onButtonClick: () => void;
+    projectId: string;
 }
 
 export const FeatureFlagSetupBannerCard = ({
@@ -70,6 +76,7 @@ export const FeatureFlagSetupBannerCard = ({
     description,
     buttonLabel,
     onButtonClick,
+    projectId,
 }: FeatureFlagSetupBannerCardProps) => (
     <BannerCard>
         <IconBox>
@@ -108,9 +115,15 @@ export const FeatureFlagSetupBannerCard = ({
                     {description}
                 </Typography>
             </TextContainer>
-            <Button variant='contained' onClick={onButtonClick}>
+            <PermissionButton
+                variant='contained'
+                onClick={onButtonClick}
+                permission={[UPDATE_PROJECT, CREATE_PROJECT_API_TOKEN]}
+                projectId={projectId}
+                sx={{ alignSelf: 'auto' }}
+            >
                 {buttonLabel}
-            </Button>
+            </PermissionButton>
         </ContentRow>
     </BannerCard>
 );

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureFlagSetupBannerCard.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureFlagSetupBannerCard.tsx
@@ -1,11 +1,6 @@
 import type { ReactNode } from 'react';
 import { styled, Typography } from '@mui/material';
 import CodeIcon from '@mui/icons-material/Code';
-import PermissionButton from 'component/common/PermissionButton/PermissionButton';
-import {
-    UPDATE_PROJECT,
-    CREATE_PROJECT_API_TOKEN,
-} from 'component/providers/AccessProvider/permissions';
 
 const BannerCard = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -66,17 +61,13 @@ const PendingDot = styled('span')(({ theme }) => ({
 interface FeatureFlagSetupBannerCardProps {
     title: string;
     description: ReactNode;
-    buttonLabel: string;
-    onButtonClick: () => void;
-    projectId: string;
+    children: ReactNode;
 }
 
 export const FeatureFlagSetupBannerCard = ({
     title,
     description,
-    buttonLabel,
-    onButtonClick,
-    projectId,
+    children,
 }: FeatureFlagSetupBannerCardProps) => (
     <BannerCard>
         <IconBox>
@@ -115,15 +106,7 @@ export const FeatureFlagSetupBannerCard = ({
                     {description}
                 </Typography>
             </TextContainer>
-            <PermissionButton
-                variant='contained'
-                onClick={onButtonClick}
-                permission={[UPDATE_PROJECT, CREATE_PROJECT_API_TOKEN]}
-                projectId={projectId}
-                sx={{ alignSelf: 'auto' }}
-            >
-                {buttonLabel}
-            </PermissionButton>
+            {children}
         </ContentRow>
     </BannerCard>
 );

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Button } from '@mui/material';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
 import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
@@ -44,9 +45,11 @@ export const FeatureImplementFlagBanner = ({
                 <FeatureFlagSetupBannerCard
                     title='Implement your flag'
                     description='Waiting for flag evaluations. Wrap your feature logic in a flag evaluation to get set up.'
-                    buttonLabel='Wrap your code'
-                    onButtonClick={onImplementClick}
-                />
+                >
+                    <Button variant='contained' onClick={onImplementClick}>
+                        Wrap your code
+                    </Button>
+                </FeatureFlagSetupBannerCard>
             )}
             <ImplementFlagDialog
                 open={dialogOpen}


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-513/featureconnectsdkbanner-button-should-be-disabled-if-you-dont-have-the

Fixes a bug where the new "Connect SDK" suggestion at the top of the flag page would be enabled if you didn't have the required permissions.

<img width="1379" height="530" alt="image" src="https://github.com/user-attachments/assets/6b50ca21-46bf-4024-8731-e467db8bb38e" />
