### PR TITLE
refactor: phase 3c of react-table v7 -> v8 migration

### DIFF
--- a/frontend/src/component/admin/banners/BannersTable/BannersTable.tsx
+++ b/frontend/src/component/admin/banners/BannersTable/BannersTable.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
@@ -7,13 +8,18 @@ import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { Button, useMediaQuery } from '@mui/material';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
-import { useFlexLayout, useSortBy, useTable } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { sortingFns } from 'utils/sortingFns';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import theme from 'themes/theme';
 import { Search } from 'component/common/Search/Search';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { useSearch } from 'hooks/useSearch';
 import { useBanners } from 'hooks/api/getters/useBanners/useBanners';
 import { useBannersApi } from 'hooks/api/actions/useBannersApi/useBannersApi';
@@ -69,37 +75,34 @@ export const BannersTable = () => {
 
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<IInternalBanner, unknown>[]>(
         () => [
             {
-                Header: 'Banner',
-                accessor: 'message',
-                Cell: ({ row: { original: banner } }: any) => (
+                id: 'message',
+                header: 'Banner',
+                accessorKey: 'message',
+                cell: ({ row: { original: banner } }) => (
                     <Banner
                         banner={{ ...banner, sticky: false }}
                         inline
                         maxHeight={42}
                     />
                 ),
-                disableSortBy: true,
-                minWidth: 200,
-                searchable: true,
+                enableSorting: false,
+                meta: { minWidth: 200, searchable: true },
             },
             {
-                Header: 'Created',
-                accessor: 'createdAt',
-                Cell: DateCell,
-                width: 120,
-                maxWidth: 120,
+                id: 'createdAt',
+                header: 'Created',
+                accessorKey: 'createdAt',
+                cell: DateCell,
+                meta: { width: 120, maxWidth: 120 },
             },
             {
-                Header: 'Enabled',
-                accessor: 'enabled',
-                Cell: ({
-                    row: { original: banner },
-                }: {
-                    row: { original: IInternalBanner };
-                }) => (
+                id: 'enabled',
+                header: 'Enabled',
+                accessorKey: 'enabled',
+                cell: ({ row: { original: banner } }) => (
                     <ToggleCell
                         checked={banner.enabled}
                         setChecked={(enabled) =>
@@ -107,15 +110,13 @@ export const BannersTable = () => {
                         }
                     />
                 ),
-                sortType: 'boolean',
-                width: 90,
-                maxWidth: 90,
+                sortingFn: sortingFns.boolean,
+                meta: { width: 90, maxWidth: 90 },
             },
             {
-                Header: 'Actions',
                 id: 'Actions',
-                align: 'center',
-                Cell: ({ row: { original: banner } }: any) => (
+                header: 'Actions',
+                cell: ({ row: { original: banner } }) => (
                     <BannersActionsCell
                         onEdit={() => {
                             setSelectedBanner(banner);
@@ -127,54 +128,55 @@ export const BannersTable = () => {
                         }}
                     />
                 ),
-                width: 100,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { width: 100, align: 'center' },
             },
         ],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [],
     );
 
     const [initialState] = useState({
-        sortBy: [{ id: 'createdAt', desc: true }],
+        sorting: [{ id: 'createdAt', desc: true }],
     });
 
     const { data, getSearchText } = useSearch(columns, searchValue, banners);
 
-    const { headerGroups, rows, prepareRow, setHiddenColumns } = useTable(
-        {
-            columns: columns as any,
-            data,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-            defaultColumn: {
-                Cell: TextCell,
-            },
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
         },
-        useSortBy,
-        useFlexLayout,
-    );
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isSmallScreen,
                 columns: ['createdAt'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
+
+    const rowCount = table.getRowModel().rows.length;
 
     return (
         <PageContent
             isLoading={loading}
             header={
                 <PageHeader
-                    title={`Banners (${rows.length})`}
+                    title={`Banners (${rowCount})`}
                     actions={
                         <>
                             <ConditionallyRender
@@ -215,14 +217,10 @@ export const BannersTable = () => {
             }
         >
             <SearchHighlightProvider value={getSearchText(searchValue)}>
-                <VirtualizedTable
-                    rows={rows}
-                    headerGroups={headerGroups}
-                    prepareRow={prepareRow}
-                />
+                <VirtualizedTableV8 tableInstance={table} />
             </SearchHighlightProvider>
             <ConditionallyRender
-                condition={rows.length === 0}
+                condition={rowCount === 0}
                 show={
                     <ConditionallyRender
                         condition={searchValue?.length > 0}

--- a/frontend/src/component/admin/billing/BillingHistory/BillingHistory.tsx
+++ b/frontend/src/component/admin/billing/BillingHistory/BillingHistory.tsx
@@ -1,16 +1,22 @@
 import {
     Table,
-    SortableTableHeader,
     TableBody,
     TableCell,
     TableRow,
     TablePlaceholder,
 } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import { useMemo, type FC } from 'react';
-import { useGlobalFilter, useSortBy, useTable } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    getFilteredRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { Box, IconButton, styled, Typography } from '@mui/material';
 import FileDownload from '@mui/icons-material/FileDownload';
@@ -21,50 +27,55 @@ const StyledTitle = styled(Typography)(({ theme }) => ({
     marginBottom: theme.spacing(2.5),
     fontSize: theme.fontSizes.mainHeader,
 }));
+
 interface IBillingHistoryProps {
     data: Record<string, any>[];
     isLoading?: boolean;
 }
 
-const columns = [
+const columns: ColumnDef<Record<string, any>, unknown>[] = [
     {
-        Header: 'Amount',
-        accessor: 'amountFormatted',
+        id: 'amountFormatted',
+        header: 'Amount',
+        accessorKey: 'amountFormatted',
     },
     {
-        Header: 'Status',
-        accessor: 'status',
-        disableGlobalFilter: true,
+        id: 'status',
+        header: 'Status',
+        accessorKey: 'status',
+        enableGlobalFilter: false,
     },
     {
-        Header: 'Created date',
-        accessor: 'created',
-        Cell: DateCell,
-        disableGlobalFilter: true,
+        id: 'created',
+        header: 'Created date',
+        accessorKey: 'created',
+        cell: DateCell,
+        enableGlobalFilter: false,
     },
     {
-        Header: 'Due date',
-        accessor: 'dueDate',
-        Cell: DateCell,
-        disableGlobalFilter: true,
+        id: 'dueDate',
+        header: 'Due date',
+        accessorKey: 'dueDate',
+        cell: DateCell,
+        enableGlobalFilter: false,
     },
     {
-        Header: 'Download',
-        accessor: 'invoicePDF',
-        align: 'center',
-        Cell: ({ value }: { value: string }) => (
+        id: 'invoicePDF',
+        header: 'Download',
+        accessorKey: 'invoicePDF',
+        cell: ({ getValue }) => (
             <Box
                 sx={{ display: 'flex', justifyContent: 'center' }}
                 data-loading
             >
-                <IconButton href={value}>
+                <IconButton href={String(getValue() ?? '')}>
                     <FileDownload />
                 </IconButton>
             </Box>
         ),
-        width: 100,
-        disableGlobalFilter: true,
-        disableSortBy: true,
+        enableSorting: false,
+        enableGlobalFilter: false,
+        meta: { width: 100, align: 'center' },
     },
 ];
 
@@ -74,52 +85,47 @@ export const BillingHistory: FC<IBillingHistoryProps> = ({
 }) => {
     const initialState = useMemo(
         () => ({
-            sortBy: [{ id: 'created', desc: true }],
+            sorting: [{ id: 'created', desc: true }],
         }),
         [],
     );
 
-    const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-        useTable(
-            {
-                columns,
-                data,
-                initialState,
-                sortTypes,
-                autoResetGlobalFilter: false,
-                disableSortRemove: true,
-                defaultColumn: {
-                    Cell: TextCell,
-                },
-            },
-            useGlobalFilter,
-            useSortBy,
-        );
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
+        },
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
+
+    const rows = table.getRowModel().rows;
 
     return (
         <PageContent isLoading={isLoading} disablePadding>
             <StyledTitle>Payment history</StyledTitle>
-            <Table {...getTableProps()}>
-                <SortableTableHeader headerGroups={headerGroups} />
-                <TableBody {...getTableBodyProps()}>
-                    {rows.map((row) => {
-                        prepareRow(row);
-                        const { key, ...rowProps } = row.getRowProps();
-                        return (
-                            <TableRow hover key={key} {...rowProps}>
-                                {row.cells.map((cell) => {
-                                    const { key, ...cellProps } =
-                                        cell.getCellProps();
-
-                                    return (
-                                        <TableCell key={key} {...cellProps}>
-                                            {cell.render('Cell')}
-                                        </TableCell>
-                                    );
-                                })}
-                            </TableRow>
-                        );
-                    })}
+            <Table>
+                <SortableTableHeaderV8 tableInstance={table} />
+                <TableBody>
+                    {rows.map((row) => (
+                        <TableRow hover key={row.id}>
+                            {row.getVisibleCells().map((cell) => (
+                                <TableCell key={cell.id}>
+                                    {flexRender(
+                                        cell.column.columnDef.cell,
+                                        cell.getContext(),
+                                    )}
+                                </TableCell>
+                            ))}
+                        </TableRow>
+                    ))}
                 </TableBody>
             </Table>
             <ConditionallyRender

--- a/frontend/src/component/admin/groups/GroupForm/GroupFormUsersTable/GroupFormUsersTable.tsx
+++ b/frontend/src/component/admin/groups/GroupForm/GroupFormUsersTable/GroupFormUsersTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type FC } from 'react';
+import { useMemo, type FC } from 'react';
 import { IconButton, Tooltip } from '@mui/material';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import type { IGroupUser } from 'interfaces/group';
@@ -6,9 +6,13 @@ import { HighlightCell } from 'component/common/Table/cells/HighlightCell/Highli
 import { ActionCell } from 'component/common/Table/cells/ActionCell/ActionCell';
 import Delete from '@mui/icons-material/Delete';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { VirtualizedTable } from 'component/common/Table';
-import { useFlexLayout, useSortBy, useTable } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { UserAvatar } from 'component/common/UserAvatar/UserAvatar';
 
 interface IGroupFormUsersTableProps {
@@ -20,37 +24,36 @@ export const GroupFormUsersTable: FC<IGroupFormUsersTableProps> = ({
     users,
     setUsers,
 }) => {
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<IGroupUser, unknown>[]>(
         () => [
             {
-                Header: 'Avatar',
-                accessor: 'imageUrl',
-                Cell: ({ row: { original: user } }: any) => (
+                id: 'imageUrl',
+                header: 'Avatar',
+                accessorKey: 'imageUrl',
+                cell: ({ row: { original: user } }) => (
                     <TextCell>
                         <UserAvatar user={user} />
                     </TextCell>
                 ),
-                maxWidth: 85,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { maxWidth: 85 },
             },
             {
                 id: 'name',
-                Header: 'Name',
-                accessor: (row: IGroupUser) => row.name || '',
-                Cell: ({ value, row: { original: row } }: any) => (
+                header: 'Name',
+                accessorFn: (row) => row.name || '',
+                cell: ({ getValue, row: { original: row } }) => (
                     <HighlightCell
-                        value={value}
+                        value={String(getValue() ?? '')}
                         subtitle={row.email || row.username}
                     />
                 ),
-                minWidth: 100,
-                searchable: true,
+                meta: { minWidth: 100 },
             },
             {
-                Header: 'Action',
                 id: 'Action',
-                align: 'center',
-                Cell: ({ row: { original: rowUser } }: any) => (
+                header: 'Action',
+                cell: ({ row: { original: rowUser } }) => (
                     <ActionCell>
                         <Tooltip
                             title='Remove user from group'
@@ -71,54 +74,27 @@ export const GroupFormUsersTable: FC<IGroupFormUsersTableProps> = ({
                         </Tooltip>
                     </ActionCell>
                 ),
-                maxWidth: 100,
-                disableSortBy: true,
-            },
-            // Always hidden -- for search
-            {
-                accessor: (row: IGroupUser) => row.username || '',
-                Header: 'Username',
-                searchable: true,
-            },
-            // Always hidden -- for search
-            {
-                accessor: (row: IGroupUser) => row.email || '',
-                Header: 'Email',
-                searchable: true,
+                enableSorting: false,
+                meta: { maxWidth: 100, align: 'center' },
             },
         ],
         [setUsers],
     );
 
-    const [initialState] = useState(() => ({
-        hiddenColumns: ['Username', 'Email'],
-    }));
-
-    const { headerGroups, rows, prepareRow } = useTable(
-        {
-            columns: columns as any[],
-            data: users as any[],
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-        },
-        useSortBy,
-        useFlexLayout,
-    );
+    const table = useReactTable({
+        columns,
+        data: users,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
     return (
         <ConditionallyRender
-            condition={rows.length > 0}
-            show={
-                <VirtualizedTable
-                    rows={rows}
-                    headerGroups={headerGroups}
-                    prepareRow={prepareRow}
-                />
-            }
+            condition={table.getRowModel().rows.length > 0}
+            show={<VirtualizedTableV8 tableInstance={table} />}
         />
     );
 };

--- a/frontend/src/component/admin/roles/RolesTable/RoleDeleteDialog/RoleDeleteDialogProjectRole/RoleDeleteDialogProjectRoleTable.tsx
+++ b/frontend/src/component/admin/roles/RolesTable/RoleDeleteDialog/RoleDeleteDialogProjectRole/RoleDeleteDialogProjectRoleTable.tsx
@@ -1,7 +1,11 @@
-import { VirtualizedTable } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { useMemo, useState } from 'react';
-import { useTable, useSortBy, useFlexLayout, type Column } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import type { IProjectRoleUsageCount } from 'interfaces/project';
 import { LinkCell } from 'component/common/Table/cells/LinkCell/LinkCell';
@@ -14,78 +18,65 @@ export const RoleDeleteDialogProjectRoleTable = ({
     projects,
 }: IRoleDeleteDialogProjectRoleTableProps) => {
     const [initialState] = useState(() => ({
-        sortBy: [{ id: 'name' }],
+        sorting: [{ id: 'name', desc: false }],
     }));
 
-    const columns = useMemo(
-        () =>
-            [
-                {
-                    id: 'name',
-                    Header: 'Project name',
-                    accessor: (row: any) => row.project || '',
-                    minWidth: 200,
-                    Cell: ({ row: { original: item } }: any) => (
-                        <LinkCell
-                            title={item.project}
-                            to={`/projects/${item.project}`}
-                        />
-                    ),
-                },
-                {
-                    id: 'users',
-                    Header: 'Assigned users',
-                    accessor: (row: any) =>
-                        row.userCount === 1
-                            ? '1 user'
-                            : `${row.userCount} users`,
-                    Cell: TextCell,
-                    maxWidth: 150,
-                },
-                {
-                    id: 'serviceAccounts',
-                    Header: 'Service accounts',
-                    accessor: (row: any) =>
-                        row.serviceAccountCount === 1
-                            ? '1 account'
-                            : `${row.serviceAccountCount} accounts`,
-                    Cell: TextCell,
-                    maxWidth: 150,
-                },
-                {
-                    id: 'groups',
-                    Header: 'Assigned groups',
-                    accessor: (row: any) =>
-                        row.groupCount === 1
-                            ? '1 group'
-                            : `${row.groupCount} groups`,
-                    Cell: TextCell,
-                    maxWidth: 150,
-                },
-            ] as Column<IProjectRoleUsageCount>[],
+    const columns = useMemo<ColumnDef<IProjectRoleUsageCount, unknown>[]>(
+        () => [
+            {
+                id: 'name',
+                header: 'Project name',
+                accessorFn: (row) => row.project || '',
+                meta: { minWidth: 200 },
+                cell: ({ row: { original: item } }) => (
+                    <LinkCell
+                        title={item.project}
+                        to={`/projects/${item.project}`}
+                    />
+                ),
+            },
+            {
+                id: 'users',
+                header: 'Assigned users',
+                accessorFn: (row) =>
+                    row.userCount === 1 ? '1 user' : `${row.userCount} users`,
+                cell: TextCell,
+                meta: { maxWidth: 150 },
+            },
+            {
+                id: 'serviceAccounts',
+                header: 'Service accounts',
+                accessorFn: (row) =>
+                    row.serviceAccountCount === 1
+                        ? '1 account'
+                        : `${row.serviceAccountCount} accounts`,
+                cell: TextCell,
+                meta: { maxWidth: 150 },
+            },
+            {
+                id: 'groups',
+                header: 'Assigned groups',
+                accessorFn: (row) =>
+                    row.groupCount === 1
+                        ? '1 group'
+                        : `${row.groupCount} groups`,
+                cell: TextCell,
+                meta: { maxWidth: 150 },
+            },
+        ],
         [],
     );
 
-    const { headerGroups, rows, prepareRow } = useTable(
-        {
-            columns,
-            data: projects,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-        },
-        useSortBy,
-        useFlexLayout,
-    );
+    const table = useReactTable({
+        columns,
+        data: projects,
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    return (
-        <VirtualizedTable
-            rows={rows}
-            headerGroups={headerGroups}
-            prepareRow={prepareRow}
-        />
-    );
+    return <VirtualizedTableV8 tableInstance={table} />;
 };

--- a/frontend/src/component/admin/roles/RolesTable/RoleDeleteDialog/RoleDeleteDialogRootRole/RoleDeleteDialogGroups.tsx
+++ b/frontend/src/component/admin/roles/RolesTable/RoleDeleteDialog/RoleDeleteDialogRootRole/RoleDeleteDialogGroups.tsx
@@ -1,9 +1,13 @@
-import { VirtualizedTable } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
 import { useMemo, useState } from 'react';
-import { useTable, useSortBy, useFlexLayout, type Column } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import type { IGroup } from 'interfaces/group';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 
@@ -19,65 +23,54 @@ export const RoleDeleteDialogGroups = ({
     groups,
 }: IRoleDeleteDialogGroupsProps) => {
     const [initialState] = useState(() => ({
-        sortBy: [{ id: 'createdAt', desc: true }],
+        sorting: [{ id: 'createdAt', desc: true }],
     }));
 
-    const columns = useMemo(
-        () =>
-            [
-                {
-                    id: 'name',
-                    Header: 'Name',
-                    accessor: (row: any) => row.name || '',
-                    minWidth: 200,
-                    Cell: ({ row: { original: group } }: any) => (
-                        <HighlightCell
-                            value={group.name}
-                            subtitle={group.description}
-                        />
-                    ),
-                },
-                {
-                    Header: 'Created',
-                    accessor: 'createdAt',
-                    Cell: DateCell,
-                    width: 120,
-                    maxWidth: 120,
-                },
-                {
-                    id: 'users',
-                    Header: 'Users',
-                    accessor: (row: IGroup) =>
-                        row.users.length === 1
-                            ? '1 user'
-                            : `${row.users.length} users`,
-                    Cell: TextCell,
-                    maxWidth: 150,
-                },
-            ] as Column<IGroup>[],
+    const columns = useMemo<ColumnDef<IGroup, unknown>[]>(
+        () => [
+            {
+                id: 'name',
+                header: 'Name',
+                accessorFn: (row) => row.name || '',
+                meta: { minWidth: 200 },
+                cell: ({ row: { original: group } }) => (
+                    <HighlightCell
+                        value={group.name ?? ''}
+                        subtitle={group.description}
+                    />
+                ),
+            },
+            {
+                id: 'createdAt',
+                header: 'Created',
+                accessorKey: 'createdAt',
+                cell: DateCell,
+                meta: { width: 120, maxWidth: 120 },
+            },
+            {
+                id: 'users',
+                header: 'Users',
+                accessorFn: (row) =>
+                    row.users.length === 1
+                        ? '1 user'
+                        : `${row.users.length} users`,
+                cell: TextCell,
+                meta: { maxWidth: 150 },
+            },
+        ],
         [],
     );
 
-    const { headerGroups, rows, prepareRow } = useTable(
-        {
-            columns,
-            data: groups,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-        },
-        useSortBy,
-        useFlexLayout,
-    );
+    const table = useReactTable({
+        columns,
+        data: groups,
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    return (
-        <VirtualizedTable
-            rows={rows}
-            headerGroups={headerGroups}
-            prepareRow={prepareRow}
-        />
-    );
+    return <VirtualizedTableV8 tableInstance={table} />;
 };

--- a/frontend/src/component/admin/roles/RolesTable/RoleDeleteDialog/RoleDeleteDialogRootRole/RoleDeleteDialogServiceAccounts.tsx
+++ b/frontend/src/component/admin/roles/RolesTable/RoleDeleteDialog/RoleDeleteDialogRootRole/RoleDeleteDialogServiceAccounts.tsx
@@ -1,9 +1,13 @@
-import { VirtualizedTable } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
 import { useMemo, useState } from 'react';
-import { useTable, useSortBy, useFlexLayout, type Column } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { TimeAgoCell } from 'component/common/Table/cells/TimeAgoCell/TimeAgoCell';
 import type { IServiceAccount } from 'interfaces/service-account';
 import { ServiceAccountTokensCell } from 'component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountTokensCell/ServiceAccountTokensCell';
@@ -20,88 +24,71 @@ export const RoleDeleteDialogServiceAccounts = ({
     serviceAccounts,
 }: IRoleDeleteDialogServiceAccountsProps) => {
     const [initialState] = useState(() => ({
-        sortBy: [{ id: 'seenAt', desc: true }],
+        sorting: [{ id: 'seenAt', desc: true }],
     }));
 
-    const columns = useMemo(
-        () =>
-            [
-                {
-                    id: 'name',
-                    Header: 'Name',
-                    accessor: (row: any) => row.name || '',
-                    minWidth: 200,
-                    Cell: ({ row: { original: serviceAccount } }: any) => (
-                        <HighlightCell
-                            value={serviceAccount.name}
-                            subtitle={serviceAccount.username}
-                        />
-                    ),
-                },
-                {
-                    id: 'tokens',
-                    Header: 'Tokens',
-                    accessor: (row: IServiceAccount) =>
-                        row.tokens
-                            ?.map(({ description }) => description)
-                            .join('\n') || '',
-                    Cell: ({
-                        row: { original: serviceAccount },
-                        value,
-                    }: {
-                        row: { original: IServiceAccount };
-                        value: string;
-                    }) => (
-                        <ServiceAccountTokensCell
-                            serviceAccount={serviceAccount}
-                            value={value}
-                        />
-                    ),
-                    maxWidth: 100,
-                },
-                {
-                    Header: 'Created',
-                    accessor: 'createdAt',
-                    Cell: DateCell,
-                    width: 120,
-                    maxWidth: 120,
-                },
-                {
-                    id: 'seenAt',
-                    Header: 'Last seen',
-                    accessor: (row: IServiceAccount) =>
-                        row.tokens.sort((a, b) => {
-                            const aSeenAt = new Date(a.seenAt || 0);
-                            const bSeenAt = new Date(b.seenAt || 0);
-                            return bSeenAt?.getTime() - aSeenAt?.getTime();
-                        })[0]?.seenAt,
-                    Cell: TimeAgoCell,
-                    maxWidth: 150,
-                },
-            ] as Column<IServiceAccount>[],
+    const columns = useMemo<ColumnDef<IServiceAccount, unknown>[]>(
+        () => [
+            {
+                id: 'name',
+                header: 'Name',
+                accessorFn: (row) => row.name || '',
+                meta: { minWidth: 200 },
+                cell: ({ row: { original: serviceAccount } }) => (
+                    <HighlightCell
+                        value={serviceAccount.name ?? ''}
+                        subtitle={serviceAccount.username}
+                    />
+                ),
+            },
+            {
+                id: 'tokens',
+                header: 'Tokens',
+                accessorFn: (row) =>
+                    row.tokens
+                        ?.map(({ description }) => description)
+                        .join('\n') || '',
+                cell: ({ row: { original: serviceAccount }, getValue }) => (
+                    <ServiceAccountTokensCell
+                        serviceAccount={serviceAccount}
+                        value={String(getValue() ?? '')}
+                    />
+                ),
+                meta: { maxWidth: 100 },
+            },
+            {
+                id: 'createdAt',
+                header: 'Created',
+                accessorKey: 'createdAt',
+                cell: DateCell,
+                meta: { width: 120, maxWidth: 120 },
+            },
+            {
+                id: 'seenAt',
+                header: 'Last seen',
+                accessorFn: (row) =>
+                    row.tokens.sort((a, b) => {
+                        const aSeenAt = new Date(a.seenAt || 0);
+                        const bSeenAt = new Date(b.seenAt || 0);
+                        return bSeenAt?.getTime() - aSeenAt?.getTime();
+                    })[0]?.seenAt,
+                cell: TimeAgoCell,
+                meta: { maxWidth: 150 },
+            },
+        ],
         [],
     );
 
-    const { headerGroups, rows, prepareRow } = useTable(
-        {
-            columns,
-            data: serviceAccounts,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-        },
-        useSortBy,
-        useFlexLayout,
-    );
+    const table = useReactTable({
+        columns,
+        data: serviceAccounts,
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    return (
-        <VirtualizedTable
-            rows={rows}
-            headerGroups={headerGroups}
-            prepareRow={prepareRow}
-        />
-    );
+    return <VirtualizedTableV8 tableInstance={table} />;
 };

--- a/frontend/src/component/admin/roles/RolesTable/RoleDeleteDialog/RoleDeleteDialogRootRole/RoleDeleteDialogUsers.tsx
+++ b/frontend/src/component/admin/roles/RolesTable/RoleDeleteDialog/RoleDeleteDialogRootRole/RoleDeleteDialogUsers.tsx
@@ -1,9 +1,13 @@
-import { VirtualizedTable } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
 import { useMemo, useState } from 'react';
-import { useTable, useSortBy, useFlexLayout, type Column } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { TimeAgoCell } from 'component/common/Table/cells/TimeAgoCell/TimeAgoCell';
 import type { IUser } from 'interfaces/user';
 
@@ -19,62 +23,51 @@ export const RoleDeleteDialogUsers = ({
     users,
 }: IRoleDeleteDialogUsersProps) => {
     const [initialState] = useState(() => ({
-        sortBy: [{ id: 'last-login', desc: true }],
+        sorting: [{ id: 'last-login', desc: true }],
     }));
 
-    const columns = useMemo(
-        () =>
-            [
-                {
-                    id: 'name',
-                    Header: 'Name',
-                    accessor: (row: any) => row.name || '',
-                    minWidth: 200,
-                    Cell: ({ row: { original: user } }: any) => (
-                        <HighlightCell
-                            value={user.name}
-                            subtitle={user.email || user.username}
-                        />
-                    ),
-                },
-                {
-                    Header: 'Created',
-                    accessor: 'createdAt',
-                    Cell: DateCell,
-                    width: 120,
-                    maxWidth: 120,
-                },
-                {
-                    id: 'last-login',
-                    Header: 'Last login',
-                    accessor: 'seenAt',
-                    Cell: TimeAgoCell,
-                    maxWidth: 150,
-                },
-            ] as Column<IUser>[],
+    const columns = useMemo<ColumnDef<IUser, unknown>[]>(
+        () => [
+            {
+                id: 'name',
+                header: 'Name',
+                accessorFn: (row) => row.name || '',
+                meta: { minWidth: 200 },
+                cell: ({ row: { original: user } }) => (
+                    <HighlightCell
+                        value={user.name ?? ''}
+                        subtitle={user.email || user.username}
+                    />
+                ),
+            },
+            {
+                id: 'createdAt',
+                header: 'Created',
+                accessorKey: 'createdAt',
+                cell: DateCell,
+                meta: { width: 120, maxWidth: 120 },
+            },
+            {
+                id: 'last-login',
+                header: 'Last login',
+                accessorKey: 'seenAt',
+                cell: TimeAgoCell,
+                meta: { maxWidth: 150 },
+            },
+        ],
         [],
     );
 
-    const { headerGroups, rows, prepareRow } = useTable(
-        {
-            columns,
-            data: users,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-        },
-        useSortBy,
-        useFlexLayout,
-    );
+    const table = useReactTable({
+        columns,
+        data: users,
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    return (
-        <VirtualizedTable
-            rows={rows}
-            headerGroups={headerGroups}
-            prepareRow={prepareRow}
-        />
-    );
+    return <VirtualizedTableV8 tableInstance={table} />;
 };

--- a/frontend/src/component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountModal/ServiceAccountTokens/ServiceAccountTokens.tsx
+++ b/frontend/src/component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountModal/ServiceAccountTokens/ServiceAccountTokens.tsx
@@ -9,7 +9,8 @@ import {
     useTheme,
 } from '@mui/material';
 import { Search } from 'component/common/Search/Search';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { ActionCell } from 'component/common/Table/cells/ActionCell/ActionCell';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
@@ -24,16 +25,15 @@ import type {
 } from 'interfaces/personalAPIToken';
 import { useMemo, useState } from 'react';
 import {
-    useTable,
-    type SortingRule,
-    useSortBy,
-    useFlexLayout,
-} from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { ServiceAccountCreateTokenDialog } from './ServiceAccountCreateTokenDialog/ServiceAccountCreateTokenDialog.tsx';
 import { ServiceAccountTokenDialog } from 'component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountTokenDialog/ServiceAccountTokenDialog';
 import { TimeAgoCell } from 'component/common/Table/cells/TimeAgoCell/TimeAgoCell';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { Dialogue } from 'component/common/Dialogue/Dialogue';
 import {
@@ -80,7 +80,7 @@ export type PageQueryType = Partial<
     Record<'sort' | 'order' | 'search', string>
 >;
 
-const defaultSort: SortingRule<string> = { id: 'createdAt', desc: true };
+const defaultSort = { id: 'createdAt', desc: true };
 
 interface IServiceAccountTokensProps {
     serviceAccount: IServiceAccount;
@@ -103,7 +103,7 @@ export const ServiceAccountTokens = ({
         useServiceAccountTokensApi();
 
     const [initialState] = useState(() => ({
-        sortBy: readOnly ? [{ id: 'seenAt' }] : [defaultSort],
+        sorting: readOnly ? [{ id: 'seenAt', desc: false }] : [defaultSort],
     }));
 
     const [searchValue, setSearchValue] = useState('');
@@ -155,44 +155,47 @@ export const ServiceAccountTokens = ({
         }
     };
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<IPersonalAPIToken, unknown>[]>(
         () => [
             {
-                Header: 'Description',
-                accessor: 'description',
-                Cell: HighlightCell,
-                minWidth: 100,
-                searchable: true,
+                id: 'description',
+                header: 'Description',
+                accessorKey: 'description',
+                cell: HighlightCell,
+                meta: { minWidth: 100, searchable: true },
             },
             {
-                Header: 'Expires',
-                accessor: 'expiresAt',
-                Cell: ({ value }: { value: string }) => {
+                id: 'expiresAt',
+                header: 'Expires',
+                accessorKey: 'expiresAt',
+                cell: ({ getValue }) => {
+                    const value = String(getValue() ?? '');
                     const date = new Date(value);
                     if (date.getFullYear() > new Date().getFullYear() + 100) {
                         return <TextCell>Never</TextCell>;
                     }
                     return <DateCell value={value} />;
                 },
-                maxWidth: 150,
+                meta: { maxWidth: 150 },
             },
             {
-                Header: 'Created',
-                accessor: 'createdAt',
-                Cell: DateCell,
-                maxWidth: 150,
+                id: 'createdAt',
+                header: 'Created',
+                accessorKey: 'createdAt',
+                cell: DateCell,
+                meta: { maxWidth: 150 },
             },
             {
-                Header: 'Last seen',
-                accessor: 'seenAt',
-                Cell: TimeAgoCell,
-                maxWidth: 150,
+                id: 'seenAt',
+                header: 'Last seen',
+                accessorKey: 'seenAt',
+                cell: TimeAgoCell,
+                meta: { maxWidth: 150 },
             },
             {
-                Header: 'Actions',
                 id: 'Actions',
-                align: 'center',
-                Cell: ({ row: { original: rowToken } }: any) => (
+                header: 'Actions',
+                cell: ({ row: { original: rowToken } }) => (
                     <ActionCell>
                         <Tooltip title='Delete token' arrow describeChild>
                             <span>
@@ -208,11 +211,11 @@ export const ServiceAccountTokens = ({
                         </Tooltip>
                     </ActionCell>
                 ),
-                maxWidth: 100,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { maxWidth: 100, align: 'center' },
             },
         ],
-        [setSelectedToken, setDeleteOpen],
+        [],
     );
 
     const { data, getSearchText, getSearchContext } = useSearch(
@@ -221,22 +224,18 @@ export const ServiceAccountTokens = ({
         tokens,
     );
 
-    const { headerGroups, rows, prepareRow, setHiddenColumns } = useTable(
-        {
-            columns: columns as any[],
-            data,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-        },
-        useSortBy,
-        useFlexLayout,
-    );
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isExtraSmallScreen,
@@ -251,9 +250,11 @@ export const ServiceAccountTokens = ({
                 columns: ['Actions', 'expiresAt', 'createdAt'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
+
+    const rowCount = table.getRowModel().rows.length;
 
     return (
         <>
@@ -278,14 +279,10 @@ export const ServiceAccountTokens = ({
                 }
             />
             <SearchHighlightProvider value={getSearchText(searchValue)}>
-                <VirtualizedTable
-                    rows={rows}
-                    headerGroups={headerGroups}
-                    prepareRow={prepareRow}
-                />
+                <VirtualizedTableV8 tableInstance={table} />
             </SearchHighlightProvider>
             <ConditionallyRender
-                condition={rows.length === 0}
+                condition={rowCount === 0}
                 show={
                     <ConditionallyRender
                         condition={searchValue?.length > 0}

--- a/frontend/src/component/admin/users/InactiveUsersList/InactiveUsersList.tsx
+++ b/frontend/src/component/admin/users/InactiveUsersList/InactiveUsersList.tsx
@@ -7,7 +7,6 @@ import useAdminUsersApi from '../../../../hooks/api/actions/useAdminUsersApi/use
 import { useInactiveUsersApi } from '../../../../hooks/api/actions/useInactiveUsersApi/useInactiveUsersApi.ts';
 import useToast from '../../../../hooks/useToast.tsx';
 import { formatUnknownError } from '../../../../utils/formatUnknownError.ts';
-import type { IUser } from '../../../../interfaces/user.ts';
 import type React from 'react';
 import { useMemo, useState } from 'react';
 import { TimeAgoCell } from '../../../common/Table/cells/TimeAgoCell/TimeAgoCell.tsx';
@@ -17,12 +16,15 @@ import { HighlightCell } from '../../../common/Table/cells/HighlightCell/Highlig
 import { PageContent } from '../../../common/PageContent/PageContent.tsx';
 import { PageHeader } from '../../../common/PageHeader/PageHeader.tsx';
 import { Button } from '@mui/material';
-import { useFlexLayout, useSortBy, useTable } from 'react-table';
-import { ConditionallyRender } from '../../../common/ConditionallyRender/ConditionallyRender.tsx';
 import {
-    TablePlaceholder,
-    VirtualizedTable,
-} from '../../../common/Table/index.ts';
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { ConditionallyRender } from '../../../common/ConditionallyRender/ConditionallyRender.tsx';
+import { TablePlaceholder } from '../../../common/Table/index.ts';
+import { VirtualizedTableV8 } from '../../../common/Table/VirtualizedTable/VirtualizedTableV8.tsx';
 
 import { DateCell } from '../../../common/Table/cells/DateCell/DateCell.tsx';
 import { InactiveUsersActionCell } from './InactiveUsersActionCell/InactiveUsersActionCell.tsx';
@@ -31,6 +33,8 @@ import DeleteUser from './DeleteUser/DeleteUser.tsx';
 import { DeleteInactiveUsers } from './DeleteInactiveUsers/DeleteInactiveUsers.tsx';
 import { Link } from 'react-router-dom';
 import { StyledUsersLinkDiv } from '../Users.styles';
+
+type InactiveUserRow = IInactiveUser & { rootRole?: number };
 
 export const InactiveUsersList = () => {
     const { removeUser, userApiErrors } = useAdminUsersApi();
@@ -89,7 +93,7 @@ export const InactiveUsersList = () => {
             setToastApiError(formatUnknownError(error));
         }
     };
-    const massagedData = useMemo(
+    const massagedData = useMemo<InactiveUserRow[]>(
         () =>
             inactiveUsers.map((inactiveUser) => {
                 const u = users.find((u) => u.id === inactiveUser.id);
@@ -100,100 +104,101 @@ export const InactiveUsersList = () => {
             }),
         [inactiveUsers, users],
     );
-    const columns = useMemo(
+
+    const columns = useMemo<ColumnDef<InactiveUserRow, unknown>[]>(
         () => [
             {
                 id: 'name',
-                Header: 'Name',
-                accessor: (row: any) => row.name || '',
-                minWidth: 200,
-                Cell: ({ row: { original: user } }: any) => (
+                header: 'Name',
+                accessorFn: (row) => row.name || '',
+                cell: ({ getValue, row: { original: user } }) => (
                     <HighlightCell
-                        value={user.name}
+                        value={String(getValue() ?? '')}
                         subtitle={user.email || user.username}
                     />
                 ),
-                searchable: true,
+                meta: { minWidth: 200 },
             },
             {
                 id: 'role',
-                Header: 'Role',
-                accessor: (row: any) =>
+                header: 'Role',
+                accessorFn: (row) =>
                     roles.find((role: IRole) => role.id === row.rootRole)
                         ?.name || '',
-                Cell: ({
-                    row: { original: user },
-                    value,
-                }: {
-                    row: { original: IUser };
-                    value: string;
-                }) => <RoleCell value={value} role={user.rootRole} />,
-                maxWidth: 120,
+                cell: ({ getValue, row: { original: user } }) => (
+                    <RoleCell
+                        value={String(getValue() ?? '')}
+                        role={user.rootRole ?? 0}
+                    />
+                ),
+                meta: { maxWidth: 120 },
             },
             {
-                Header: 'Created',
-                accessor: 'createdAt',
-                Cell: DateCell,
-                width: 120,
-                maxWidth: 120,
+                id: 'createdAt',
+                header: 'Created',
+                accessorKey: 'createdAt',
+                cell: DateCell,
+                meta: { width: 120, maxWidth: 120 },
             },
             {
                 id: 'last-login',
-                Header: 'Last login',
-                accessor: 'seenAt',
-                Cell: TimeAgoCell,
-                maxWidth: 150,
+                header: 'Last login',
+                accessorKey: 'seenAt',
+                cell: TimeAgoCell,
+                meta: { maxWidth: 150 },
             },
             {
                 id: 'pat-last-login',
-                Header: 'PAT last used',
-                accessor: 'patSeenAt',
-                Cell: TimeAgoCell,
-                maxWidth: 150,
+                header: 'PAT last used',
+                accessorKey: 'patSeenAt',
+                cell: TimeAgoCell,
+                meta: { maxWidth: 150 },
             },
             {
                 id: 'Actions',
-                Header: 'Actions',
-                align: 'center',
-                Cell: ({ row: { original: user } }: any) => (
+                header: 'Actions',
+                cell: ({ row: { original: user } }) => (
                     <InactiveUsersActionCell onDelete={openDelDialog(user)} />
                 ),
-                width: 200,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { width: 200, align: 'center' },
             },
         ],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [roles],
     );
-    const initialState = useMemo(() => {
-        return {
-            sortBy: [{ id: 'createdAt', desc: true }],
-            hiddenColumns: ['username', 'email'],
-        };
-    }, []);
 
-    const { headerGroups, rows, prepareRow } = useTable(
-        {
-            columns: columns as any,
-            data: massagedData,
-            initialState,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-            defaultColumn: {
-                Cell: TextCell,
-            },
-        },
-        useSortBy,
-        useFlexLayout,
+    const initialState = useMemo(
+        () => ({
+            sorting: [{ id: 'createdAt', desc: true }],
+        }),
+        [],
     );
+
+    const table = useReactTable({
+        columns,
+        data: massagedData,
+        initialState,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
+        },
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
+
+    const rowCount = table.getRowModel().rows.length;
 
     return (
         <PageContent
             isLoading={loading}
             header={
                 <PageHeader
-                    title={`Inactive users (${rows.length})`}
+                    title={`Inactive users (${rowCount})`}
                     actions={
                         <>
                             <Button
@@ -212,13 +217,9 @@ export const InactiveUsersList = () => {
             <StyledUsersLinkDiv>
                 <Link to={'/admin/users'}>View all users</Link>
             </StyledUsersLinkDiv>
-            <VirtualizedTable
-                rows={rows}
-                headerGroups={headerGroups}
-                prepareRow={prepareRow}
-            />
+            <VirtualizedTableV8 tableInstance={table} />
             <ConditionallyRender
-                condition={rows.length === 0}
+                condition={rowCount === 0}
                 show={
                     <TablePlaceholder>
                         No inactive users found.

--- a/frontend/src/component/admin/users/UsersList/AccessRequestsTable/AccessRequestsTable.tsx
+++ b/frontend/src/component/admin/users/UsersList/AccessRequestsTable/AccessRequestsTable.tsx
@@ -1,13 +1,17 @@
 import { useMemo, useState } from 'react';
-import { useFlexLayout, useSortBy, useTable } from 'react-table';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { Button, IconButton, Typography, styled } from '@mui/material';
 import Delete from '@mui/icons-material/Delete';
-import { VirtualizedTable } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import { UserAvatar } from 'component/common/UserAvatar/UserAvatar';
 import { Dialogue } from 'component/common/Dialogue/Dialogue';
-import { sortTypes } from 'utils/sortTypes';
 import { useUsers } from 'hooks/api/getters/useUsers/useUsers';
 import { useUserAccessRequests } from 'hooks/api/getters/useUserAccessRequests/useUserAccessRequests';
 import { useUserAccessRequestsApi } from 'hooks/api/actions/useUserAccessRequestsApi/useUserAccessRequestsApi';
@@ -92,40 +96,39 @@ export const AccessRequestsTable = () => {
         }
     };
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<UserAccessRequestSchema, unknown>[]>(
         () => [
             {
-                Header: 'Avatar',
                 id: 'avatar',
-                accessor: 'email',
-                Cell: ({ row: { original } }: any) => (
+                header: 'Avatar',
+                accessorKey: 'email',
+                cell: ({ row: { original } }) => (
                     <TextCell>
-                        <UserAvatar user={original} />
+                        <UserAvatar
+                            user={{
+                                ...original,
+                                id: Number(original.id),
+                            }}
+                        />
                     </TextCell>
                 ),
-                disableSortBy: true,
-                maxWidth: 80,
+                enableSorting: false,
+                meta: { maxWidth: 80 },
             },
             {
                 id: 'email',
-                Header: 'Email',
-                accessor: (row: any) => row.email || '',
-                minWidth: 180,
-                Cell: ({
-                    row: { original },
-                }: {
-                    row: { original: UserAccessRequestSchema };
-                }) => <TextCell>{original.email}</TextCell>,
+                header: 'Email',
+                accessorFn: (row) => row.email || '',
+                cell: ({ row: { original } }) => (
+                    <TextCell>{original.email}</TextCell>
+                ),
+                meta: { minWidth: 180 },
             },
             {
                 id: 'role',
-                Header: 'Role',
-                accessor: () => '',
-                Cell: ({
-                    row: { original },
-                }: {
-                    row: { original: UserAccessRequestSchema };
-                }) => (
+                header: 'Role',
+                accessorFn: () => '',
+                cell: ({ row: { original } }) => (
                     <RoleSelectCell
                         roles={roles}
                         selectedRoleId={getRoleId(original.id)}
@@ -134,25 +137,20 @@ export const AccessRequestsTable = () => {
                         }
                     />
                 ),
-                maxWidth: 120,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { maxWidth: 120 },
             },
             {
-                Header: 'Requested',
-                accessor: 'requestedAt',
-                Cell: DateCell,
-                width: 200,
-                maxWidth: 200,
+                id: 'requestedAt',
+                header: 'Requested',
+                accessorKey: 'requestedAt',
+                cell: DateCell,
+                meta: { width: 200, maxWidth: 200 },
             },
             {
-                Header: 'Actions',
                 id: 'actions',
-                align: 'center',
-                Cell: ({
-                    row: { original },
-                }: {
-                    row: { original: UserAccessRequestSchema };
-                }) => (
+                header: 'Actions',
+                cell: ({ row: { original } }) => (
                     <StyledActions>
                         <Button
                             variant='outlined'
@@ -170,37 +168,36 @@ export const AccessRequestsTable = () => {
                         </IconButton>
                     </StyledActions>
                 ),
-                width: 250,
-                maxWidth: 250,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { width: 250, maxWidth: 250, align: 'center' },
             },
         ],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [roles, selectedRoles, defaultRoleId],
     );
 
     const initialState = useMemo(
         () => ({
-            sortBy: [{ id: 'requestedAt', desc: true }],
+            sorting: [{ id: 'requestedAt', desc: true }],
         }),
         [],
     );
 
-    const { headerGroups, rows, prepareRow } = useTable(
-        {
-            columns: columns as any,
-            data: accessRequests,
-            initialState,
-            sortTypes,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-            defaultColumn: {
-                Cell: TextCell,
-            },
+    const table = useReactTable({
+        columns,
+        data: accessRequests,
+        initialState,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
         },
-        useSortBy,
-        useFlexLayout,
-    );
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
     if (accessRequests.length === 0) {
         return null;
@@ -209,11 +206,7 @@ export const AccessRequestsTable = () => {
     return (
         <StyledContainer>
             <StyledTitle>Access requests ({accessRequests.length})</StyledTitle>
-            <VirtualizedTable
-                rows={rows}
-                headerGroups={headerGroups}
-                prepareRow={prepareRow}
-            />
+            <VirtualizedTableV8 tableInstance={table} />
             <Dialogue
                 open={Boolean(requestToReject)}
                 title='Reject access request?'

--- a/frontend/src/component/common/Table/cells/DateCell/DateCell.tsx
+++ b/frontend/src/component/common/Table/cells/DateCell/DateCell.tsx
@@ -5,12 +5,18 @@ import { getLocalizedDateString } from '../../../util.ts';
 
 interface IDateCellProps {
     value?: Date | string | null;
-    getValue?: () => Date | string | null | undefined;
+    getValue?: () => unknown;
 }
 
 // `getValue is for new @tanstack/react-table (v8), `value` is for legacy react-table (v7)
 export const DateCell: FC<IDateCellProps> = ({ value, getValue }) => {
-    const input = value || getValue?.() || null;
+    const raw = value ?? getValue?.();
+    const input =
+        raw == null
+            ? null
+            : raw instanceof Date || typeof raw === 'string'
+              ? raw
+              : null;
     const { locationSettings } = useLocationSettings();
     const date = getLocalizedDateString(input, locationSettings.locale);
 

--- a/frontend/src/component/common/Table/cells/HighlightCell/HighlightCell.tsx
+++ b/frontend/src/component/common/Table/cells/HighlightCell/HighlightCell.tsx
@@ -8,7 +8,8 @@ import { HtmlTooltip } from 'component/common/HtmlTooltip/HtmlTooltip';
 import { Truncator } from 'component/common/Truncator/Truncator';
 
 interface IHighlightCellProps {
-    value: string;
+    value?: string;
+    getValue?: () => unknown;
     subtitle?: string;
     afterTitle?: React.ReactNode;
     subtitleTooltip?: boolean;
@@ -38,12 +39,14 @@ const StyledSubtitle = styled('span')(({ theme }) => ({
 
 export const HighlightCell: FC<IHighlightCellProps> = ({
     value,
+    getValue,
     subtitle,
     afterTitle,
     subtitleTooltip,
     maxTitleLines,
 }) => {
     const { searchQuery } = useSearchHighlightContext();
+    const resolvedValue = value ?? (getValue ? String(getValue() ?? '') : '');
 
     const renderSubtitle = (
         <ConditionallyRender
@@ -71,12 +74,14 @@ export const HighlightCell: FC<IHighlightCellProps> = ({
         <StyledContainer>
             <Truncator
                 lines={maxTitleLines ?? (subtitle ? 1 : 2)}
-                title={value}
+                title={resolvedValue}
                 arrow
                 data-loading
             >
                 <StyledTitle>
-                    <Highlighter search={searchQuery}>{value}</Highlighter>
+                    <Highlighter search={searchQuery}>
+                        {resolvedValue}
+                    </Highlighter>
                     {afterTitle}
                 </StyledTitle>
             </Truncator>

--- a/frontend/src/component/common/Table/cells/TextCell/TextCell.tsx
+++ b/frontend/src/component/common/Table/cells/TextCell/TextCell.tsx
@@ -4,6 +4,7 @@ import { Box, styled, type SxProps, type Theme } from '@mui/material';
 
 interface ITextCellProps {
     value?: string | null;
+    getValue?: () => unknown;
     lineClamp?: number;
     'data-testid'?: string;
     sx?: SxProps<Theme>;
@@ -32,14 +33,18 @@ const StyledSpan = styled('span')(() => ({
 
 export const TextCell: FC<ITextCellProps> = ({
     value,
+    getValue,
     children,
     lineClamp,
     sx,
     'data-testid': testid,
-}) => (
-    <StyledWrapper lineClamp={lineClamp} sx={sx}>
-        <StyledSpan data-loading='true' data-testid={testid}>
-            {children ?? value}
-        </StyledSpan>
-    </StyledWrapper>
-);
+}) => {
+    const resolved = children ?? value ?? (getValue ? getValue() : undefined);
+    return (
+        <StyledWrapper lineClamp={lineClamp} sx={sx}>
+            <StyledSpan data-loading='true' data-testid={testid}>
+                {resolved as React.ReactNode}
+            </StyledSpan>
+        </StyledWrapper>
+    );
+};

--- a/frontend/src/component/common/Table/cells/TimeAgoCell/TimeAgoCell.tsx
+++ b/frontend/src/component/common/Table/cells/TimeAgoCell/TimeAgoCell.tsx
@@ -4,31 +4,61 @@ import type { FC, ReactNode } from 'react';
 import { formatDateYMD } from 'utils/formatDate';
 import { TextCell } from '../TextCell/TextCell.tsx';
 import { TimeAgo } from 'component/common/TimeAgo/TimeAgo';
-import type { ColumnInstance } from 'react-table';
+
+type ColumnLike = {
+    Header?: string;
+    columnDef?: { header?: unknown };
+};
 
 export interface ITimeAgoCellProps {
     value?: string | number | Date | null;
-    column?: ColumnInstance;
+    getValue?: () => unknown;
+    column?: ColumnLike;
     live?: boolean;
     emptyText?: string;
     title?: (date?: string) => ReactNode;
     dateFormat?: (value: string | number | Date, locale: string) => string;
 }
 
+const headerText = (column?: ColumnLike): string | undefined => {
+    if (typeof column?.Header === 'string') {
+        return column.Header;
+    }
+    const v8Header = column?.columnDef?.header;
+    if (typeof v8Header === 'string') {
+        return v8Header;
+    }
+    return undefined;
+};
+
 export const TimeAgoCell: FC<ITimeAgoCellProps> = ({
     value,
+    getValue,
     column,
     live = false,
     emptyText = 'Never',
-    title = (date) =>
-        date ? (column ? `${column.Header}: ${date}` : date) : '',
+    title,
     dateFormat = formatDateYMD,
 }) => {
     const { locationSettings } = useLocationSettings();
+    const raw = value ?? getValue?.();
+    const input =
+        raw == null
+            ? null
+            : raw instanceof Date ||
+                typeof raw === 'string' ||
+                typeof raw === 'number'
+              ? raw
+              : null;
 
-    const tooltip = value
-        ? title(dateFormat(value, locationSettings.locale))
-        : title();
+    const header = headerText(column);
+    const defaultTitle = (date?: string) =>
+        date ? (header ? `${header}: ${date}` : date) : '';
+    const titleFn = title ?? defaultTitle;
+
+    const tooltip = input
+        ? titleFn(dateFormat(input, locationSettings.locale))
+        : titleFn();
 
     return (
         <TextCell>
@@ -43,8 +73,8 @@ export const TimeAgoCell: FC<ITimeAgoCellProps> = ({
                     variant='body2'
                     data-loading
                 >
-                    {value ? (
-                        <TimeAgo date={value} refresh={live} />
+                    {input ? (
+                        <TimeAgo date={input} refresh={live} />
                     ) : (
                         emptyText
                     )}

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsTable/ApplicationsCell.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsTable/ApplicationsCell.tsx
@@ -11,7 +11,7 @@ interface IFeatureTagCellProps {
     row: {
         original: {
             appName: string;
-            selectedApplications: string[];
+            selectedApplications?: string[];
         };
     };
 }

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsTable/FeatureMetricsTable.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsTable/FeatureMetricsTable.tsx
@@ -1,14 +1,22 @@
 import type { IFeatureMetricsRaw } from 'interfaces/featureToggle';
 import { TableBody, TableRow, useMediaQuery } from '@mui/material';
 import { DateTimeCell } from 'component/common/Table/cells/DateTimeCell/DateTimeCell';
-import { useTable, useGlobalFilter, useSortBy } from 'react-table';
-import { SortableTableHeader, TableCell, Table } from 'component/common/Table';
+import {
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    getFilteredRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
+import { TableCell, Table } from 'component/common/Table';
 import { IconCell } from 'component/common/Table/cells/IconCell/IconCell';
 import Assessment from '@mui/icons-material/Assessment';
 import { useMemo } from 'react';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import theme from 'themes/theme';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { ApplicationsCell } from './ApplicationsCell.tsx';
 
 interface IFeatureMetricsTableProps {
@@ -16,42 +24,84 @@ interface IFeatureMetricsTableProps {
     tableSectionId?: string;
 }
 
+const COLUMNS: ColumnDef<IFeatureMetricsRaw, any>[] = [
+    {
+        id: 'Icon',
+        meta: { width: '1%' },
+        enableSorting: false,
+        cell: () => <IconCell icon={<Assessment color='disabled' />} />,
+    },
+    {
+        id: 'timestamp',
+        header: 'Time',
+        accessorKey: 'timestamp',
+        cell: ({ row }) => (
+            <DateTimeCell
+                value={row.original.timestamp}
+                timeZone={
+                    row.original.timestamp.includes('23:59') ? 'UTC' : undefined
+                }
+            />
+        ),
+    },
+    {
+        id: 'appName',
+        header: 'Application',
+        accessorKey: 'appName',
+        cell: ({ row }) => <ApplicationsCell row={row} />,
+    },
+    {
+        id: 'environment',
+        header: 'Environment',
+        accessorKey: 'environment',
+    },
+    {
+        id: 'requested',
+        header: 'Requested',
+        accessorFn: (original) => original.yes + original.no,
+    },
+    {
+        id: 'yes',
+        header: 'Enabled',
+        accessorKey: 'yes',
+    },
+];
+
 export const FeatureMetricsTable = ({
     metrics,
     tableSectionId,
 }: IFeatureMetricsTableProps) => {
     const isMediumScreen = useMediaQuery(theme.breakpoints.down('md'));
 
-    const initialState = useMemo(() => ({ sortBy: [{ id: 'timestamp' }] }), []);
-
-    const {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
-        setHiddenColumns,
-    } = useTable(
-        {
-            initialState,
-            columns: COLUMNS as any,
-            data: metrics as any,
-            autoResetHiddenColumns: false,
-            disableSortRemove: true,
-            defaultColumn: { Cell: TextCell },
-        },
-        useGlobalFilter,
-        useSortBy,
+    const initialState = useMemo(
+        () => ({ sorting: [{ id: 'timestamp', desc: false }] }),
+        [],
     );
 
-    useConditionallyHiddenColumns(
+    const table = useReactTable({
+        initialState,
+        columns: COLUMNS,
+        data: metrics,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
+        },
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
+
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isMediumScreen,
                 columns: ['appName', 'environment'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         COLUMNS,
     );
 
@@ -60,68 +110,22 @@ export const FeatureMetricsTable = ({
     }
 
     return (
-        <Table {...getTableProps()} rowHeight='standard' id={tableSectionId}>
-            <SortableTableHeader headerGroups={headerGroups} />
-            <TableBody {...getTableBodyProps()}>
-                {rows.map((row) => {
-                    prepareRow(row);
-                    const { key, ...rowProps } = row.getRowProps();
-                    return (
-                        <TableRow hover key={key} {...rowProps}>
-                            {row.cells.map((cell) => {
-                                const { key, ...cellProps } =
-                                    cell.getCellProps();
-                                return (
-                                    <TableCell key={key} {...cellProps}>
-                                        {cell.render('Cell')}
-                                    </TableCell>
-                                );
-                            })}
-                        </TableRow>
-                    );
-                })}
+        <Table rowHeight='standard' id={tableSectionId}>
+            <SortableTableHeaderV8 tableInstance={table} />
+            <TableBody>
+                {table.getRowModel().rows.map((row) => (
+                    <TableRow hover key={row.id}>
+                        {row.getVisibleCells().map((cell) => (
+                            <TableCell key={cell.id}>
+                                {flexRender(
+                                    cell.column.columnDef.cell,
+                                    cell.getContext(),
+                                )}
+                            </TableCell>
+                        ))}
+                    </TableRow>
+                ))}
             </TableBody>
         </Table>
     );
 };
-
-const COLUMNS = [
-    {
-        id: 'Icon',
-        width: '1%',
-        disableSortBy: true,
-        Cell: () => <IconCell icon={<Assessment color='disabled' />} />,
-    },
-    {
-        Header: 'Time',
-        accessor: 'timestamp',
-        Cell: (props: any) => (
-            <DateTimeCell
-                value={props.row.original.timestamp}
-                timeZone={
-                    props.row.original.timestamp.includes('23:59')
-                        ? 'UTC'
-                        : undefined
-                }
-            />
-        ),
-    },
-    {
-        Header: 'Application',
-        accessor: 'appName',
-        Cell: ApplicationsCell,
-    },
-    {
-        Header: 'Environment',
-        accessor: 'environment',
-    },
-    {
-        id: 'requested',
-        Header: 'Requested',
-        accessor: (original: any) => original.yes + original.no,
-    },
-    {
-        Header: 'Enabled',
-        accessor: 'yes',
-    },
-];

--- a/frontend/src/component/playground/Playground/PlaygroundEnvironmentTable/PlaygroundEnvironmentTable.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundEnvironmentTable/PlaygroundEnvironmentTable.tsx
@@ -1,19 +1,18 @@
 import { useMemo, useRef } from 'react';
 import {
-    useFlexLayout,
-    useGlobalFilter,
-    useSortBy,
-    useTable,
-} from 'react-table';
+    createColumnHelper,
+    getCoreRowModel,
+    getFilteredRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 
-import { VirtualizedTable } from 'component/common/Table';
-import { sortTypes } from 'utils/sortTypes';
-import type {
-    AdvancedPlaygroundEnvironmentFeatureSchema,
-    PlaygroundFeatureSchema,
-} from 'openapi';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
+import { sortingFns } from 'utils/sortingFns';
+import type { AdvancedPlaygroundEnvironmentFeatureSchema } from 'openapi';
 import { Box, useMediaQuery, useTheme } from '@mui/material';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import type { IFeatureVariant } from 'interfaces/featureToggle';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { FeatureStatusCell } from '../PlaygroundResultsTable/FeatureStatusCell/FeatureStatusCell.tsx';
 import { FeatureResultInfoPopoverCell } from '../PlaygroundResultsTable/FeatureResultInfoPopoverCell/FeatureResultInfoPopoverCell.tsx';
 import { VariantCell } from '../PlaygroundResultsTable/VariantCell/VariantCell.tsx';
@@ -30,62 +29,66 @@ export const PlaygroundEnvironmentTable = ({
     const theme = useTheme();
     const isExtraSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
-    const dynamicHeaders = Object.keys(features[0].context).map(
-        (contextField) => ({
-            Header: capitalizeFirst(contextField),
-            accessor: (row: { context: Record<string, unknown> }) =>
-                row.context[contextField],
-            minWidth: 160,
-            Cell: HighlightCell,
-        }),
-    );
+    const columnHelper =
+        createColumnHelper<AdvancedPlaygroundEnvironmentFeatureSchema>();
 
-    const COLUMNS = useMemo(() => {
+    const columns = useMemo(() => {
+        const dynamicHeaders = Object.keys(features[0].context).map(
+            (contextField) =>
+                columnHelper.accessor((row) => row.context?.[contextField], {
+                    id: `context_${contextField}`,
+                    header: capitalizeFirst(contextField),
+                    cell: ({ getValue }) => (
+                        <HighlightCell value={String(getValue() ?? '')} />
+                    ),
+                    meta: { minWidth: 160 },
+                }),
+        );
+
         return [
             ...dynamicHeaders,
-            {
-                Header: 'Variant',
+            columnHelper.accessor((row) => row.variant?.name ?? '', {
                 id: 'variant',
-                accessor: 'variant.name',
-                sortType: 'alphanumeric',
-                filterName: 'variant',
-                maxWidth: 200,
-                Cell: ({
-                    value,
+                header: 'Variant',
+                sortingFn: 'alphanumeric',
+                cell: ({
+                    getValue,
                     row: {
-                        original: { variant, feature, variants, isEnabled },
+                        original: { variant, name, variants, isEnabled },
                     },
-                }: any) => (
+                }) => (
                     <VariantCell
-                        variant={variant?.enabled ? value : ''}
-                        variants={variants}
-                        feature={feature}
+                        variant={variant?.enabled ? String(getValue()) : ''}
+                        // schema/interface mismatch predates this migration
+                        variants={variants as IFeatureVariant[]}
+                        feature={name}
                         isEnabled={isEnabled}
                     />
                 ),
-            },
-            {
-                id: 'isEnabled',
-                Header: 'isEnabled',
-                filterName: 'isEnabled',
-                accessor: (row: PlaygroundFeatureSchema) =>
+                meta: { maxWidth: 200 },
+            }),
+            columnHelper.accessor(
+                (row) =>
                     row?.isEnabled
                         ? 'true'
                         : row?.strategies?.result === 'unknown'
                           ? 'unknown'
                           : 'false',
-                Cell: ({ row }: any) => (
-                    <FeatureStatusCell feature={row.original} />
-                ),
-                sortType: 'playgroundResultState',
-                maxWidth: 120,
-                sortInverted: true,
-            },
-            {
-                Header: '',
-                maxWidth: 70,
+                {
+                    id: 'isEnabled',
+                    header: 'isEnabled',
+                    cell: ({ row }) => (
+                        <FeatureStatusCell feature={row.original} />
+                    ),
+                    sortingFn: sortingFns.playgroundResultState,
+                    sortDescFirst: true,
+                    meta: { maxWidth: 120 },
+                },
+            ),
+            columnHelper.display({
                 id: 'info',
-                Cell: ({ row }: any) => (
+                header: '',
+                cell: ({ row }) => (
                     <FeatureResultInfoPopoverCell
                         feature={row.original}
                         input={{
@@ -94,35 +97,32 @@ export const PlaygroundEnvironmentTable = ({
                         }}
                     />
                 ),
-            },
+                meta: { maxWidth: 70 },
+            }),
         ];
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const { headerGroups, rows, prepareRow, setHiddenColumns } = useTable(
-        {
-            columns: COLUMNS as any,
-            data: features,
-            sortTypes,
-            autoResetGlobalFilter: false,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-        },
-        useGlobalFilter,
-        useFlexLayout,
-        useSortBy,
-    );
+    const table = useReactTable({
+        columns,
+        data: features,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isExtraSmallScreen,
                 columns: ['variant'],
             },
         ],
-        setHiddenColumns,
-        COLUMNS,
+        table.setColumnVisibility,
+        columns,
     );
 
     const parentRef = useRef<HTMLElement | null>(null);
@@ -135,12 +135,7 @@ export const PlaygroundEnvironmentTable = ({
                 maxHeight: '800px',
             }}
         >
-            <VirtualizedTable
-                parentRef={parentRef}
-                rows={rows}
-                headerGroups={headerGroups}
-                prepareRow={prepareRow}
-            />
+            <VirtualizedTableV8 parentRef={parentRef} tableInstance={table} />
         </Box>
     );
 };

--- a/frontend/src/hooks/useConditionallyHiddenColumnsV8.ts
+++ b/frontend/src/hooks/useConditionallyHiddenColumnsV8.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+import type { Updater, VisibilityState } from '@tanstack/react-table';
+
+interface IConditionallyHiddenColumns {
+    condition: boolean;
+    columns: string[];
+}
+
+/**
+ * v8 counterpart of `useConditionallyHiddenColumns`. Applies visibility
+ * directly via the table's `setColumnVisibility`, which expects a
+ * `Record<string, boolean>` rather than v7's `string[]` of hidden ids.
+ */
+export const useConditionallyHiddenColumnsV8 = (
+    conditionallyHiddenColumns: IConditionallyHiddenColumns[],
+    setColumnVisibility: (updater: Updater<VisibilityState>) => void,
+    columnsDefinition: unknown[],
+) => {
+    // biome-ignore lint/correctness/useExhaustiveDependencies: spreading the conditions array into deps is intentional so the effect re-runs when any condition flips
+    useEffect(() => {
+        const columnsToHide = conditionallyHiddenColumns
+            .filter(({ condition }) => condition)
+            .flatMap(({ columns }) => columns);
+
+        const columnsToShow = conditionallyHiddenColumns
+            .filter(({ condition }) => !condition)
+            .flatMap(({ columns }) => columns);
+
+        setColumnVisibility((current) => {
+            const next = { ...current };
+            for (const column of columnsToHide) {
+                next[column] = false;
+            }
+            for (const column of columnsToShow) {
+                next[column] = true;
+            }
+            return next;
+        });
+    }, [
+        ...conditionallyHiddenColumns.map(({ condition }) => condition),
+        setColumnVisibility,
+        columnsDefinition,
+    ]);
+};

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -21,6 +21,27 @@ const normalizeSearchValue = (value: string) =>
 const removeQuotes = (value: string) =>
     value.replaceAll("'", '').replaceAll('"', '');
 
+// Cell shape sniffing: v7 columns expose fields at the top level; v8 columns
+// (`@tanstack/react-table`) put accessors under `accessorKey`/`accessorFn` and
+// custom fields under `meta`. These getters read both, so callers can pass
+// either shape during the v7 -> v8 migration.
+const getAccessor = (column: any): unknown =>
+    column.accessorFn ?? column.accessorKey ?? column.accessor;
+const getSearchable = (column: any): boolean | undefined =>
+    column.meta?.searchable ?? column.searchable;
+const getFilterName = (column: any): string | undefined =>
+    column.meta?.filterName ?? column.filterName;
+const getFilterBy = (
+    column: any,
+): ((row: any, values: string[]) => boolean) | undefined =>
+    column.meta?.filterBy ?? column.filterBy;
+const getSearchBy = (
+    column: any,
+): ((row: any, value: string) => boolean) | undefined =>
+    column.meta?.searchBy ?? column.searchBy;
+const getFilterParsing = (column: any): ((value: any) => string) | undefined =>
+    column.meta?.filterParsing ?? column.filterParsing;
+
 export const useSearch = <T>(
     columns: any[],
     searchValue: string,
@@ -59,13 +80,15 @@ export const filter = (columns: any[], searchValue: string, data: any[]) => {
     let filteredDataSet = data;
 
     getFilterableColumns(columns)
-        .filter((column) => isValidFilter(searchValue, column.filterName))
+        .filter((column) => isValidFilter(searchValue, getFilterName(column)!))
         .forEach((column) => {
-            const values = getFilterValues(column.filterName, searchValue);
+            const filterName = getFilterName(column)!;
+            const values = getFilterValues(filterName, searchValue);
 
             filteredDataSet = filteredDataSet.filter((row) => {
-                if (column.filterBy) {
-                    return column.filterBy(row, values);
+                const filterBy = getFilterBy(column);
+                if (filterBy) {
+                    return filterBy.call(column, row, values);
                 }
 
                 return defaultFilter(getColumnValues(column, row), values);
@@ -82,13 +105,14 @@ export const searchInFilteredData = <T>(
 ) => {
     const trimmedSearchValue = searchValue.trim();
     const searchableColumns = columns.filter(
-        (column) => column.searchable && column.accessor,
+        (column) => getSearchable(column) && getAccessor(column),
     );
 
     return filteredData.filter((row) => {
         return searchableColumns.some((column) => {
-            if (column.searchBy) {
-                return column.searchBy(row, trimmedSearchValue);
+            const searchBy = getSearchBy(column);
+            if (searchBy) {
+                return searchBy.call(column, row, trimmedSearchValue);
             }
 
             return defaultSearch(
@@ -112,8 +136,8 @@ const defaultSearch = (fieldValue: string, value: string) =>
 
 export const getSearchTextGenerator = (columns: any[]) => {
     const filters = columns
-        .filter((column) => column.filterName)
-        .map((column) => column.filterName);
+        .map((column) => getFilterName(column))
+        .filter((filterName): filterName is string => Boolean(filterName));
 
     const isValidSearch = (fragment: string) => {
         return filters.some((filter) => isValidFilter(fragment, filter));
@@ -131,20 +155,24 @@ export const isValidFilter = (input: string, match: string) =>
     new RegExp(`${match}:(?:\\w+|["'][^"']+["'])`).test(input);
 
 export const getFilterableColumns = (columns: any[]) =>
-    columns.filter((column) => column.filterName && column.accessor);
+    columns.filter((column) => getFilterName(column) && getAccessor(column));
 
 export const getColumnValues = (column: any, row: any) => {
+    const accessor = getAccessor(column);
     const value =
-        typeof column.accessor === 'function'
-            ? column.accessor(row)
-            : column.accessor.includes('.')
-              ? column.accessor
+        typeof accessor === 'function'
+            ? accessor(row)
+            : typeof accessor === 'string' && accessor.includes('.')
+              ? accessor
                     .split('.')
                     .reduce((object: any, key: string) => object?.[key], row)
-              : row[column.accessor];
+              : typeof accessor === 'string'
+                ? row[accessor]
+                : undefined;
 
-    if (column.filterParsing) {
-        return column.filterParsing(value);
+    const filterParsing = getFilterParsing(column);
+    if (filterParsing) {
+        return filterParsing(value);
     }
 
     return value;


### PR DESCRIPTION
## Summary

Second PR in the v7 → v8 stack. Builds on
https://github.com/Unleash/unleash/pull/12069. This PR groups together everything that touches
shared infrastructure beyond a single table — common cell components, the
`useSearch` hook, and a small v8-only "conditionally hidden columns" hook —
along with the ~10 tables that consume those shared changes.

After this PR, the shared surface is stable; remaining PRs are essentially
parallel leaf migrations.

## What's in this PR

**Shared infrastructure changes**
- `useConditionallyHiddenColumnsV8` — v8 analogue of the existing v7 hook
  (the v7 one stays around until PR 5 since other tables still use it).
- Common cell components updated for v8 prop shapes:
  `DateCell`, `HighlightCell`, `TimeAgoCell`, `TextCell`.
- `useSearch` — extended to work with v8's `ColumnDef`/`Row` types.

**Tables migrated** (~10)
- Phase 3a: `FeatureMetricsTable`, `PlaygroundEnvironmentTable`,
  `ApplicationsCell`
- Phase 3b: `GroupFormUsersTable`, the four `RoleDeleteDialog*` tables,
  `AccessRequestsTable`
- Phase 3c: `BannersTable`, `BillingHistory`, `ServiceAccountTokens`,
  `InactiveUsersList`

## Stack

1. Foundation
2. **This PR** — shared cells, `useSearch`, first batch of tables
3. Leaf table migrations, batch 1 (~14 tables)
4. Leaf table migrations, batch 2 + API token tables
5. Remove the v7 dependency

## Review notes

- The shared-cell component changes are the highest-leverage diff to scan
  carefully — every later migrated table reads through them.
- v7 and v8 still coexist; expect both `useConditionallyHiddenColumns`
  variants to exist until PR 5.
