### PR TITLE
chore: restructure `NewProjectCard` layout + add `NewProjectCardFooter`

### DIFF
--- a/frontend/src/component/project/ProjectCard/NewProjectCard.tsx
+++ b/frontend/src/component/project/ProjectCard/NewProjectCard.tsx
@@ -3,15 +3,13 @@ import {
     StyledProjectCard,
     StyledProjectCardBody,
     StyledProjectCardHeader,
-    StyledProjectCardContent,
     StyledProjectCardTitleContainer,
+    StyledProjectCardContent,
 } from './ProjectCard.styles';
-import { ProjectCardFooter } from './ProjectCardFooter/ProjectCardFooter.tsx';
+import { NewProjectCardFooter } from './NewProjectCardFooter.tsx';
 import { ProjectModeBadge } from './ProjectModeBadge/ProjectModeBadge.tsx';
 import { FavoriteAction } from './FavoriteAction/FavoriteAction.tsx';
 import { styled } from '@mui/material';
-import { TimeAgo } from 'component/common/TimeAgo/TimeAgo';
-import { ProjectLastSeen } from './ProjectLastSeen/ProjectLastSeen.tsx';
 import { Highlighter } from 'component/common/Highlighter/Highlighter';
 import { useSearchHighlightContext } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { ProjectMembers } from './ProjectCardFooter/ProjectMembers/ProjectMembers.tsx';
@@ -19,16 +17,22 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 import { DEFAULT_PROJECT_ID } from 'hooks/api/getters/useDefaultProject/useDefaultProjectId';
 import type { ProjectSchema } from 'openapi';
 import { Truncator } from 'component/common/Truncator/Truncator.tsx';
+import { ProjectLastSeen } from './ProjectLastSeen/ProjectLastSeen.tsx';
 
 const StyledSubtitle = styled('span')(({ theme }) => ({
     color: theme.palette.text.secondary,
     fontSize: theme.fontSizes.smallerBody,
 }));
 
