### PR TITLE
fix: override correct MUI class for Enterprise Edge alert

### DIFF
--- a/frontend/src/component/admin/enterprise-edge/EnterpriseEdgeDismissibleAlert.tsx
+++ b/frontend/src/component/admin/enterprise-edge/EnterpriseEdgeDismissibleAlert.tsx
@@ -23,7 +23,7 @@ const StyledAlert = styled(Alert)(({ theme }) => ({
         width: '100%',
         gap: theme.spacing(1),
     },
-    '&.MuiAlert-standard.MuiAlert-colorSuccess': {
+    '&.MuiAlert-standard.MuiAlert-colorInfo': {
         backgroundColor: theme.palette.secondary.light,
         color: theme.palette.text.primary,
         border: `1px solid ${theme.palette.secondary.border}`,
@@ -76,6 +76,7 @@ export const EnterpriseEdgeDismissibleAlert = ({
     return (
         <Collapse in={alertState === 'open'}>
             <StyledAlert
+                severity='info'
                 onClose={() => setAlertState('closed')}
                 icon={false}
                 {...props}

--- a/frontend/src/component/admin/enterprise-edge/EnterpriseEdgeDismissibleAlert.tsx
+++ b/frontend/src/component/admin/enterprise-edge/EnterpriseEdgeDismissibleAlert.tsx
@@ -23,7 +23,7 @@ const StyledAlert = styled(Alert)(({ theme }) => ({
         width: '100%',
         gap: theme.spacing(1),
     },
-    '&.MuiPaper-root': {
+    '&.MuiAlert-standard.MuiAlert-colorSuccess': {
         backgroundColor: theme.palette.secondary.light,
         color: theme.palette.text.primary,
         border: `1px solid ${theme.palette.secondary.border}`,


### PR DESCRIPTION
After the MUI upgrade to v9, the Enterprise Edge banner changed color from purple to green. This is due to the fact that the style override was targeting the wrong class (`&.MuiPaper-root` override stopped winning after v9). 
This makes it look purple again.

Before: 
<img width="1079" height="375" alt="Screenshot 2026-05-18 at 14 58 58" src="https://github.com/user-attachments/assets/27657c38-a019-48dc-9b34-3ecd19057e03" />
<img width="1079" height="375" alt="Screenshot 2026-05-18 at 14 59 55" src="https://github.com/user-attachments/assets/c6060d1a-d814-4b7c-8458-b57ae21e8d8b" />

After:
<img width="1079" height="375" alt="Screenshot 2026-05-18 at 14 59 06" src="https://github.com/user-attachments/assets/5c2b21b5-0995-42b5-a611-58cad912cea1" />
<img width="1079" height="375" alt="Screenshot 2026-05-18 at 15 00 06" src="https://github.com/user-attachments/assets/985b5e10-227a-4d64-bee4-52b9d116085b" />

