### PR TITLE
dev: VScode used wrong TypeScrcip version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "editor.defaultFormatter": "biomejs.biome"
+  "editor.defaultFormatter": "biomejs.biome",
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
I got weird errors in VSCode today. 

like: `This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.ts(2875) in VSCode mean - it's not showing up in build` 

Fixing it requires picking TypeScript version "Use Workspace Version" and that changes shared `.vscode/settings.json` 