### PR TITLE
fix: rendering error in integrations form

### DIFF
--- a/frontend/src/component/integrations/IntegrationForm/IntegrationParameters/IntegrationParameter/IntegrationParameterTextField.tsx
+++ b/frontend/src/component/integrations/IntegrationForm/IntegrationParameters/IntegrationParameter/IntegrationParameterTextField.tsx
@@ -60,6 +60,9 @@ export const IntegrationParameterTextField = ({
                 inputLabel: {
                     shrink: true,
                 },
+                formHelperText: {
+                    component: 'div',
+                },
             }}
             value={value}
             error={Boolean(error)}


### PR DESCRIPTION
Bumped into a runtime error while testing integrations:

<img width="829" height="572" alt="image" src="https://github.com/user-attachments/assets/409aa0b0-3694-4931-873c-5930e7854282" />

It seems that the `helperText` in MUI's `TextField` renders via `FormHelperText` which is a `<p>` by default. But, `<Markdown>` inside it wraps content in another `<p>`, causing the nesting violation.

**The fix** : tell `FormHelperText` to render as a `<div>` instead via `slotProps`
