### PR TITLE
refactor: phase 2 of react-table v7 -> v8 migration

### DIFF
--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -18,7 +18,7 @@ import {
     type CommandResultGroupItem,
 } from './RecentlyVisited/CommandResultGroup.tsx';
 import { CommandPageSuggestions } from './CommandPageSuggestions.tsx';
-import { useAsyncDebounce } from 'react-table';
+import { useDebouncedCallback } from 'hooks/useDebouncedCallback';
 import useProjects from 'hooks/api/getters/useProjects/useProjects';
 import {
     type CommandQueryCounter,
@@ -107,7 +107,9 @@ export const CommandBar = () => {
     const searchContainerRef = useRef<HTMLInputElement>(null);
     const [showSuggestions, setShowSuggestions] = useState(false);
     const [searchLoading, setSearchLoading] = useState(false);
-    const [searchString, setSearchString] = useState(undefined);
+    const [searchString, setSearchString] = useState<string | undefined>(
+        undefined,
+    );
     const [searchedProjects, setSearchedProjects] = useState<
         CommandResultGroupItem[]
     >([]);
@@ -126,7 +128,7 @@ export const CommandBar = () => {
 
     const { projects } = useProjects();
 
-    const debouncedSetSearchState = useAsyncDebounce((query) => {
+    const debouncedSetSearchState = useDebouncedCallback((query: string) => {
         setSearchString(query);
 
         const filteredProjects = projects.filter((project) =>

--- a/frontend/src/component/common/Search/Search.tsx
+++ b/frontend/src/component/common/Search/Search.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
-import { useAsyncDebounce } from 'react-table';
+import { useDebouncedCallback } from 'hooks/useDebouncedCallback';
 import {
     Box,
     IconButton,
@@ -124,7 +124,7 @@ export const Search = ({
     const { savedQuery, setSavedQuery } = useSavedQuery(id);
 
     const [value, setValue] = useState<string>(initialValue);
-    const debouncedOnChange = useAsyncDebounce(onChange, debounceTime);
+    const debouncedOnChange = useDebouncedCallback(onChange, debounceTime);
 
     const onSearchChange = (value: string) => {
         debouncedOnChange(value);

--- a/frontend/src/component/common/Table/SortableTableHeader/SortableTableHeaderV8.tsx
+++ b/frontend/src/component/common/Table/SortableTableHeader/SortableTableHeaderV8.tsx
@@ -1,0 +1,63 @@
+import { TableHead, TableRow } from '@mui/material';
+import { flexRender, type Table as TableType } from '@tanstack/react-table';
+import { CellSortable } from './CellSortable/CellSortable.tsx';
+
+export const SortableTableHeaderV8 = <T,>({
+    tableInstance,
+    className,
+    flex,
+}: {
+    tableInstance: TableType<T>;
+    className?: string;
+    flex?: boolean;
+}) => (
+    <TableHead className={className}>
+        {tableInstance.getHeaderGroups().map((headerGroup) => (
+            <TableRow
+                key={headerGroup.id}
+                data-loading
+                style={flex ? { display: 'flex' } : undefined}
+            >
+                {headerGroup.headers.map((header) => {
+                    const column = header.column;
+                    const meta = column.columnDef.meta;
+                    const sortDirection = column.getIsSorted();
+                    const headerDef = column.columnDef.header;
+                    const content = header.isPlaceholder
+                        ? null
+                        : flexRender(headerDef, header.getContext());
+
+                    return (
+                        <CellSortable
+                            key={header.id}
+                            styles={meta?.styles ?? {}}
+                            ariaTitle={
+                                typeof headerDef === 'string'
+                                    ? headerDef
+                                    : undefined
+                            }
+                            isSortable={column.getCanSort()}
+                            isSorted={sortDirection !== false}
+                            isDescending={sortDirection === 'desc'}
+                            onClick={
+                                column.getCanSort()
+                                    ? () => column.toggleSorting()
+                                    : undefined
+                            }
+                            maxWidth={meta?.maxWidth}
+                            minWidth={meta?.minWidth}
+                            width={
+                                meta?.width ?? meta?.maxWidth ?? meta?.minWidth
+                            }
+                            isFlex={flex}
+                            isFlexGrow={Boolean(meta?.minWidth)}
+                            align={meta?.align}
+                        >
+                            {content}
+                        </CellSortable>
+                    );
+                })}
+            </TableRow>
+        ))}
+    </TableHead>
+);

--- a/frontend/src/component/common/Table/VirtualizedTable/VirtualizedTableV8.tsx
+++ b/frontend/src/component/common/Table/VirtualizedTable/VirtualizedTableV8.tsx
@@ -1,0 +1,122 @@
+import { type CSSProperties, type RefObject, useMemo } from 'react';
+import { useTheme, TableBody, TableRow } from '@mui/material';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
+import { TableCell } from 'component/common/Table/TableCell/TableCell';
+import { Table } from 'component/common/Table/Table/Table';
+import { useVirtualizedRange } from 'hooks/useVirtualizedRange';
+import { flexRender, type Table as TableType } from '@tanstack/react-table';
+
+/**
+ * READ BEFORE USE
+ *
+ * Virtualized tables require some setup. With this component all but one
+ * column are fixed width, and one fills remaining space. Set
+ * `meta: { maxWidth }` for static columns and `meta: { minWidth }` on the
+ * one that should grow. v8 has no `useFlexLayout`; layout fields live on
+ * the column's `meta` (see `frontend/src/types/react-table-v8.d.ts`).
+ */
+export const VirtualizedTableV8 = <T,>({
+    rowHeight: rowHeightOverride,
+    tableInstance,
+    parentRef,
+}: {
+    rowHeight?: number;
+    tableInstance: TableType<T>;
+    parentRef?: RefObject<HTMLElement | null>;
+}) => {
+    const theme = useTheme();
+    const rowHeight = useMemo(
+        () => rowHeightOverride || theme.shape.tableRowHeight,
+        [rowHeightOverride, theme.shape.tableRowHeight],
+    );
+
+    const rows = tableInstance.getRowModel().rows;
+
+    const [firstRenderedIndex, lastRenderedIndex] = useVirtualizedRange(
+        rowHeight,
+        40,
+        5,
+        parentRef?.current,
+    );
+
+    const tableHeight = useMemo(
+        () => rowHeight * rows.length + theme.shape.tableRowHeightCompact,
+        [rowHeight, rows.length, theme.shape.tableRowHeightCompact],
+    );
+
+    return (
+        <Table
+            role='table'
+            rowHeight={rowHeight}
+            style={{ height: tableHeight }}
+        >
+            <SortableTableHeaderV8 tableInstance={tableInstance} flex />
+            <TableBody
+                role='rowgroup'
+                sx={{
+                    '& tr': {
+                        position: 'absolute',
+                        width: '100%',
+                        '&:hover': {
+                            '.show-row-hover': {
+                                opacity: 1,
+                            },
+                        },
+                    },
+                    '& tr td': {
+                        alignItems: 'center',
+                        display: 'flex',
+                        flexShrink: 0,
+                        '& > *': {
+                            flexGrow: 1,
+                        },
+                    },
+                }}
+            >
+                {rows.map((row, index) => {
+                    const top =
+                        index * rowHeight + theme.shape.tableRowHeightCompact;
+
+                    const isVirtual =
+                        index < firstRenderedIndex || index > lastRenderedIndex;
+
+                    if (isVirtual) {
+                        return null;
+                    }
+
+                    return (
+                        <TableRow
+                            hover
+                            key={row.id}
+                            style={{ display: 'flex', top }}
+                        >
+                            {row.getVisibleCells().map((cell) => {
+                                const meta = cell.column.columnDef.meta;
+                                const cellStyle: CSSProperties = {
+                                    boxSizing: 'border-box',
+                                    flex: meta?.minWidth
+                                        ? '1 0 auto'
+                                        : undefined,
+                                    minWidth: meta?.minWidth,
+                                    maxWidth: meta?.maxWidth,
+                                    width:
+                                        meta?.width ??
+                                        meta?.maxWidth ??
+                                        meta?.minWidth,
+                                };
+                                return (
+                                    <TableCell key={cell.id} style={cellStyle}>
+                                        {flexRender(
+                                            cell.column.columnDef.cell,
+                                            cell.getContext(),
+                                        )}
+                                    </TableCell>
+                                );
+                            })}
+                        </TableRow>
+                    );
+                })}
+            </TableBody>
+        </Table>
+    );
+};

--- a/frontend/src/component/playground/Playground/PlaygroundEnvironmentTable/PlaygroundEnvironmentDiffTable.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundEnvironmentTable/PlaygroundEnvironmentDiffTable.tsx
@@ -1,13 +1,14 @@
 import { useMemo, useRef } from 'react';
 import {
-    useFlexLayout,
-    useGlobalFilter,
-    useSortBy,
-    useTable,
-} from 'react-table';
+    createColumnHelper,
+    getCoreRowModel,
+    getFilteredRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 
-import { VirtualizedTable } from 'component/common/Table';
-import { sortTypes } from 'utils/sortTypes';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
+import { sortingFns } from 'utils/sortingFns';
 import type { AdvancedPlaygroundFeatureSchemaEnvironments } from 'openapi';
 import { Box } from '@mui/material';
 import { FeatureStatusCell } from '../PlaygroundResultsTable/FeatureStatusCell/FeatureStatusCell.tsx';
@@ -37,62 +38,74 @@ export const PlaygroundEnvironmentDiffTable = ({
     );
     type RowType = (typeof data)[0];
 
-    const contextFieldsHeaders = Object.keys(firstContext).map(
-        (contextField) => ({
-            Header: capitalizeFirst(contextField),
-            accessor: (
-                row: Record<string, { context: Record<string, unknown> }>,
-            ) => row[environments[0]].context[contextField],
-            minWidth: 160,
-            Cell: HighlightCell,
-        }),
-    );
+    const columnHelper = createColumnHelper<RowType>();
 
-    const environmentHeaders = environments.map((environment) => ({
-        Header: environment,
-        accessor: (row: RowType) =>
-            row[environment]?.isEnabled
-                ? 'true'
-                : row[environment]?.strategies?.result === 'unknown'
-                  ? 'unknown'
-                  : 'false',
-        Cell: ({ row }: { row: { original: RowType } }) => {
-            return (
-                <Box sx={{ display: 'flex' }}>
-                    <FeatureStatusCell feature={row.original[environment]} />
-                    <FeatureResultInfoPopoverCell
-                        feature={row.original[environment]}
-                        input={{
-                            environment: row.original[environment].environment,
-                            context: row.original[environment].context,
-                        }}
-                    />
-                </Box>
-            );
-        },
-        sortType: 'playgroundResultState',
-        maxWidth: 140,
-    }));
+    const columns = useMemo(() => {
+        const contextColumns = Object.keys(firstContext).map((contextField) =>
+            columnHelper.accessor(
+                (row) =>
+                    (
+                        row[environments[0]] as {
+                            context: Record<string, unknown>;
+                        }
+                    ).context[contextField],
+                {
+                    id: `context_${contextField}`,
+                    header: capitalizeFirst(contextField),
+                    cell: ({ getValue }) => (
+                        <HighlightCell value={String(getValue() ?? '')} />
+                    ),
+                    meta: { minWidth: 160 },
+                },
+            ),
+        );
 
-    const COLUMNS = useMemo(() => {
-        return [...contextFieldsHeaders, ...environmentHeaders];
+        const environmentColumns = environments.map((environment) =>
+            columnHelper.accessor(
+                (row) =>
+                    row[environment]?.isEnabled
+                        ? 'true'
+                        : row[environment]?.strategies?.result === 'unknown'
+                          ? 'unknown'
+                          : 'false',
+                {
+                    id: environment,
+                    header: environment,
+                    cell: ({ row }) => (
+                        <Box sx={{ display: 'flex' }}>
+                            <FeatureStatusCell
+                                feature={row.original[environment]}
+                            />
+                            <FeatureResultInfoPopoverCell
+                                feature={row.original[environment]}
+                                input={{
+                                    environment:
+                                        row.original[environment].environment,
+                                    context: row.original[environment].context,
+                                }}
+                            />
+                        </Box>
+                    ),
+                    sortingFn: sortingFns.playgroundResultState,
+                    meta: { maxWidth: 140 },
+                },
+            ),
+        );
+
+        return [...contextColumns, ...environmentColumns];
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const { headerGroups, rows, prepareRow } = useTable(
-        {
-            columns: COLUMNS as any[],
-            data,
-            sortTypes,
-            autoResetGlobalFilter: false,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-        },
-        useGlobalFilter,
-        useFlexLayout,
-        useSortBy,
-    );
+    const table = useReactTable({
+        columns,
+        data,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
     const parentRef = useRef<HTMLElement | null>(null);
 
@@ -104,12 +117,7 @@ export const PlaygroundEnvironmentDiffTable = ({
                 maxHeight: '800px',
             }}
         >
-            <VirtualizedTable
-                parentRef={parentRef}
-                rows={rows}
-                headerGroups={headerGroups}
-                prepareRow={prepareRow}
-            />
+            <VirtualizedTableV8 parentRef={parentRef} tableInstance={table} />
         </Box>
     );
 };

--- a/frontend/src/hooks/useDebouncedCallback.ts
+++ b/frontend/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,25 @@
+import { useEffect, useMemo, useRef } from 'react';
+import debounce from 'debounce';
+
+/**
+ * Stable debounced callback that always invokes the latest `fn`.
+ * Replaces `react-table` v7's `useAsyncDebounce`.
+ */
+export const useDebouncedCallback = <Args extends unknown[]>(
+    fn: (...args: Args) => void,
+    delay: number,
+) => {
+    const fnRef = useRef(fn);
+
+    useEffect(() => {
+        fnRef.current = fn;
+    }, [fn]);
+
+    return useMemo(
+        () =>
+            debounce((...args: Args) => {
+                fnRef.current(...args);
+            }, delay),
+        [delay],
+    );
+};

--- a/frontend/src/hooks/usePinnedFavorites.test.ts
+++ b/frontend/src/hooks/usePinnedFavorites.test.ts
@@ -1,48 +1,29 @@
 import { expect, test } from 'vitest';
-import type { Row } from 'react-table';
-import { sortTypesWithFavorites } from './usePinnedFavorites.js';
+import type { Row } from '@tanstack/react-table';
+import { sortingFnsWithFavorites } from './usePinnedFavorites.js';
 
-const data = [
-    {
-        id: 1,
-        favorite: true,
-    },
-    {
-        id: 2,
-        favorite: false,
-    },
-    {
-        id: 3,
-        favorite: true,
-    },
-    {
-        id: 4,
-        favorite: false,
-    },
-    {
-        id: 5,
-        favorite: false,
-    },
-].map((d) => ({ values: d, original: d })) as unknown as Row<object>[];
+type Datum = { id: number; favorite: boolean };
+
+const data: Datum[] = [
+    { id: 1, favorite: true },
+    { id: 2, favorite: false },
+    { id: 3, favorite: true },
+    { id: 4, favorite: false },
+    { id: 5, favorite: false },
+];
+
+const rows = data.map((datum) => ({
+    original: datum,
+    getValue: (key: string) => (datum as Record<string, unknown>)[key],
+})) as unknown as Row<Datum>[];
 
 test('puts favorite items first', () => {
-    const output = data.sort((a, b) =>
-        sortTypesWithFavorites.alphanumeric(a, b, 'id'),
+    const output = rows.sort((rowA, rowB) =>
+        sortingFnsWithFavorites.alphanumeric(rowA, rowB, 'id'),
     );
-    const ids = output.map(({ values: { id } }) => id);
-    const favorites = output.map(({ values: { favorite } }) => favorite);
+    const ids = output.map((row) => row.original.id);
+    const favorites = output.map((row) => row.original.favorite);
 
     expect(ids).toEqual([1, 3, 2, 4, 5]);
     expect(favorites).toEqual([true, true, false, false, false]);
-});
-
-test('in descending order put favorites last (react-table will reverse order)', () => {
-    const output = data.sort((a, b) =>
-        sortTypesWithFavorites.alphanumeric(a, b, 'id', true),
-    );
-    const ids = output.map(({ values: { id } }) => id);
-    const favorites = output.map(({ values: { favorite } }) => favorite);
-
-    expect(ids).toEqual([2, 4, 5, 1, 3]);
-    expect(favorites).toEqual([false, false, false, true, true]);
 });

--- a/frontend/src/hooks/usePinnedFavorites.ts
+++ b/frontend/src/hooks/usePinnedFavorites.ts
@@ -1,30 +1,31 @@
 import { useMemo, useState } from 'react';
-import { sortTypes } from 'utils/sortTypes';
-import type { Row, SortByFn } from 'react-table';
+import { sortingFns } from 'utils/sortingFns';
+import type { Row, SortingFn } from '@tanstack/react-table';
 import { usePlausibleTracker } from './usePlausibleTracker.js';
 
 type WithFavorite = {
     favorite: boolean;
-    [key: string]: any;
+    [key: string]: unknown;
 };
 
-export const sortTypesWithFavorites: Record<
-    keyof typeof sortTypes,
-    SortByFn<object> // TODO: possible type improvement in react-table v8
+export const sortingFnsWithFavorites: Record<
+    keyof typeof sortingFns,
+    SortingFn<WithFavorite>
 > = Object.assign(
     {},
-    ...Object.entries(sortTypes).map(([key, value]) => ({
+    ...Object.entries(sortingFns).map(([key, value]) => ({
         [key]: (
-            v1: Row<WithFavorite>,
-            v2: Row<WithFavorite>,
-            id: string,
-            desc?: boolean,
+            rowA: Row<WithFavorite>,
+            rowB: Row<WithFavorite>,
+            columnId: string,
         ) => {
-            if (v1?.original?.favorite && !v2?.original?.favorite)
-                return desc ? 1 : -1;
-            if (!v1?.original?.favorite && v2?.original?.favorite)
-                return desc ? -1 : 1;
-            return value(v1, v2, id, desc);
+            if (rowA.original.favorite && !rowB.original.favorite) {
+                return -1;
+            }
+            if (!rowA.original.favorite && rowB.original.favorite) {
+                return 1;
+            }
+            return value(rowA, rowB, columnId);
         },
     })),
 );
@@ -45,13 +46,13 @@ export const usePinnedFavorites = (initialState = false) => {
         setIsFavoritesPinned(newState);
     };
 
-    const enhancedSortTypes = useMemo(() => {
-        return isFavoritesPinned ? sortTypesWithFavorites : sortTypes;
+    const enhancedSortingFns = useMemo(() => {
+        return isFavoritesPinned ? sortingFnsWithFavorites : sortingFns;
     }, [isFavoritesPinned]);
 
     return {
         isFavoritesPinned,
         onChangeIsFavoritePinned,
-        sortTypes: enhancedSortTypes,
+        sortingFns: enhancedSortingFns,
     };
 };

--- a/frontend/src/types/react-table-v8.d.ts
+++ b/frontend/src/types/react-table-v8.d.ts
@@ -1,9 +1,13 @@
 import '@tanstack/react-table';
+import type { CSSProperties } from 'react';
 import type { RowData } from '@tanstack/react-table';
 
 declare module '@tanstack/react-table' {
     interface ColumnMeta<_TData extends RowData, _TValue> {
         align?: 'left' | 'center' | 'right';
         width?: number | string;
+        minWidth?: number | string;
+        maxWidth?: number | string;
+        styles?: CSSProperties;
     }
 }

--- a/frontend/src/utils/sortingFns.test.ts
+++ b/frontend/src/utils/sortingFns.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from 'vitest';
+import type { Row } from '@tanstack/react-table';
+import { sortingFns } from './sortingFns.js';
+
+type Datum = { id: number; age: number; bool: boolean; value: number | string };
+
+const data: Datum[] = [
+    { id: 1, age: 42, bool: true, value: 0 },
+    { id: 2, age: 35, bool: false, value: 9999999 },
+    { id: 3, age: 25, bool: true, value: 3456 },
+    { id: 4, age: 32, bool: false, value: 3455 },
+    { id: 5, age: 18, bool: true, value: '49585' },
+];
+
+const rows = data.map((datum) => ({
+    original: datum,
+    getValue: (key: string) => (datum as Record<string, unknown>)[key],
+})) as unknown as Row<Datum>[];
+
+test('sortingFns', () => {
+    expect(
+        rows
+            .sort((rowA, rowB) => sortingFns.boolean(rowA, rowB, 'bool'))
+            .map((row) => row.original.id),
+    ).toEqual([2, 4, 1, 3, 5]);
+
+    expect(
+        rows
+            .sort((rowA, rowB) => sortingFns.alphanumeric(rowA, rowB, 'age'))
+            .map((row) => row.original.age),
+    ).toEqual([18, 25, 32, 35, 42]);
+
+    expect(
+        rows
+            .sort((rowA, rowB) =>
+                sortingFns.numericZeroLast(rowA, rowB, 'value'),
+            )
+            .map((row) => row.original.value),
+    ).toEqual([3455, 3456, '49585', 9999999, 0]);
+});

--- a/frontend/src/utils/sortingFns.ts
+++ b/frontend/src/utils/sortingFns.ts
@@ -1,4 +1,4 @@
-import type { Row, SortingFn } from '@tanstack/react-table';
+import type { Row } from '@tanstack/react-table';
 
 const date = <TData>(rowA: Row<TData>, rowB: Row<TData>, columnId: string) => {
     const a = new Date(
@@ -72,10 +72,7 @@ const numericZeroLast = <TData>(
     return aVal - bVal;
 };
 
-export const sortingFns: Record<
-    'date' | 'boolean' | 'alphanumeric' | 'playgroundResultState' | 'numericZeroLast',
-    SortingFn<unknown>
-> = {
+export const sortingFns = {
     date,
     boolean,
     alphanumeric,

--- a/frontend/src/utils/sortingFns.ts
+++ b/frontend/src/utils/sortingFns.ts
@@ -1,0 +1,84 @@
+import type { Row, SortingFn } from '@tanstack/react-table';
+
+const date = <TData>(rowA: Row<TData>, rowB: Row<TData>, columnId: string) => {
+    const a = new Date(
+        (rowA.getValue(columnId) ?? 0) as string | number | Date,
+    );
+    const b = new Date(
+        (rowB.getValue(columnId) ?? 0) as string | number | Date,
+    );
+    return b.getTime() - a.getTime();
+};
+
+const boolean = <TData>(
+    rowA: Row<TData>,
+    rowB: Row<TData>,
+    columnId: string,
+) => {
+    const a = rowA.getValue(columnId);
+    const b = rowB.getValue(columnId);
+    if (a === b) {
+        return 0;
+    }
+    return a ? 1 : -1;
+};
+
+const alphanumeric = <TData>(
+    rowA: Row<TData>,
+    rowB: Row<TData>,
+    columnId: string,
+) => {
+    const aVal = `${rowA.getValue(columnId) ?? ''}`.toLowerCase();
+    const bVal = `${rowB.getValue(columnId) ?? ''}`.toLowerCase();
+    return aVal.localeCompare(bVal);
+};
+
+const playgroundResultState = <TData>(
+    rowA: Row<TData>,
+    rowB: Row<TData>,
+    columnId: string,
+) => {
+    const a = rowA.getValue(columnId);
+    const b = rowB.getValue(columnId);
+    if (a === b) {
+        return 0;
+    }
+    if (a === 'true') {
+        return 1;
+    }
+    if (b === 'true') {
+        return -1;
+    }
+    if (a === 'false') {
+        return -1;
+    }
+    if (b === 'false') {
+        return 1;
+    }
+    return 0;
+};
+
+const numericZeroLast = <TData>(
+    rowA: Row<TData>,
+    rowB: Row<TData>,
+    columnId: string,
+) => {
+    const aVal =
+        Number.parseInt(`${rowA.getValue(columnId) ?? 0}`, 10) ||
+        Number.MAX_SAFE_INTEGER;
+    const bVal =
+        Number.parseInt(`${rowB.getValue(columnId) ?? 0}`, 10) ||
+        Number.MAX_SAFE_INTEGER;
+    return aVal - bVal;
+};
+
+export const sortingFns: Record<
+    'date' | 'boolean' | 'alphanumeric' | 'playgroundResultState' | 'numericZeroLast',
+    SortingFn<unknown>
+> = {
+    date,
+    boolean,
+    alphanumeric,
+    playgroundResultState,
+    numericZeroLast,
+};


### PR DESCRIPTION
## Summary

First PR in a 5-part stack migrating the frontend from `react-table` v7 to
`@tanstack/react-table` v8. This one lays down the shared infrastructure that
later PRs will use, and migrates a single table end-to-end as a proof of
concept. No v7 code is removed yet — the two libraries will coexist
throughout the stack and v7 is dropped in the final PR.

## What's in this PR

**Shared utilities**
- `frontend/src/utils/sortingFns.ts` — v8-compatible sorting functions (with
  tests), replacing the v7 `sortTypes` we'll delete in PR 5.
- `frontend/src/hooks/useDebouncedCallback.ts` — extracted so the new search
  flow can share it; v8 doesn't manage debounce internally the way v7's
  `useGlobalFilter` did.
- `usePinnedFavorites` — adapted to the new state shape and now tested
  against v8 sort state.

**v8 wrapper components**
- `SortableTableHeaderV8`, `VirtualizedTableV8`, and the
  `react-table-v8.d.ts` ambient types. These wrap `@tanstack/react-table`
  with the same look-and-feel as our existing v7 wrappers so individual
  table migrations are mostly mechanical.

**First migrated table**
- `PlaygroundEnvironmentDiffTable` — converted in this PR to validate the
  wrapper APIs before fanning out to the rest.

**Small consumer tweaks**
- `Search.tsx` / `CommandBar.tsx` — adjusted to the new debounce hook.

## Stack

1. **This PR** — foundation
2. Shared cell components + `useSearch` + first batch of tables
3. Leaf table migrations, batch 1 (~14 tables)
4. Leaf table migrations, batch 2 + API token tables
5. Remove the v7 dependency and delete old wrappers

## Review notes

- Nothing user-visible should change. The single migrated table renders the
  same as before.
- Pay attention to the wrapper APIs (`SortableTableHeaderV8`,
  `VirtualizedTableV8`) — they're the public surface that every later table
  migration will use.
