### PR TITLE
chore: fix bugs where connect sdk dialog disappeared when connected, or set to step 2 by mistake

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
@@ -22,13 +22,6 @@ export const FeatureConnectSdkBanner = ({
     const { trackEvent } = usePlausibleTracker();
     const [connectSdkOpen, setConnectSdkOpen] = useState(false);
 
-    if (
-        project.onboardingStatus.status === 'onboarded' ||
-        project.onboardingStatus.status === 'sdk-connected'
-    ) {
-        return null;
-    }
-
     const environments =
         project.environments?.map((env) => env.environment) ?? [];
 
@@ -39,22 +32,28 @@ export const FeatureConnectSdkBanner = ({
         setConnectSdkOpen(true);
     };
 
+    const shouldShowBanner =
+        project.onboardingStatus.status !== 'onboarded' &&
+        project.onboardingStatus.status !== 'sdk-connected';
+
     return (
         <>
-            <FeatureFlagSetupBannerCard
-                title='Connect SDK'
-                description='You must connect an SDK to the project before you can implement this flag in your code.'
-            >
-                <PermissionButton
-                    variant='contained'
-                    onClick={onConnectSdkClick}
-                    permission={[UPDATE_PROJECT, CREATE_PROJECT_API_TOKEN]}
-                    projectId={projectId}
-                    sx={{ alignSelf: 'auto' }}
+            {shouldShowBanner && (
+                <FeatureFlagSetupBannerCard
+                    title='Connect SDK'
+                    description='You must connect an SDK to the project before you can implement this flag in your code.'
                 >
-                    Connect SDK
-                </PermissionButton>
-            </FeatureFlagSetupBannerCard>
+                    <PermissionButton
+                        variant='contained'
+                        onClick={onConnectSdkClick}
+                        permission={[UPDATE_PROJECT, CREATE_PROJECT_API_TOKEN]}
+                        projectId={projectId}
+                        sx={{ alignSelf: 'auto' }}
+                    >
+                        Connect SDK
+                    </PermissionButton>
+                </FeatureFlagSetupBannerCard>
+            )}
             <ConnectSdkDialog
                 open={connectSdkOpen}
                 onClose={() => setConnectSdkOpen(false)}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
@@ -18,7 +18,7 @@ export const FeatureConnectSdkBanner = ({
     projectId,
     featureId,
 }: FeatureConnectSdkBannerProps) => {
-    const { project } = useProjectOverview(projectId);
+    const { project, refetch } = useProjectOverview(projectId);
     const { trackEvent } = usePlausibleTracker();
     const [connectSdkOpen, setConnectSdkOpen] = useState(false);
 
@@ -35,6 +35,11 @@ export const FeatureConnectSdkBanner = ({
     const shouldShowBanner =
         project.onboardingStatus.status !== 'onboarded' &&
         project.onboardingStatus.status !== 'sdk-connected';
+
+    const onDialogClose = () => {
+        setConnectSdkOpen(false);
+        refetch();
+    };
 
     return (
         <>
@@ -56,8 +61,8 @@ export const FeatureConnectSdkBanner = ({
             )}
             <ConnectSdkDialog
                 open={connectSdkOpen}
-                onClose={() => setConnectSdkOpen(false)}
-                onFinish={() => setConnectSdkOpen(false)}
+                onClose={onDialogClose}
+                onFinish={onDialogClose}
                 project={projectId}
                 environments={environments}
                 feature={featureId}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureConnectSdkBanner.tsx
@@ -32,14 +32,14 @@ export const FeatureConnectSdkBanner = ({
         setConnectSdkOpen(true);
     };
 
-    const shouldShowBanner =
-        project.onboardingStatus.status !== 'onboarded' &&
-        project.onboardingStatus.status !== 'sdk-connected';
-
     const onDialogClose = () => {
         setConnectSdkOpen(false);
         refetch();
     };
+
+    const shouldShowBanner =
+        project.onboardingStatus.status !== 'onboarded' &&
+        project.onboardingStatus.status !== 'sdk-connected';
 
     return (
         <>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
@@ -15,8 +15,11 @@ export const FeatureImplementFlagBanner = ({
     projectId,
     featureId,
 }: FeatureImplementFlagBannerProps) => {
-    const { project } = useProjectOverview(projectId);
-    const { feature, loading } = useFeature(projectId, featureId);
+    const { project, refetch } = useProjectOverview(projectId);
+    const { feature, loading, refetchFeature } = useFeature(
+        projectId,
+        featureId,
+    );
     const { trackEvent } = usePlausibleTracker();
     const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -28,15 +31,17 @@ export const FeatureImplementFlagBanner = ({
         (!feature.lifecycle || feature.lifecycle.stage === 'initial');
     const showBanner = isOnboarded && isInitialStage;
 
-    if (!showBanner && !dialogOpen) {
-        return null;
-    }
-
     const onImplementClick = () => {
         trackEvent('onboarding', {
             props: { eventType: 'flag-implement-clicked' },
         });
         setDialogOpen(true);
+    };
+
+    const onDialogClose = () => {
+        setDialogOpen(false);
+        refetch();
+        refetchFeature();
     };
 
     return (
@@ -53,7 +58,7 @@ export const FeatureImplementFlagBanner = ({
             )}
             <ImplementFlagDialog
                 open={dialogOpen}
-                onClose={() => setDialogOpen(false)}
+                onClose={onDialogClose}
                 projectId={projectId}
                 feature={featureId}
             />

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureImplementFlagBanner.tsx
@@ -29,7 +29,12 @@ export const FeatureImplementFlagBanner = ({
     const isInitialStage =
         !loading &&
         (!feature.lifecycle || feature.lifecycle.stage === 'initial');
-    const showBanner = isOnboarded && isInitialStage;
+
+    const onDialogClose = () => {
+        setDialogOpen(false);
+        refetch();
+        refetchFeature();
+    };
 
     const onImplementClick = () => {
         trackEvent('onboarding', {
@@ -38,11 +43,7 @@ export const FeatureImplementFlagBanner = ({
         setDialogOpen(true);
     };
 
-    const onDialogClose = () => {
-        setDialogOpen(false);
-        refetch();
-        refetchFeature();
-    };
+    const showBanner = isOnboarded && isInitialStage;
 
     return (
         <>

--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
@@ -158,7 +158,7 @@ const InnerDialog = ({
     };
 
     const onApiKeyChange = (apiKey?: string) => {
-        if (!apiKey) {
+        if (!apiKey && sdk) {
             setCurrentStep(1);
         }
         setApiKey(apiKey);


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-529/connect-sdk-dialog-should-not-disappear-when-one-feature-flag-page

Fixes 4 bugs related to the onboarding flow:
 - Connect SDK dialog disappeared when connected if opened through the flag page banner
 - Connect SDK dialog current step was set to 2 (Generate API key) even if we didn't select the SDK yet
 - Connect SDK flag page banner did not correctly go away once we were done with the Connect SDK step
 - Wrap flag banner did not correctly go away once we were done with the Wrap flag step