+const StyledNewProjectCardContent = styled(StyledProjectCardContent)(
+    ({ theme }) => ({
+        marginTop: theme.spacing(2),
+    }),
+);
+
 export const NewProjectCard = ({
     name,
     featureCount,
-    technicalDebt,
     memberCount = 0,
     id,
     mode,
@@ -54,37 +58,31 @@ export const NewProjectCard = ({
                                 {name}
                             </Highlighter>
                         </Truncator>
-                        <StyledSubtitle>
-                            Updated{' '}
-                            <TimeAgo date={lastUpdatedAt || createdAt} />
+                        <StyledSubtitle data-loading>
+                            {featureCount === 1
+                                ? `${featureCount} flag`
+                                : `${featureCount} flags`}
                         </StyledSubtitle>
                     </StyledProjectCardTitleContainer>
                     <ProjectModeBadge mode={mode} />
                     <FavoriteAction id={id} isFavorite={favorite} />
                 </StyledProjectCardHeader>
-                <div>
-                    <StyledProjectCardContent>
-                        <div data-loading>
-                            <strong>{featureCount}</strong> flag
-                            {featureCount === 1 ? '' : 's'}
-                        </div>
-                    </StyledProjectCardContent>
-                    <StyledProjectCardContent>
-                        <div data-loading>
-                            <strong>{technicalDebt}%</strong> technical debt
-                        </div>
-                        <div data-loading>
-                            <ProjectLastSeen date={lastReportedFlagUsage} />
-                        </div>
-                    </StyledProjectCardContent>
-                </div>
+                <StyledNewProjectCardContent>
+                    <div data-loading>
+                        <ProjectLastSeen date={lastReportedFlagUsage} />
+                    </div>
+                </StyledNewProjectCardContent>
             </StyledProjectCardBody>
-            <ProjectCardFooter id={id} owners={owners}>
+            <NewProjectCardFooter
+                owners={owners}
+                lastUpdatedAt={lastUpdatedAt}
+                createdAt={createdAt}
+            >
                 <ConditionallyRender
                     condition={id !== DEFAULT_PROJECT_ID}
                     show={<ProjectMembers count={memberCount} members={[]} />}
                 />
-            </ProjectCardFooter>
+            </NewProjectCardFooter>
         </StyledProjectCard>
     );
 };

--- a/frontend/src/component/project/ProjectCard/NewProjectCard.tsx
+++ b/frontend/src/component/project/ProjectCard/NewProjectCard.tsx
@@ -24,11 +24,9 @@ const StyledSubtitle = styled('span')(({ theme }) => ({
     fontSize: theme.fontSizes.smallerBody,
 }));
 
-const StyledNewProjectCardContent = styled(StyledProjectCardContent)(
-    ({ theme }) => ({
-        marginTop: theme.spacing(2),
-    }),
-);
+const StyledNewProjectCard = styled(StyledProjectCard)(({ theme }) => ({
+    minHeight: theme.spacing(23),
+}));
 
 export const NewProjectCard = ({
     name,
@@ -45,7 +43,7 @@ export const NewProjectCard = ({
     const { searchQuery } = useSearchHighlightContext();
 
     return (
-        <StyledProjectCard>
+        <StyledNewProjectCard>
             <StyledProjectCardBody>
                 <StyledProjectCardHeader>
                     <StyledProjectCardTitleContainer data-loading>
@@ -67,11 +65,11 @@ export const NewProjectCard = ({
                     <ProjectModeBadge mode={mode} />
                     <FavoriteAction id={id} isFavorite={favorite} />
                 </StyledProjectCardHeader>
-                <StyledNewProjectCardContent>
+                <StyledProjectCardContent>
                     <div data-loading>
                         <ProjectLastSeen date={lastReportedFlagUsage} />
                     </div>
-                </StyledNewProjectCardContent>
+                </StyledProjectCardContent>
             </StyledProjectCardBody>
             <NewProjectCardFooter
                 owners={owners}
@@ -83,6 +81,6 @@ export const NewProjectCard = ({
                     show={<ProjectMembers count={memberCount} members={[]} />}
                 />
             </NewProjectCardFooter>
-        </StyledProjectCard>
+        </StyledNewProjectCard>
     );
 };

--- a/frontend/src/component/project/ProjectCard/NewProjectCardFooter.tsx
+++ b/frontend/src/component/project/ProjectCard/NewProjectCardFooter.tsx
@@ -50,7 +50,7 @@ export const NewProjectCardFooter = ({
         <StyledFooter>
             {lastUpdatedAt ? (
                 <StyledSubtitle>
-                    Last updated <TimeAgo date={lastUpdatedAt} />
+                    Updated <TimeAgo date={lastUpdatedAt} />
                 </StyledSubtitle>
             ) : createdAt ? (
                 <StyledSubtitle>

--- a/frontend/src/component/project/ProjectCard/NewProjectCardFooter.tsx
+++ b/frontend/src/component/project/ProjectCard/NewProjectCardFooter.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from 'react';
+import { Box, styled } from '@mui/material';
+import {
+    ProjectOwners,
+    type IProjectOwnersProps,
+} from './ProjectCardFooter/ProjectOwners/ProjectOwners.tsx';
+import type { ProjectSchemaOwners } from 'openapi';
+import { TimeAgo } from 'component/common/TimeAgo/TimeAgo.tsx';
+
+interface INewProjectCardFooterProps {
+    children?: ReactNode;
+    owners?: IProjectOwnersProps['owners'];
+    lastUpdatedAt?: string | null;
+    createdAt?: string;
+}
+
+const StyledFooter = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    background: theme.palette.background.elevation1,
+    boxShadow: theme.boxShadows.accordionFooter,
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderTop: `1px solid ${theme.palette.divider}`,
+    paddingInline: theme.spacing(2),
+    paddingBlock: theme.spacing(1.5),
+}));
+
+const StyledRightGroup = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+    marginLeft: 'auto',
+}));
+
+const StyledSubtitle = styled('span')(({ theme }) => ({
+    color: theme.palette.text.secondary,
+    fontSize: theme.fontSizes.smallerBody,
+}));
+
+export const NewProjectCardFooter = ({
+    children,
+    owners,
+    lastUpdatedAt,
+    createdAt,
+}: INewProjectCardFooterProps) => {
+    const ownersWithoutSystem = owners?.filter(
+        (owner) => owner.ownerType !== 'system',
+    );
+    return (
+        <StyledFooter>
+            {lastUpdatedAt ? (
+                <StyledSubtitle>
+                    Last updated <TimeAgo date={lastUpdatedAt} />
+                </StyledSubtitle>
+            ) : createdAt ? (
+                <StyledSubtitle>
+                    Created <TimeAgo date={createdAt} />
+                </StyledSubtitle>
+            ) : null}
+            <StyledRightGroup>
+                {ownersWithoutSystem ? (
+                    <ProjectOwners
+                        owners={ownersWithoutSystem as ProjectSchemaOwners}
+                    />
+                ) : null}
+                {children}
+            </StyledRightGroup>
+        </StyledFooter>
+    );
+};


### PR DESCRIPTION
When `newProjectList` is enabled, on a project card (in `/projects`): 
- Removes "technical debt" section
- Moves number of flags as a subtitle under the project name
- Moves "Updated ..." to the bottom footer 
- Adds a minHeight to the card to add a bit of room between the subtitle and the "Last seen" section 
- Adds a  `NewProjectCardFooter`:
  - Date label (now reads "Updated ..." or "Created ..." depending on which date is available) on the left
  - Owner avatars anchored to the right (doesn't look great right now, but the component is going to be changed later as part of the redesign)
  - Members count rendered alongside the avatars on the right (to be removed soon)
  
FF `newProjectList` enabled:  

<img width="1079" height="636" alt="Screenshot 2026-05-19 at 10 31 10" src="https://github.com/user-attachments/assets/133700b5-0b54-412f-858f-01fc9f731dca" />


FF not enabled: 

<img width="1079" height="636" alt="Screenshot 2026-05-18 at 17 26 32" src="https://github.com/user-attachments/assets/b4533db7-f1ef-42fe-adda-01dbd6994bc3" />
