### PR TITLE
chore: add `newProjectList` feature flag

### DIFF
--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -97,6 +97,7 @@ export type UiFlags = {
     accessOverviewRework?: boolean;
     onboardingConnectSDKNewDialog?: boolean;
     logRocketEnabled?: boolean;
+    newProjectList?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -79,7 +79,8 @@ export type IFlagKey =
     | 'externalImpactMetrics'
     | 'accessOverviewRework'
     | 'onboardingConnectSDKNewDialog'
-    | 'logRocketEnabled';
+    | 'logRocketEnabled'
+    | 'newProjectList';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -360,6 +361,10 @@ const flags: IFlags = {
     ),
     logRocketEnabled: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_LOGROCKET_ENABLED,
+        false,
+    ),
+    newProjectList: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_NEW_PROJECT_LIST,
         false,
     ),
 };


### PR DESCRIPTION
Adds a `newProjectList` feature flag which will be used in a follow up PR to determine wether a user should see the the 'old' (`LegacyProjectCard`) project card or the redesigned one. 