### PR TITLE
refactor: phase 3l of react-table v7 -> v8 migration

### DIFF
--- a/frontend/src/component/admin/roles/RolesTable/RolesTable.tsx
+++ b/frontend/src/component/admin/roles/RolesTable/RolesTable.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import type { IRole, PredefinedRoleType } from 'interfaces/role';
 import useToast from 'hooks/useToast';
@@ -7,10 +8,14 @@ import { formatUnknownError } from 'utils/formatUnknownError';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { useTheme, useMediaQuery } from '@mui/material';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
-import { useFlexLayout, useSortBy, useTable } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { useSearch } from 'hooks/useSearch';
 import { IconCell } from 'component/common/Table/cells/IconCell/IconCell';
 import SupervisedUserCircle from '@mui/icons-material/SupervisedUserCircle';
@@ -64,38 +69,37 @@ export const RolesTable = ({
 
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<IRole, unknown>[]>(
         () => [
             {
                 id: 'Icon',
-                Cell: () => (
+                cell: () => (
                     <IconCell
                         icon={<SupervisedUserCircle color='disabled' />}
                     />
                 ),
-                disableGlobalFilter: true,
-                maxWidth: 50,
+                enableGlobalFilter: false,
+                meta: { maxWidth: 50 },
             },
             {
-                Header: 'Role',
-                accessor: 'name',
-                Cell: ({ row: { original: role } }: any) => (
+                id: 'name',
+                header: 'Role',
+                accessorKey: 'name',
+                cell: ({ row: { original: role } }) => (
                     <RolesCell role={role} />
                 ),
-                searchable: true,
-                minWidth: 100,
+                meta: { searchable: true, minWidth: 100 },
             },
             {
                 id: 'permissions',
-                Header: 'Permissions',
-                Cell: RolePermissionsCell,
-                maxWidth: 140,
+                header: 'Permissions',
+                cell: RolePermissionsCell,
+                meta: { maxWidth: 140 },
             },
             {
-                Header: 'Actions',
                 id: 'Actions',
-                align: 'center',
-                Cell: ({ row: { original: role } }: any) => (
+                header: 'Actions',
+                cell: ({ row: { original: role } }) => (
                     <RolesActionsCell
                         role={role}
                         onEdit={() => {
@@ -108,22 +112,24 @@ export const RolesTable = ({
                         }}
                     />
                 ),
-                width: 150,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { width: 150, align: 'center' },
             },
             // Always hidden -- for search
             {
-                accessor: 'description',
-                Header: 'Description',
-                searchable: true,
+                id: 'description',
+                header: 'Description',
+                accessorKey: 'description',
+                meta: { searchable: true },
             },
         ],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [],
     );
 
     const [initialState] = useState({
-        sortBy: [{ id: 'name' }],
-        hiddenColumns: ['description'],
+        sorting: [{ id: 'name', desc: false }],
+        columnVisibility: { description: false },
     });
 
     const { data, getSearchText } = useSearch(
@@ -132,46 +138,42 @@ export const RolesTable = ({
         type === ROOT_ROLE_TYPE ? roles : projectRoles,
     );
 
-    const { headerGroups, rows, prepareRow, setHiddenColumns } = useTable(
-        {
-            columns: columns as any,
-            data,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-            defaultColumn: {
-                Cell: TextCell,
-            },
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
         },
-        useSortBy,
-        useFlexLayout,
-    );
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isSmallScreen,
                 columns: ['Icon'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
+
+    const rowCount = table.getRowModel().rows.length;
 
     return (
         <PageContent isLoading={loading}>
             <SearchHighlightProvider value={getSearchText(searchValue)}>
-                <VirtualizedTable
-                    rows={rows}
-                    headerGroups={headerGroups}
-                    prepareRow={prepareRow}
-                />
+                <VirtualizedTableV8 tableInstance={table} />
             </SearchHighlightProvider>
             <ConditionallyRender
-                condition={rows.length === 0}
+                condition={rowCount === 0}
                 show={
                     <ConditionallyRender
                         condition={searchValue?.length > 0}

--- a/frontend/src/component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountsTable.tsx
+++ b/frontend/src/component/admin/serviceAccounts/ServiceAccountsTable/ServiceAccountsTable.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import type { IRole } from 'interfaces/role';
 import useToast from 'hooks/useToast';
@@ -8,15 +9,19 @@ import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { Button, useMediaQuery } from '@mui/material';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
-import { useFlexLayout, useSortBy, useTable } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import theme from 'themes/theme';
 import { Search } from 'component/common/Search/Search';
 import { UserAvatar } from 'component/common/UserAvatar/UserAvatar';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { useSearch } from 'hooks/useSearch';
 import { useServiceAccounts } from 'hooks/api/getters/useServiceAccounts/useServiceAccounts';
 import { useServiceAccountsApi } from 'hooks/api/actions/useServiceAccountsApi/useServiceAccountsApi';
@@ -61,96 +66,88 @@ export const ServiceAccountsTable = () => {
     const isExtraSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<IServiceAccount, unknown>[]>(
         () => [
             {
-                Header: 'Avatar',
-                accessor: 'imageUrl',
-                Cell: ({ row: { original: serviceAccount } }: any) => (
+                id: 'imageUrl',
+                header: 'Avatar',
+                accessorKey: 'imageUrl',
+                cell: ({ row: { original: serviceAccount } }) => (
                     <TextCell>
                         <UserAvatar user={serviceAccount} />
                     </TextCell>
                 ),
-                disableSortBy: true,
-                maxWidth: 80,
+                enableSorting: false,
+                meta: { maxWidth: 80 },
             },
             {
                 id: 'name',
-                Header: 'Name',
-                accessor: (row: any) => row.name || '',
-                minWidth: 200,
-                Cell: ({ row: { original: serviceAccount } }: any) => (
+                header: 'Name',
+                accessorFn: (row) => row.name || '',
+                cell: ({ row: { original: serviceAccount } }) => (
                     <HighlightCell
-                        value={serviceAccount.name}
+                        value={serviceAccount.name ?? ''}
                         subtitle={serviceAccount.username}
                     />
                 ),
-                searchable: true,
+                meta: { minWidth: 200, searchable: true },
             },
             {
                 id: 'role',
-                Header: 'Role',
-                accessor: (row: any) =>
+                header: 'Role',
+                accessorFn: (row) =>
                     roles.find((role: IRole) => role.id === row.rootRole)
                         ?.name || '',
-                Cell: ({
-                    row: { original: serviceAccount },
-                    value,
-                }: {
-                    row: { original: IServiceAccount };
-                    value: string;
-                }) => <RoleCell value={value} role={serviceAccount.rootRole} />,
-                maxWidth: 120,
+                cell: ({ getValue, row: { original: serviceAccount } }) => (
+                    <RoleCell
+                        value={String(getValue() ?? '')}
+                        role={serviceAccount.rootRole}
+                    />
+                ),
+                meta: { maxWidth: 120 },
             },
             {
                 id: 'tokens',
-                Header: 'Tokens',
-                accessor: (row: IServiceAccount) =>
+                header: 'Tokens',
+                accessorFn: (row) =>
                     row.tokens
                         ?.map(({ description }) => description)
                         .join('\n') || '',
-                Cell: ({
-                    row: { original: serviceAccount },
-                    value,
-                }: {
-                    row: { original: IServiceAccount };
-                    value: string;
-                }) => (
+                cell: ({ getValue, row: { original: serviceAccount } }) => (
                     <ServiceAccountTokensCell
                         serviceAccount={serviceAccount}
-                        value={value}
+                        value={String(getValue() ?? '')}
                         onCreateToken={() => {
                             setSelectedServiceAccount(serviceAccount);
                             setModalOpen(true);
                         }}
                     />
                 ),
-                searchable: true,
+                meta: { searchable: true },
             },
             {
-                Header: 'Created',
-                accessor: 'createdAt',
-                Cell: DateCell,
-                width: 120,
-                maxWidth: 120,
+                id: 'createdAt',
+                header: 'Created',
+                accessorKey: 'createdAt',
+                cell: DateCell,
+                meta: { width: 120, maxWidth: 120 },
             },
             {
                 id: 'seenAt',
-                Header: 'Last seen',
-                accessor: (row: IServiceAccount) =>
+                header: 'Last seen',
+                accessorFn: (row) =>
                     row.tokens.sort((a, b) => {
                         const aSeenAt = new Date(a.seenAt || 0);
                         const bSeenAt = new Date(b.seenAt || 0);
                         return bSeenAt?.getTime() - aSeenAt?.getTime();
                     })[0]?.seenAt,
-                Cell: TimeAgoCell,
-                maxWidth: 150,
+                cell: TimeAgoCell,
+                meta: { maxWidth: 150 },
             },
             {
-                Header: 'Actions',
                 id: 'Actions',
-                align: 'center',
-                Cell: ({ row: { original: serviceAccount } }: any) => (
+                header: 'Actions',
+                cell: ({ row: { original: serviceAccount } }) => (
                     <ServiceAccountsActionsCell
                         onEdit={() => {
                             setSelectedServiceAccount(serviceAccount);
@@ -162,22 +159,24 @@ export const ServiceAccountsTable = () => {
                         }}
                     />
                 ),
-                width: 150,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { width: 150, align: 'center' },
             },
             // Always hidden -- for search
             {
-                accessor: 'username',
-                Header: 'Username',
-                searchable: true,
+                id: 'username',
+                header: 'Username',
+                accessorKey: 'username',
+                meta: { searchable: true },
             },
         ],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [roles],
     );
 
     const [initialState] = useState({
-        sortBy: [{ id: 'createdAt', desc: true }],
-        hiddenColumns: ['username'],
+        sorting: [{ id: 'createdAt', desc: true }],
+        columnVisibility: { username: false },
     });
 
     const { data, getSearchText } = useSearch(
@@ -186,25 +185,23 @@ export const ServiceAccountsTable = () => {
         serviceAccounts,
     );
 
-    const { headerGroups, rows, prepareRow, setHiddenColumns } = useTable(
-        {
-            columns: columns as any,
-            data,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-            defaultColumn: {
-                Cell: TextCell,
-            },
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
         },
-        useSortBy,
-        useFlexLayout,
-    );
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isExtraSmallScreen,
@@ -215,16 +212,18 @@ export const ServiceAccountsTable = () => {
                 columns: ['imageUrl', 'tokens', 'createdAt'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
+
+    const rowCount = table.getRowModel().rows.length;
 
     return (
         <PageContent
             isLoading={loading}
             header={
                 <PageHeader
-                    title={`Service Accounts (${rows.length})`}
+                    title={`Service Accounts (${rowCount})`}
                     actions={
                         <>
                             <ConditionallyRender
@@ -265,14 +264,10 @@ export const ServiceAccountsTable = () => {
             }
         >
             <SearchHighlightProvider value={getSearchText(searchValue)}>
-                <VirtualizedTable
-                    rows={rows}
-                    headerGroups={headerGroups}
-                    prepareRow={prepareRow}
-                />
+                <VirtualizedTableV8 tableInstance={table} />
             </SearchHighlightProvider>
             <ConditionallyRender
-                condition={rows.length === 0}
+                condition={rowCount === 0}
                 show={
                     <ConditionallyRender
                         condition={searchValue?.length > 0}

--- a/frontend/src/component/archive/FeaturesArchiveTable.tsx
+++ b/frontend/src/component/archive/FeaturesArchiveTable.tsx
@@ -1,11 +1,10 @@
 import { ArchiveTable } from 'component/archive/ArchiveTable/ArchiveTable';
-import type { SortingRule } from 'react-table';
 import { usePageTitle } from 'hooks/usePageTitle';
 import { createLocalStorage } from 'utils/createLocalStorage';
 import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
 import { useSearchParams } from 'react-router-dom';
 
-const defaultSort: SortingRule<string> = { id: 'createdAt' };
+const defaultSort: { id: string; desc?: boolean } = { id: 'createdAt' };
 const { value, setValue } = createLocalStorage(
     'FeaturesArchiveTable:v1',
     defaultSort,

--- a/frontend/src/component/changeRequest/ProjectChangeRequests/ChangeRequestsTabs/ChangeRequestsTabs.tsx
+++ b/frontend/src/component/changeRequest/ProjectChangeRequests/ChangeRequestsTabs/ChangeRequestsTabs.tsx
@@ -3,18 +3,23 @@ import { isClosed } from 'component/changeRequest/changeRequest.types';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import {
-    SortableTableHeader,
     Table,
     TableBody,
     TableCell,
     TablePlaceholder,
     TableRow,
 } from 'component/common/Table';
-import { type SortingRule, useSortBy, useTable } from 'react-table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
+import {
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { Box, styled, Tab, Tabs, useMediaQuery } from '@mui/material';
 import { Link, useSearchParams } from 'react-router-dom';
-import { sortTypes } from 'utils/sortTypes';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { Search } from 'component/common/Search/Search';
 import { featuresPlaceholder } from 'component/feature/FeatureToggleList/FeatureToggleListTable';
@@ -26,7 +31,7 @@ import { ChangeRequestStatusCell } from './ChangeRequestStatusCell.tsx';
 import { AvatarCell } from './AvatarCell.tsx';
 import { ChangeRequestTitleCell } from './ChangeRequestTitleCell.tsx';
 import { createLocalStorage } from 'utils/createLocalStorage';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { useStyles } from './ChangeRequestsTabs.styles';
 import { FeaturesCell } from './FeaturesCell.tsx';
 import { HighlightCell } from '../../../common/Table/cells/HighlightCell/HighlightCell.tsx';
@@ -38,7 +43,9 @@ export interface IChangeRequestTableProps {
     placeholder?: ReactNode;
 }
 
-const defaultSort: SortingRule<string> & {
+const defaultSort: {
+    id: string;
+    desc: boolean;
     columns?: string[];
     type?: 'open' | 'closed';
 } = { id: 'createdAt', desc: true };
@@ -120,87 +127,109 @@ export const ChangeRequestsTabs = ({
     const activeTab =
         tabs.find((tab) => tab.type === changeRequestType) || tabs[0];
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<any, unknown>[]>(
         () => [
             {
                 id: 'Title',
-                Header: 'Title',
-                canSort: true,
-                accessor: 'title',
-                searchable: true,
-                Cell: ChangeRequestTitleCell,
+                header: 'Title',
+                accessorKey: 'title',
+                cell: ({ getValue, row }) => (
+                    <ChangeRequestTitleCell
+                        value={getValue() as string}
+                        row={row}
+                    />
+                ),
+                meta: { searchable: true },
             },
             {
                 id: 'Updated feature flags',
-                Header: 'Updated feature flags',
-                canSort: false,
-                accessor: 'features',
-                searchable: true,
-                filterName: 'feature',
-                filterParsing: (values: Array<{ name: string }>) => {
-                    return values?.map(({ name }) => name).join('\n') || '';
-                },
-                filterBy: (
-                    row: { features: Array<{ name: string }> },
-                    values: Array<string>,
-                ) => {
-                    return row.features.find((feature) =>
-                        values
-                            .map((value) => value.toLowerCase())
-                            .includes(feature.name.toLowerCase()),
-                    );
-                },
-                Cell: ({
-                    value,
+                header: 'Updated feature flags',
+                accessorKey: 'features',
+                enableSorting: false,
+                cell: ({
+                    getValue,
                     row: {
                         original: { title },
                     },
-                }: any) => (
+                }) => (
                     <FeaturesCell
                         project={projectId}
-                        value={value}
+                        value={getValue()}
                         key={title}
                     />
                 ),
+                meta: {
+                    searchable: true,
+                    filterName: 'feature',
+                    filterParsing: (values: Array<{ name: string }>) => {
+                        return values?.map(({ name }) => name).join('\n') || '';
+                    },
+                    filterBy: (
+                        row: { features: Array<{ name: string }> },
+                        values: Array<string>,
+                    ) => {
+                        return row.features.find((feature) =>
+                            values
+                                .map((value) => value.toLowerCase())
+                                .includes(feature.name.toLowerCase()),
+                        );
+                    },
+                },
             },
             {
-                Header: 'By',
-                accessor: 'createdBy',
-                width: '10%',
-                canSort: false,
-                Cell: AvatarCell,
-                align: 'left',
-                searchable: true,
-                filterName: 'by',
-                filterParsing: (value: { username?: string }) =>
-                    value?.username || '',
+                id: 'createdBy',
+                header: 'By',
+                accessorKey: 'createdBy',
+                enableSorting: false,
+                cell: ({ getValue }) => (
+                    <AvatarCell value={getValue() as any} />
+                ),
+                meta: {
+                    width: '10%',
+                    align: 'left',
+                    searchable: true,
+                    filterName: 'by',
+                    filterParsing: (value: { username?: string }) =>
+                        value?.username || '',
+                },
             },
             {
-                Header: 'Submitted',
-                accessor: 'createdAt',
-                maxWidth: 100,
-                width: '5%',
-                Cell: TimeAgoCell,
+                id: 'createdAt',
+                header: 'Submitted',
+                accessorKey: 'createdAt',
+                cell: TimeAgoCell,
+                meta: { maxWidth: 100, width: '5%' },
             },
             {
-                Header: 'Environment',
-                accessor: 'environment',
-                searchable: true,
-                width: '10%',
-                Cell: HighlightCell,
-                filterName: 'environment',
+                id: 'environment',
+                header: 'Environment',
+                accessorKey: 'environment',
+                cell: HighlightCell,
+                meta: {
+                    searchable: true,
+                    width: '10%',
+                    filterName: 'environment',
+                },
             },
             {
-                Header: 'Status',
-                accessor: 'state',
-                searchable: true,
-                maxWidth: '170px',
-                width: '10%',
-                Cell: ChangeRequestStatusCell,
-                filterName: 'status',
+                id: 'state',
+                header: 'Status',
+                accessorKey: 'state',
+                cell: ({ getValue, row }) => (
+                    <ChangeRequestStatusCell
+                        value={getValue() as string}
+                        row={row}
+                    />
+                ),
+                meta: {
+                    searchable: true,
+                    maxWidth: '170px',
+                    width: '10%',
+                    filterName: 'status',
+                },
             },
         ],
-        //eslint-disable-next-line
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [projectId],
     );
 
@@ -216,7 +245,7 @@ export const ChangeRequestsTabs = ({
     );
 
     const [initialState] = useState(() => ({
-        sortBy: [
+        sorting: [
             {
                 id: searchParams.get('sort') || storedParams.id,
                 desc: searchParams.has('order')
@@ -224,51 +253,48 @@ export const ChangeRequestsTabs = ({
                     : storedParams.desc,
             },
         ],
-        hiddenColumns: [],
     }));
 
-    const {
-        headerGroups,
-        rows,
-        state: { sortBy },
-        prepareRow,
-        setHiddenColumns,
-        getTableProps,
-        getTableBodyProps,
-    } = useTable(
-        {
-            columns: columns as any[], // TODO: fix after `react-table` v8 update
-            data,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            disableSortRemove: true,
-            autoResetSortBy: false,
-            defaultColumn: {
-                Cell: TextCell,
-            },
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
         },
-        useSortBy,
-    );
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isSmallScreen,
                 columns: ['createdBy'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
+
+    const sorting = table.getState().sorting;
+    const rows = table.getRowModel().rows;
 
     useEffect(() => {
         if (loading) {
             return;
         }
+        const sortRule = sorting[0];
+        if (!sortRule) {
+            return;
+        }
         const tableState: Record<string, string> = {};
-        tableState.sort = sortBy[0].id;
-        if (sortBy[0].desc) {
+        tableState.sort = sortRule.id;
+        if (sortRule.desc) {
             tableState.order = 'desc';
         }
         if (searchValue) {
@@ -281,12 +307,12 @@ export const ChangeRequestsTabs = ({
         });
         setStoredParams((params) => ({
             ...params,
-            id: sortBy[0].id,
-            desc: sortBy[0].desc || false,
+            id: sortRule.id,
+            desc: sortRule.desc || false,
             type: changeRequestType,
         }));
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [loading, sortBy, searchValue, setSearchParams, changeRequestType]);
+    }, [loading, sorting, searchValue, setSearchParams, changeRequestType]);
 
     return (
         <PageContent
@@ -337,27 +363,21 @@ export const ChangeRequestsTabs = ({
                 </Link>
             </ConfigurationLinkBox>
             <SearchHighlightProvider value={getSearchText(searchValue)}>
-                <StyledTable {...getTableProps()}>
-                    <SortableTableHeader headerGroups={headerGroups} />
-                    <TableBody {...getTableBodyProps()}>
-                        {rows.map((row) => {
-                            prepareRow(row);
-                            const { key, ...rowProps } = row.getRowProps();
-                            return (
-                                <TableRow hover key={key} {...rowProps}>
-                                    {row.cells.map((cell) => {
-                                        const { key, ...cellProps } =
-                                            cell.getCellProps();
-
-                                        return (
-                                            <TableCell key={key} {...cellProps}>
-                                                {cell.render('Cell')}
-                                            </TableCell>
-                                        );
-                                    })}
-                                </TableRow>
-                            );
-                        })}
+                <StyledTable>
+                    <SortableTableHeaderV8 tableInstance={table} />
+                    <TableBody>
+                        {rows.map((row) => (
+                            <TableRow hover key={row.id}>
+                                {row.getVisibleCells().map((cell) => (
+                                    <TableCell key={cell.id}>
+                                        {flexRender(
+                                            cell.column.columnDef.cell,
+                                            cell.getContext(),
+                                        )}
+                                    </TableCell>
+                                ))}
+                            </TableRow>
+                        ))}
                     </TableBody>
                 </StyledTable>
             </SearchHighlightProvider>

--- a/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
+++ b/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
@@ -1,13 +1,20 @@
 import { type FC, useMemo, useState } from 'react';
-import { useGlobalFilter, useSortBy, useTable } from 'react-table';
+import {
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    getFilteredRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import {
     Table,
-    SortableTableHeader,
     TableBody,
     TableCell,
     TableRow,
     TablePlaceholder,
 } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
@@ -18,7 +25,6 @@ import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { AddContextButton } from '../AddContextButton.tsx';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
-import { sortTypes } from 'utils/sortTypes';
 import { LinkCell } from 'component/common/Table/cells/LinkCell/LinkCell';
 import { ContextActionsCell } from '../ContextActionsCell.tsx';
 import Adjust from '@mui/icons-material/Adjust';
@@ -27,20 +33,30 @@ import { Search } from 'component/common/Search/Search';
 import { UsedInCell } from '../UsedInCell.tsx';
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam.ts';
 
+type ContextRow = {
+    name: string;
+    description: string;
+    sortOrder: number;
+    usedInProjects?: number;
+    usedInFeatures?: number;
+};
+
 const ContextList: FC = () => {
     const projectId = useOptionalPathParam('projectId');
     const [showDelDialogue, setShowDelDialogue] = useState(false);
     const [contextFieldToDelete, setContextFieldToDelete] = useState<string>();
+    const [globalFilter, setGlobalFilter] = useState('');
     const { context, refetchUnleashContext, loading } =
         useScopedUnleashContext();
     const { removeContext } = useContextsApi(projectId);
     const { setToastData, setToastApiError } = useToast();
 
-    const data = useMemo(() => {
+    const data = useMemo<ContextRow[]>(() => {
         if (loading) {
             return Array(5).fill({
                 name: 'Context name',
                 description: 'Context description when loading',
+                sortOrder: 0,
             });
         }
 
@@ -54,8 +70,8 @@ const ContextList: FC = () => {
                     usedInFeatures,
                 }) => ({
                     name,
-                    description,
-                    sortOrder,
+                    description: description ?? '',
+                    sortOrder: sortOrder ?? 0,
                     usedInProjects,
                     usedInFeatures,
                 }),
@@ -63,22 +79,22 @@ const ContextList: FC = () => {
             .sort((a, b) => a.sortOrder - b.sortOrder);
     }, [context, loading]);
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<ContextRow, unknown>[]>(
         () => [
             {
                 id: 'Icon',
-                Cell: () => <IconCell icon={<Adjust color='disabled' />} />,
-                disableGlobalFilter: true,
+                cell: () => <IconCell icon={<Adjust color='disabled' />} />,
+                enableGlobalFilter: false,
             },
             {
-                Header: 'Name',
-                accessor: 'name',
-                width: '70%',
-                Cell: ({
+                id: 'name',
+                header: 'Name',
+                accessorKey: 'name',
+                cell: ({
                     row: {
                         original: { name, description },
                     },
-                }: any) => {
+                }) => {
                     const editUrl = projectId
                         ? `/projects/${projectId}/settings/context/edit/${name}`
                         : `/context/edit/${name}`;
@@ -91,24 +107,28 @@ const ContextList: FC = () => {
                         />
                     );
                 },
-                sortType: 'alphanumeric',
+                sortingFn: 'alphanumeric',
+                meta: { width: '70%' },
             },
             {
-                Header: 'Used in',
-                width: '60%',
-                Cell: ({ row: { original } }: any) => (
-                    <UsedInCell original={original} />
+                id: 'usedIn',
+                header: 'Used in',
+                cell: ({ row: { original } }) => (
+                    // UsedInCell types its prop against
+                    // IUnleashContextDefinition; runtime only reads
+                    // usedInProjects/usedInFeatures, present on ContextRow.
+                    <UsedInCell original={original as never} />
                 ),
+                meta: { width: '60%' },
             },
             {
-                Header: 'Actions',
                 id: 'Actions',
-                align: 'center',
-                Cell: ({
+                header: 'Actions',
+                cell: ({
                     row: {
                         original: { name, usedInFeatures },
                     },
-                }: any) => (
+                }) => (
                     <ContextActionsCell
                         name={name}
                         onDelete={() => {
@@ -118,27 +138,28 @@ const ContextList: FC = () => {
                         allowDelete={usedInFeatures === 0}
                     />
                 ),
-                width: 150,
-                disableGlobalFilter: true,
-                disableSortBy: true,
+                enableSorting: false,
+                enableGlobalFilter: false,
+                meta: { width: 150, align: 'center' },
             },
             {
-                accessor: 'description',
-                disableSortBy: true,
+                id: 'description',
+                accessorKey: 'description',
+                enableSorting: false,
             },
             {
-                accessor: 'sortOrder',
-                disableGlobalFilter: true,
-                sortType: 'number',
+                id: 'sortOrder',
+                accessorKey: 'sortOrder',
+                enableGlobalFilter: false,
             },
         ],
-        [],
+        [projectId],
     );
 
     const initialState = useMemo(
         () => ({
-            sortBy: [{ id: 'name', desc: false }],
-            hiddenColumns: ['description', 'sortOrder'],
+            sorting: [{ id: 'name', desc: false }],
+            columnVisibility: { description: false, sortOrder: false },
         }),
         [],
     );
@@ -161,27 +182,20 @@ const ContextList: FC = () => {
         setShowDelDialogue(false);
     };
 
-    const {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
         state: { globalFilter },
-        setGlobalFilter,
-    } = useTable(
-        {
-            columns: columns as any[], // TODO: fix after `react-table` v8 update
-            data,
-            initialState,
-            sortTypes,
-            autoResetGlobalFilter: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-        },
-        useGlobalFilter,
-        useSortBy,
-    );
+        onGlobalFilterChange: setGlobalFilter,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
+
+    const rows = table.getRowModel().rows;
 
     return (
         <PageContent
@@ -193,7 +207,7 @@ const ContextList: FC = () => {
                         <>
                             <Search
                                 initialValue={globalFilter}
-                                onChange={setGlobalFilter}
+                                onChange={(value) => setGlobalFilter(value)}
                             />
                             <PageHeader.Divider />
                             <AddContextButton />
@@ -203,27 +217,21 @@ const ContextList: FC = () => {
             }
         >
             <SearchHighlightProvider value={globalFilter}>
-                <Table {...getTableProps()}>
-                    <SortableTableHeader headerGroups={headerGroups} />
-                    <TableBody {...getTableBodyProps()}>
-                        {rows.map((row) => {
-                            prepareRow(row);
-                            const { key, ...rowProps } = row.getRowProps();
-                            return (
-                                <TableRow hover key={key} {...rowProps}>
-                                    {row.cells.map((cell) => {
-                                        const { key, ...cellProps } =
-                                            cell.getCellProps();
-
-                                        return (
-                                            <TableCell key={key} {...cellProps}>
-                                                {cell.render('Cell')}
-                                            </TableCell>
-                                        );
-                                    })}
-                                </TableRow>
-                            );
-                        })}
+                <Table>
+                    <SortableTableHeaderV8 tableInstance={table} />
+                    <TableBody>
+                        {rows.map((row) => (
+                            <TableRow hover key={row.id}>
+                                {row.getVisibleCells().map((cell) => (
+                                    <TableCell key={cell.id}>
+                                        {flexRender(
+                                            cell.column.columnDef.cell,
+                                            cell.getContext(),
+                                        )}
+                                    </TableCell>
+                                ))}
+                            </TableRow>
+                        ))}
                     </TableBody>
                 </Table>
             </SearchHighlightProvider>

--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentRow/EnvironmentRow.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentRow/EnvironmentRow.tsx
@@ -1,11 +1,12 @@
 import { type OnMoveItem, useDragItem } from 'hooks/useDragItem';
-import type { Row } from 'react-table';
+import { flexRender, type Row } from '@tanstack/react-table';
 import { styled, TableRow } from '@mui/material';
 import { TableCell } from 'component/common/Table';
 import { useSearchHighlightContext } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { UPDATE_ENVIRONMENT } from 'component/providers/AccessProvider/permissions';
 import AccessContext from 'contexts/AccessContext';
 import { type ForwardedRef, useContext, useRef } from 'react';
+import type { IEnvironment } from 'interfaces/environments';
 
 const StyledTableRow = styled(TableRow)(() => ({
     '&:hover': {
@@ -17,7 +18,7 @@ const StyledTableRow = styled(TableRow)(() => ({
 }));
 
 interface IEnvironmentRowProps {
-    row: Row;
+    row: Row<IEnvironment>;
     onMoveItem: OnMoveItem;
 }
 
@@ -33,31 +34,38 @@ export const EnvironmentRow = ({ row, onMoveItem }: IEnvironmentRowProps) => {
         dragHandleRef,
     );
 
-    const renderCell = (cell: any, ref: ForwardedRef<HTMLElement>) => {
-        const { key, ...cellProps } = cell.getCellProps();
-        if (draggable && cell.column.isDragHandle) {
+    const renderCell = (
+        cell: Row<IEnvironment>['_getAllVisibleCells'] extends () => infer T
+            ? T extends Array<infer U>
+                ? U
+                : never
+            : never,
+        ref: ForwardedRef<HTMLElement>,
+    ) => {
+        const isDragHandle = cell.column.columnDef.meta?.isDragHandle;
+        const content = flexRender(
+            cell.column.columnDef.cell,
+            cell.getContext(),
+        );
+        if (draggable && isDragHandle) {
             return (
                 <TableCell
-                    key={key}
-                    {...cellProps}
-                    ref={ref}
+                    key={cell.id}
+                    ref={ref as ForwardedRef<HTMLTableCellElement>}
                     className='drag-handle'
                 >
-                    {cell.render('Cell')}
-                </TableCell>
-            );
-        } else {
-            return (
-                <TableCell key={key} {...cellProps}>
-                    {cell.render('Cell')}
+                    {content}
                 </TableCell>
             );
         }
+        return <TableCell key={cell.id}>{content}</TableCell>;
     };
 
     return (
         <StyledTableRow hover ref={draggable ? dragItemRef : undefined}>
-            {row.cells.map((cell: any) => renderCell(cell, dragHandleRef))}
+            {row
+                .getVisibleCells()
+                .map((cell) => renderCell(cell, dragHandleRef))}
         </StyledTableRow>
     );
 };

--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentTable.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentTable.tsx
@@ -2,13 +2,15 @@ import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { useEnvironments } from 'hooks/api/getters/useEnvironments/useEnvironments';
 import { CreateEnvironmentButton } from 'component/environments/CreateEnvironmentButton/CreateEnvironmentButton';
-import { useTable, useGlobalFilter } from 'react-table';
 import {
-    SortableTableHeader,
-    Table,
-    TablePlaceholder,
-} from 'component/common/Table';
-import { useCallback, useMemo } from 'react';
+    type ColumnDef,
+    getCoreRowModel,
+    getFilteredRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { Table, TablePlaceholder } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
+import { useCallback, useMemo, useState } from 'react';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { Alert, styled, TableBody } from '@mui/material';
 import type { OnMoveItem } from 'hooks/useDragItem';
@@ -34,12 +36,55 @@ const StyledAlert = styled(Alert)(({ theme }) => ({
     marginBottom: theme.spacing(4),
 }));
 
+const COLUMNS: ColumnDef<IEnvironment, unknown>[] = [
+    {
+        id: 'Icon',
+        cell: ({ row: { original } }) => (
+            <EnvironmentIconCell environment={original} />
+        ),
+        enableGlobalFilter: false,
+        meta: { width: '1%', isDragHandle: true },
+    },
+    {
+        id: 'name',
+        header: 'Name',
+        accessorKey: 'name',
+        cell: ({ row: { original } }) => (
+            <EnvironmentNameCell environment={original} />
+        ),
+        meta: { minWidth: 350 },
+    },
+    {
+        id: 'type',
+        header: 'Type',
+        accessorKey: 'type',
+        cell: HighlightCell,
+    },
+    {
+        id: 'projectCount',
+        header: 'Visible in',
+        accessorFn: (row) =>
+            row.projectCount === 1
+                ? '1 project'
+                : `${row.projectCount} projects`,
+        cell: TextCell,
+    },
+    {
+        id: 'apiTokenCount',
+        header: 'API Tokens',
+        accessorFn: (row) =>
+            row.apiTokenCount === 1 ? '1 token' : `${row.apiTokenCount} tokens`,
+        cell: TextCell,
+    },
+];
+
 export const EnvironmentTable = () => {
     const { changeSortOrder } = useEnvironmentApi();
     const { setToastApiError } = useToast();
     const { environments, mutateEnvironments } = useEnvironments();
     const isFeatureEnabled = useUiFlag('EEA');
     const { isEnterprise } = useUiConfig();
+    const [globalFilter, setGlobalFilter] = useState('');
 
     const onMoveItem: OnMoveItem = useCallback(
         async ({ dragIndex, dropIndex, save }) => {
@@ -63,59 +108,57 @@ export const EnvironmentTable = () => {
         [changeSortOrder, environments, mutateEnvironments, setToastApiError],
     );
 
-    const columnsWithActions = useMemo(() => {
-        const baseColumns = [
+    const columnsWithActions = useMemo<
+        ColumnDef<IEnvironment, unknown>[]
+    >(() => {
+        const baseColumns: ColumnDef<IEnvironment, unknown>[] = [
             ...COLUMNS,
             ...(isFeatureEnabled
                 ? [
                       {
-                          Header: 'Actions',
                           id: 'Actions',
-                          align: 'center',
-                          width: '1%',
-                          Cell: ({
-                              row: { original },
-                          }: {
-                              row: { original: IEnvironment };
-                          }) => (
+                          header: 'Actions',
+                          cell: ({ row: { original } }) => (
                               <EnvironmentActionCell environment={original} />
                           ),
-                          disableGlobalFilter: true,
-                      },
+                          enableGlobalFilter: false,
+                          meta: { width: '1%', align: 'center' as const },
+                      } satisfies ColumnDef<IEnvironment, unknown>,
                   ]
                 : []),
         ];
         if (isEnterprise()) {
             baseColumns.splice(2, 0, {
-                Header: 'Change request',
-                accessor: (row: IEnvironment) =>
+                id: 'changeRequest',
+                header: 'Change request',
+                accessorFn: (row) =>
                     Number.isInteger(row.requiredApprovals) ? 'yes' : 'no',
-                Cell: TextCell,
+                cell: TextCell,
             });
         }
 
         return baseColumns;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isFeatureEnabled]);
 
-    const {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
+    const table = useReactTable({
+        columns: columnsWithActions,
+        data: environments,
         state: { globalFilter },
-        setGlobalFilter,
-    } = useTable(
-        {
-            columns: columnsWithActions as any,
-            data: environments,
-            disableSortBy: true,
-        },
-        useGlobalFilter,
-    );
+        onGlobalFilterChange: setGlobalFilter,
+        getCoreRowModel: getCoreRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        enableSorting: false,
+        autoResetAll: false,
+    });
+
+    const rows = table.getRowModel().rows;
 
     const headerSearch = (
-        <Search initialValue={globalFilter} onChange={setGlobalFilter} />
+        <Search
+            initialValue={globalFilter}
+            onChange={(value) => setGlobalFilter(value)}
+        />
     );
 
     const headerActions = (
@@ -146,19 +189,16 @@ export const EnvironmentTable = () => {
                 inside each feature flag.
             </StyledAlert>
             <SearchHighlightProvider value={globalFilter}>
-                <Table {...getTableProps()} rowHeight='compact'>
-                    <SortableTableHeader headerGroups={headerGroups as any} />
-                    <TableBody {...getTableBodyProps()}>
-                        {rows.map((row) => {
-                            prepareRow(row);
-                            return (
-                                <EnvironmentRow
-                                    row={row as any}
-                                    onMoveItem={onMoveItem}
-                                    key={row.original.name}
-                                />
-                            );
-                        })}
+                <Table rowHeight='compact'>
+                    <SortableTableHeaderV8 tableInstance={table} />
+                    <TableBody>
+                        {rows.map((row) => (
+                            <EnvironmentRow
+                                row={row}
+                                onMoveItem={onMoveItem}
+                                key={row.original.name}
+                            />
+                        ))}
                     </TableBody>
                 </Table>
             </SearchHighlightProvider>
@@ -186,42 +226,3 @@ export const EnvironmentTable = () => {
         </PageContent>
     );
 };
-
-const COLUMNS = [
-    {
-        id: 'Icon',
-        width: '1%',
-        Cell: ({ row: { original } }: { row: { original: IEnvironment } }) => (
-            <EnvironmentIconCell environment={original} />
-        ),
-        disableGlobalFilter: true,
-        isDragHandle: true,
-    },
-    {
-        Header: 'Name',
-        accessor: 'name',
-        Cell: ({ row: { original } }: { row: { original: IEnvironment } }) => (
-            <EnvironmentNameCell environment={original} />
-        ),
-        minWidth: 350,
-    },
-    {
-        Header: 'Type',
-        accessor: 'type',
-        Cell: HighlightCell,
-    },
-    {
-        Header: 'Visible in',
-        accessor: (row: IEnvironment) =>
-            row.projectCount === 1
-                ? '1 project'
-                : `${row.projectCount} projects`,
-        Cell: TextCell,
-    },
-    {
-        Header: 'API Tokens',
-        accessor: (row: IEnvironment) =>
-            row.apiTokenCount === 1 ? '1 token' : `${row.apiTokenCount} tokens`,
-        Cell: TextCell,
-    },
-];

--- a/frontend/src/component/environments/EnvironmentTable/EnvironmentTableSingle.tsx
+++ b/frontend/src/component/environments/EnvironmentTable/EnvironmentTableSingle.tsx
@@ -1,7 +1,13 @@
 import { styled, TableBody, TableRow } from '@mui/material';
 import type { IEnvironment } from 'interfaces/environments';
-import { useTable } from 'react-table';
-import { SortableTableHeader, Table, TableCell } from 'component/common/Table';
+import {
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { Table, TableCell } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
 import { EnvironmentIconCell } from 'component/environments/EnvironmentTable/EnvironmentIconCell/EnvironmentIconCell';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
@@ -26,42 +32,37 @@ export const EnvironmentTableSingle = ({
     environment,
     warnEnabledToggles,
 }: IEnvironmentTableSingleProps) => {
-    const COLUMNS = useMemo(
+    const columns = useMemo<ColumnDef<IEnvironment, unknown>[]>(
         () => [
             {
                 id: 'Icon',
-                width: '1%',
-                Cell: ({
-                    row: { original },
-                }: {
-                    row: { original: IEnvironment };
-                }) => <EnvironmentIconCell environment={original} />,
+                cell: ({ row: { original } }) => (
+                    <EnvironmentIconCell environment={original} />
+                ),
+                meta: { width: '1%' },
             },
             {
-                Header: 'Name',
-                accessor: 'name',
-                Cell: TextCell,
+                id: 'name',
+                header: 'Name',
+                accessorKey: 'name',
+                cell: TextCell,
             },
             {
-                Header: 'Type',
-                accessor: 'type',
-                Cell: TextCell,
+                id: 'type',
+                header: 'Type',
+                accessorKey: 'type',
+                cell: TextCell,
             },
             {
-                Header: 'Visible in',
-                accessor: (row: IEnvironment) =>
+                id: 'projectCount',
+                header: 'Visible in',
+                accessorFn: (row) =>
                     row.projectCount === 1
                         ? '1 project'
                         : `${row.projectCount} projects`,
-                Cell: ({
-                    row: { original },
-                    value,
-                }: {
-                    row: { original: IEnvironment };
-                    value: string;
-                }) => (
+                cell: ({ getValue, row: { original } }) => (
                     <TextCell>
-                        {value}
+                        {String(getValue() ?? '')}
                         <ConditionallyRender
                             condition={Boolean(warnEnabledToggles)}
                             show={
@@ -84,35 +85,29 @@ export const EnvironmentTableSingle = ({
         [warnEnabledToggles],
     );
 
-    const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-        useTable({
-            columns: COLUMNS as any,
-            data: [environment],
-            disableSortBy: true,
-        });
+    const table = useReactTable({
+        columns,
+        data: [environment],
+        getCoreRowModel: getCoreRowModel(),
+        enableSorting: false,
+    });
 
     return (
-        <StyledTable {...getTableProps()} rowHeight='compact'>
-            <SortableTableHeader headerGroups={headerGroups as any} />
-            <TableBody {...getTableBodyProps()}>
-                {rows.map((row) => {
-                    prepareRow(row);
-                    const { key, ...rowProps } = row.getRowProps();
-                    return (
-                        <TableRow hover key={key} {...rowProps}>
-                            {row.cells.map((cell) => {
-                                const { key, ...cellProps } =
-                                    cell.getCellProps();
-
-                                return (
-                                    <TableCell key={key} {...cellProps}>
-                                        {cell.render('Cell')}
-                                    </TableCell>
-                                );
-                            })}
-                        </TableRow>
-                    );
-                })}
+        <StyledTable rowHeight='compact'>
+            <SortableTableHeaderV8 tableInstance={table} />
+            <TableBody>
+                {table.getRowModel().rows.map((row) => (
+                    <TableRow hover key={row.id}>
+                        {row.getVisibleCells().map((cell) => (
+                            <TableCell key={cell.id}>
+                                {flexRender(
+                                    cell.column.columnDef.cell,
+                                    cell.getContext(),
+                                )}
+                            </TableCell>
+                        ))}
+                    </TableRow>
+                ))}
             </TableBody>
         </StyledTable>
     );

--- a/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsTable/EnvironmentVariantsTable.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureVariants/FeatureEnvironmentVariants/EnvironmentVariantsCard/EnvironmentVariantsTable/EnvironmentVariantsTable.tsx
@@ -1,11 +1,7 @@
 import { TableBody, TableRow, useMediaQuery, useTheme } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import {
-    SortableTableHeader,
-    Table,
-    TableCell,
-    TablePlaceholder,
-} from 'component/common/Table';
+import { Table, TableCell, TablePlaceholder } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
@@ -18,11 +14,16 @@ import type {
     IPayload,
 } from 'interfaces/featureToggle';
 import { useMemo } from 'react';
-import { useSortBy, useTable } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { PayloadCell } from './PayloadCell/PayloadCell.tsx';
 import { OverridesCell } from './OverridesCell/OverridesCell.tsx';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 
 interface IEnvironmentVariantsTableProps {
     variants: IFeatureVariant[];
@@ -39,96 +40,97 @@ export const EnvironmentVariantsTable = ({
     const isMediumScreen = useMediaQuery(theme.breakpoints.down('md'));
     const isLargeScreen = useMediaQuery(theme.breakpoints.down('lg'));
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<IFeatureVariant, unknown>[]>(
         () => [
             {
-                Header: 'Name',
-                accessor: 'name',
-                Cell: HighlightCell,
-                sortType: 'alphanumeric',
-                minWidth: 350,
-                searchable: true,
+                id: 'name',
+                header: 'Name',
+                accessorKey: 'name',
+                cell: HighlightCell,
+                sortingFn: 'alphanumeric',
+                meta: { minWidth: 350, searchable: true },
             },
             {
-                Header: 'Payload',
-                accessor: 'payload',
-                Cell: PayloadCell,
-                disableSortBy: true,
-                searchable: true,
-                filterParsing: (value: IPayload) => value?.value,
+                id: 'payload',
+                header: 'Payload',
+                accessorKey: 'payload',
+                cell: ({ getValue }) => (
+                    <PayloadCell value={getValue() as IPayload} />
+                ),
+                enableSorting: false,
+                meta: {
+                    searchable: true,
+                    filterParsing: (value: IPayload) => value?.value,
+                },
             },
             {
-                Header: 'Overrides',
-                accessor: 'overrides',
-                Cell: OverridesCell,
-                disableSortBy: true,
-                searchable: true,
-                filterParsing: (value: IOverride[]) =>
-                    value
-                        ?.map(
-                            ({ contextName, values }) =>
-                                `${contextName}:${values.join()}`,
-                        )
-                        .join('\n') || '',
+                id: 'overrides',
+                header: 'Overrides',
+                accessorKey: 'overrides',
+                cell: ({ getValue }) => (
+                    <OverridesCell value={getValue() as IOverride[]} />
+                ),
+                enableSorting: false,
+                meta: {
+                    searchable: true,
+                    filterParsing: (value: IOverride[]) =>
+                        value
+                            ?.map(
+                                ({ contextName, values }) =>
+                                    `${contextName}:${values.join()}`,
+                            )
+                            .join('\n') || '',
+                },
             },
             {
-                Header: 'Weight',
-                accessor: 'weight',
-                Cell: ({
+                id: 'weight',
+                header: 'Weight',
+                accessorKey: 'weight',
+                cell: ({
                     row: {
                         original: { name, weight },
                     },
-                }: any) => {
-                    return (
-                        <TextCell data-testid={`VARIANT_WEIGHT_${name}`}>
-                            {calculateVariantWeight(weight)} %
-                        </TextCell>
-                    );
-                },
-                sortType: 'number',
+                }) => (
+                    <TextCell data-testid={`VARIANT_WEIGHT_${name}`}>
+                        {calculateVariantWeight(weight)} %
+                    </TextCell>
+                ),
+                sortingFn: 'basic',
             },
             {
-                Header: 'Type',
-                accessor: (row: any) =>
+                id: 'weightType',
+                header: 'Type',
+                accessorFn: (row) =>
                     row.weightType === 'fix' ? 'Fixed' : 'Variable',
-                Cell: TextCell,
-                sortType: 'alphanumeric',
+                cell: TextCell,
+                sortingFn: 'alphanumeric',
             },
         ],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [projectId, variants],
     );
 
     const initialState = useMemo(
         () => ({
-            sortBy: [{ id: 'name', desc: false }],
+            sorting: [{ id: 'name', desc: false }],
         }),
         [],
     );
 
     const { data, getSearchText } = useSearch(columns, searchValue, variants);
 
-    const {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
-        setHiddenColumns,
-    } = useTable(
-        {
-            columns: columns as any[],
-            data,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-        },
-        useSortBy,
-    );
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isMediumScreen,
@@ -139,33 +141,30 @@ export const EnvironmentVariantsTable = ({
                 columns: ['weightType'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
+
+    const rows = table.getRowModel().rows;
 
     return (
         <>
             <SearchHighlightProvider value={getSearchText(searchValue)}>
-                <Table {...getTableProps()}>
-                    <SortableTableHeader headerGroups={headerGroups as any} />
-                    <TableBody {...getTableBodyProps()}>
-                        {rows.map((row) => {
-                            prepareRow(row);
-                            const { key, ...rowProps } = row.getRowProps();
-                            return (
-                                <TableRow hover {...rowProps} key={key}>
-                                    {row.cells.map((cell) => {
-                                        const { key, ...cellProps } =
-                                            cell.getCellProps();
-                                        return (
-                                            <TableCell key={key} {...cellProps}>
-                                                {cell.render('Cell')}
-                                            </TableCell>
-                                        );
-                                    })}
-                                </TableRow>
-                            );
-                        })}
+                <Table>
+                    <SortableTableHeaderV8 tableInstance={table} />
+                    <TableBody>
+                        {rows.map((row) => (
+                            <TableRow hover key={row.id}>
+                                {row.getVisibleCells().map((cell) => (
+                                    <TableCell key={cell.id}>
+                                        {flexRender(
+                                            cell.column.columnDef.cell,
+                                            cell.getContext(),
+                                        )}
+                                    </TableCell>
+                                ))}
+                            </TableRow>
+                        ))}
                     </TableBody>
                 </Table>
             </SearchHighlightProvider>

--- a/frontend/src/component/featureTypes/FeatureTypesList.tsx
+++ b/frontend/src/component/featureTypes/FeatureTypesList.tsx
@@ -1,18 +1,19 @@
 import { useMemo } from 'react';
 import { Route, Routes, useNavigate } from 'react-router-dom';
-import { useSortBy, useTable } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { sortingFns } from 'utils/sortingFns';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import useFeatureTypes from 'hooks/api/getters/useFeatureTypes/useFeatureTypes';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { Box } from '@mui/material';
-import {
-    Table,
-    TableBody,
-    TableCell,
-    TableRow,
-    SortableTableHeader,
-} from 'component/common/Table';
+import { Table, TableBody, TableCell, TableRow } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { getFeatureTypeIcons } from 'utils/getFeatureTypeIcons';
 import { IconCell } from 'component/common/Table/cells/IconCell/IconCell';
@@ -23,6 +24,7 @@ import Edit from '@mui/icons-material/Edit';
 import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
 import { FeatureTypeEdit } from './FeatureTypeEdit/FeatureTypeEdit.tsx';
 import { LinkCell } from 'component/common/Table/cells/LinkCell/LinkCell';
+import type { FeatureTypeSchema } from 'openapi';
 
 const basePath = '/feature-toggle-type';
 
@@ -30,11 +32,14 @@ export const FeatureTypesList = () => {
     const { featureTypes, loading } = useFeatureTypes();
     const navigate = useNavigate();
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<FeatureTypeSchema, unknown>[]>(
         () => [
             {
-                accessor: 'id',
-                Cell: ({ value }: { value: string }) => {
+                id: 'id',
+                header: '',
+                accessorKey: 'id',
+                cell: ({ getValue }) => {
+                    const value = String(getValue() ?? '');
                     const IconComponent = getFeatureTypeIcons(value);
                     return (
                         <IconCell
@@ -47,32 +52,33 @@ export const FeatureTypesList = () => {
                         />
                     );
                 },
-                width: 50,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { width: 50 },
             },
             {
-                Header: 'Name',
-                accessor: 'name',
-                width: '90%',
-                Cell: ({
+                id: 'name',
+                header: 'Name',
+                accessorKey: 'name',
+                cell: ({
                     row: {
                         original: { name, description },
                     },
-                }: any) => {
-                    return (
-                        <LinkCell
-                            data-loading
-                            title={name}
-                            subtitle={description}
-                        />
-                    );
-                },
-                sortType: 'alphanumeric',
+                }) => (
+                    <LinkCell
+                        data-loading
+                        title={name}
+                        subtitle={description}
+                    />
+                ),
+                sortingFn: 'alphanumeric',
+                meta: { width: '90%' },
             },
             {
-                Header: 'Lifetime',
-                accessor: 'lifetimeDays',
-                Cell: ({ value }: { value: number }) => {
+                id: 'lifetimeDays',
+                header: 'Lifetime',
+                accessorKey: 'lifetimeDays',
+                cell: ({ getValue }) => {
+                    const value = getValue() as number | undefined;
                     if (value) {
                         return (
                             <TextCell>
@@ -80,15 +86,15 @@ export const FeatureTypesList = () => {
                             </TextCell>
                         );
                     }
-
                     return <TextCell>doesn't expire</TextCell>;
                 },
-                minWidth: 150,
-                sortType: 'numericZeroLast',
+                sortingFn: sortingFns.numericZeroLast,
+                meta: { minWidth: 150 },
             },
             {
-                Header: 'Actions',
-                Cell: ({ row: { original: featureType } }: any) => (
+                id: 'Actions',
+                header: 'Actions',
+                cell: ({ row: { original: featureType } }) => (
                     <Box sx={(theme) => ({ padding: theme.spacing(0.5, 0) })}>
                         <ActionCell>
                             <PermissionIconButton
@@ -109,7 +115,7 @@ export const FeatureTypesList = () => {
                         </ActionCell>
                     </Box>
                 ),
-                disableSortBy: true,
+                enableSorting: false,
             },
         ],
         [navigate],
@@ -118,61 +124,48 @@ export const FeatureTypesList = () => {
     const data = useMemo(
         () =>
             loading
-                ? Array(5).fill({
+                ? (Array(5).fill({
                       id: '',
                       name: 'Loading...',
                       description: 'Loading...',
                       lifetimeDays: 1,
-                  })
+                  }) as FeatureTypeSchema[])
                 : featureTypes,
         [loading, featureTypes],
     );
 
-    const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-        useTable(
-            {
-                columns: columns as any[],
-                data,
-                sortTypes,
-                autoResetSortBy: false,
-                disableSortRemove: true,
-                initialState: {
-                    sortBy: [
-                        {
-                            id: 'lifetimeDays',
-                        },
-                    ],
-                },
-            },
-            useSortBy,
-        );
+    const table = useReactTable({
+        columns,
+        data,
+        initialState: {
+            sorting: [{ id: 'lifetimeDays', desc: false }],
+        },
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
 
     return (
         <PageContent
             isLoading={loading}
             header={<PageHeader title='Feature flag types' />}
         >
-            <Table {...getTableProps()}>
-                <SortableTableHeader headerGroups={headerGroups} />
-                <TableBody {...getTableBodyProps()}>
-                    {rows.map((row) => {
-                        prepareRow(row);
-                        const { key, ...rowProps } = row.getRowProps();
-                        return (
-                            <TableRow hover key={key} {...rowProps}>
-                                {row.cells.map((cell) => {
-                                    const { key, ...cellProps } =
-                                        cell.getCellProps();
-
-                                    return (
-                                        <TableCell key={key} {...cellProps}>
-                                            {cell.render('Cell')}
-                                        </TableCell>
-                                    );
-                                })}
-                            </TableRow>
-                        );
-                    })}
+            <Table>
+                <SortableTableHeaderV8 tableInstance={table} />
+                <TableBody>
+                    {table.getRowModel().rows.map((row) => (
+                        <TableRow hover key={row.id}>
+                            {row.getVisibleCells().map((cell) => (
+                                <TableCell key={cell.id}>
+                                    {flexRender(
+                                        cell.column.columnDef.cell,
+                                        cell.getContext(),
+                                    )}
+                                </TableCell>
+                            ))}
+                        </TableRow>
+                    ))}
                 </TableBody>
             </Table>
             <Routes>

--- a/frontend/src/component/feedbackNew/FeedbackList.tsx
+++ b/frontend/src/component/feedbackNew/FeedbackList.tsx
@@ -1,8 +1,12 @@
 import useFeedbackPosted from 'hooks/api/getters/useFeedbackPosted/useFeedbackPosted';
-import { VirtualizedTable } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
-import { useFlexLayout, useSortBy, useTable } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
@@ -16,11 +20,6 @@ import { useState, useMemo } from 'react';
 import type { FeedbackSchema } from 'openapi';
 import { getActiveExperiments } from './activeExperiments.ts';
 import { Truncator } from 'component/common/Truncator/Truncator';
-
-interface IFeedbackSchemaCellProps {
-    value?: string | null; // FIXME: proper type
-    row: { original: FeedbackSchema };
-}
 
 const StyledSectionHeader = styled(Typography)(({ theme }) => ({
     fontWeight: theme.fontWeight.bold,
@@ -52,111 +51,107 @@ export const FeedbackList = () => {
 
     const [searchValue, setSearchValue] = useState('');
 
-    const columns = [
-        {
-            Header: 'Feature',
-            accessor: 'category',
-            minWidth: 100,
-            Cell: ({
-                row: { original: feedback },
-            }: IFeedbackSchemaCellProps) => (
-                <TextCell>{feedback.category}</TextCell>
-            ),
-            searchable: true,
-        },
-        {
-            Header: 'User Type',
-            accessor: 'userType',
-            Cell: ({
-                row: { original: feedback },
-            }: IFeedbackSchemaCellProps) => (
-                <TextCell>{feedback.userType}</TextCell>
-            ),
-            searchable: true,
-        },
-        {
-            Header: 'Score',
-            accessor: 'difficultyScore',
-            maxWidth: 90,
-            Cell: ({
-                row: { original: feedback },
-            }: IFeedbackSchemaCellProps) => (
-                <TextCell>{feedback.difficultyScore}</TextCell>
-            ),
-        },
-        {
-            Header: 'What do you like most?',
-            accessor: 'positive',
-            minWidth: 100,
-            Cell: ({
-                row: { original: feedback },
-            }: IFeedbackSchemaCellProps) => (
-                <TextCell>
-                    <Truncator lines={2} title={feedback.positive ?? ''} arrow>
-                        {feedback.positive}
-                    </Truncator>
-                </TextCell>
-            ),
-            disableSortBy: true,
-            searchable: true,
-        },
-        {
-            Header: 'What should be improved?',
-            accessor: 'areasForImprovement',
-            minWidth: 100,
-            Cell: ({
-                row: { original: feedback },
-            }: IFeedbackSchemaCellProps) => (
-                <TextCell>
-                    <Truncator
-                        lines={2}
-                        title={feedback.areasForImprovement ?? ''}
-                        arrow
-                    >
-                        {feedback.areasForImprovement}
-                    </Truncator>
-                </TextCell>
-            ),
-            disableSortBy: true,
-            searchable: true,
-        },
-        {
-            Header: 'Date',
-            accessor: 'createdAt',
-            Cell: DateCell,
-        },
-    ];
+    const columns = useMemo<ColumnDef<FeedbackSchema, unknown>[]>(
+        () => [
+            {
+                id: 'category',
+                header: 'Feature',
+                accessorKey: 'category',
+                cell: ({ row: { original } }) => (
+                    <TextCell>{original.category}</TextCell>
+                ),
+                meta: { minWidth: 100, searchable: true },
+            },
+            {
+                id: 'userType',
+                header: 'User Type',
+                accessorKey: 'userType',
+                cell: ({ row: { original } }) => (
+                    <TextCell>{original.userType}</TextCell>
+                ),
+                meta: { searchable: true },
+            },
+            {
+                id: 'difficultyScore',
+                header: 'Score',
+                accessorKey: 'difficultyScore',
+                cell: ({ row: { original } }) => (
+                    <TextCell>
+                        {original.difficultyScore?.toString() ?? ''}
+                    </TextCell>
+                ),
+                meta: { maxWidth: 90 },
+            },
+            {
+                id: 'positive',
+                header: 'What do you like most?',
+                accessorKey: 'positive',
+                cell: ({ row: { original } }) => (
+                    <TextCell>
+                        <Truncator
+                            lines={2}
+                            title={original.positive ?? ''}
+                            arrow
+                        >
+                            {original.positive}
+                        </Truncator>
+                    </TextCell>
+                ),
+                enableSorting: false,
+                meta: { minWidth: 100, searchable: true },
+            },
+            {
+                id: 'areasForImprovement',
+                header: 'What should be improved?',
+                accessorKey: 'areasForImprovement',
+                cell: ({ row: { original } }) => (
+                    <TextCell>
+                        <Truncator
+                            lines={2}
+                            title={original.areasForImprovement ?? ''}
+                            arrow
+                        >
+                            {original.areasForImprovement}
+                        </Truncator>
+                    </TextCell>
+                ),
+                enableSorting: false,
+                meta: { minWidth: 100, searchable: true },
+            },
+            {
+                id: 'createdAt',
+                header: 'Date',
+                accessorKey: 'createdAt',
+                cell: DateCell,
+            },
+        ],
+        [],
+    );
 
     const { data, getSearchText } = useSearch(columns, searchValue, feedback);
 
     const activeExperiments = useMemo(() => getActiveExperiments(data), [data]);
 
-    const { headerGroups, rows, prepareRow } = useTable(
-        {
-            columns: columns as any,
-            data: data as object[],
-            initialState: {
-                sortBy: [
-                    {
-                        id: 'createdAt',
-                        desc: true,
-                    },
-                ],
-            },
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-            defaultColumn: {
-                Cell: TextCell,
-            },
+    const table = useReactTable({
+        columns,
+        data,
+        initialState: {
+            sorting: [{ id: 'createdAt', desc: true }],
         },
-        useSortBy,
-        useFlexLayout,
-    );
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
+        },
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
+    const rowCount = table.getRowModel().rows.length;
 
     return (
         <PageContent
@@ -217,15 +212,9 @@ export const FeedbackList = () => {
                     </Box>
                 )}
             </ActiveExperiments>
-            <StyledSectionHeader>
-                All feedback ({rows.length})
-            </StyledSectionHeader>
+            <StyledSectionHeader>All feedback ({rowCount})</StyledSectionHeader>
             <SearchHighlightProvider value={getSearchText(searchValue)}>
-                <VirtualizedTable
-                    rows={rows}
-                    headerGroups={headerGroups}
-                    prepareRow={prepareRow}
-                />
+                <VirtualizedTableV8 tableInstance={table} />
             </SearchHighlightProvider>
         </PageContent>
     );

--- a/frontend/src/component/loginHistory/LoginHistoryTable/LoginHistorySuccessfulCell/LoginHistorySuccessfulCell.tsx
+++ b/frontend/src/component/loginHistory/LoginHistoryTable/LoginHistorySuccessfulCell/LoginHistorySuccessfulCell.tsx
@@ -15,15 +15,17 @@ interface ILoginHistorySuccessfulCellProps {
     row: {
         original: ILoginEvent;
     };
-    value: boolean;
+    value?: boolean;
+    getValue?: () => unknown;
 }
 
 export const LoginHistorySuccessfulCell: FC<
     ILoginHistorySuccessfulCellProps
-> = ({ row, value }) => {
+> = ({ row, value, getValue }) => {
     const { searchQuery } = useSearchHighlightContext();
+    const resolved = value ?? Boolean(getValue ? getValue() : false);
 
-    if (value)
+    if (resolved)
         return (
             <StyledBox>
                 <Badge color='success'>True</Badge>

--- a/frontend/src/component/loginHistory/LoginHistoryTable/LoginHistoryTable.tsx
+++ b/frontend/src/component/loginHistory/LoginHistoryTable/LoginHistoryTable.tsx
@@ -1,22 +1,22 @@
 import { useEffect, useMemo, useState } from 'react';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { IconButton, Tooltip, useMediaQuery } from '@mui/material';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import {
-    type SortingRule,
-    useFlexLayout,
-    useSortBy,
-    useTable,
-} from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import theme from 'themes/theme';
 import { Search } from 'component/common/Search/Search';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { useSearch } from 'hooks/useSearch';
 import { TimeAgoCell } from 'component/common/Table/cells/TimeAgoCell/TimeAgoCell';
 import { useLoginHistory } from 'hooks/api/getters/useLoginHistory/useLoginHistory';
@@ -32,7 +32,7 @@ export type PageQueryType = Partial<
     Record<'sort' | 'order' | 'search', string>
 >;
 
-const defaultSort: SortingRule<string> = { id: 'created_at', desc: true };
+const defaultSort = { id: 'created_at', desc: true };
 
 const { value: storedParams, setValue: setStoredParams } = createLocalStorage(
     'LoginHistoryTable:v1',
@@ -53,7 +53,7 @@ export const LoginHistoryTable = () => {
 
     const [searchParams, setSearchParams] = useSearchParams();
     const [initialState] = useState(() => ({
-        sortBy: [
+        sorting: [
             {
                 id: searchParams.get('sort') || storedParams.id,
                 desc: searchParams.has('order')
@@ -61,7 +61,7 @@ export const LoginHistoryTable = () => {
                     : storedParams.desc,
             },
         ],
-        hiddenColumns: ['failure_reason'],
+        columnVisibility: { failure_reason: false },
         globalFilter: searchParams.get('search') || '',
     }));
 
@@ -70,56 +70,66 @@ export const LoginHistoryTable = () => {
     const isExtraSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<ILoginEvent, unknown>[]>(
         () => [
             {
-                Header: 'Created',
-                accessor: 'created_at',
-                Cell: ({ value, column }) => (
+                id: 'created_at',
+                header: 'Created',
+                accessorKey: 'created_at',
+                cell: ({ getValue, column }) => (
                     <TimeAgoCell
-                        value={value}
+                        value={String(getValue() ?? '')}
                         column={column}
                         dateFormat={formatDateYMDHMS}
                     />
                 ),
-                maxWidth: 150,
+                meta: { maxWidth: 150 },
             },
             {
-                Header: 'Username',
-                accessor: 'username',
-                minWidth: 100,
-                Cell: HighlightCell,
-                searchable: true,
+                id: 'username',
+                header: 'Username',
+                accessorKey: 'username',
+                cell: HighlightCell,
+                meta: { minWidth: 100, searchable: true },
             },
             {
-                Header: 'Authentication',
-                accessor: (event: ILoginEvent) =>
+                id: 'auth_type',
+                header: 'Authentication',
+                accessorFn: (event) =>
                     AUTH_TYPE_LABEL[event.auth_type] || event.auth_type,
-                width: 150,
-                maxWidth: 150,
-                Cell: HighlightCell,
-                searchable: true,
-                filterName: 'auth',
+                cell: HighlightCell,
+                meta: {
+                    width: 150,
+                    maxWidth: 150,
+                    searchable: true,
+                    filterName: 'auth',
+                },
             },
             {
-                Header: 'IP address',
-                accessor: 'ip',
-                Cell: HighlightCell,
-                searchable: true,
+                id: 'ip',
+                header: 'IP address',
+                accessorKey: 'ip',
+                cell: HighlightCell,
+                meta: { width: 150, searchable: true },
             },
             {
-                Header: 'Success',
-                accessor: 'successful',
-                align: 'center',
-                Cell: LoginHistorySuccessfulCell,
-                filterName: 'success',
-                filterParsing: (value: boolean) => value.toString(),
+                id: 'successful',
+                header: 'Success',
+                accessorKey: 'successful',
+                cell: LoginHistorySuccessfulCell,
+                meta: {
+                    width: 100,
+                    align: 'center',
+                    filterName: 'success',
+                    filterParsing: (value: boolean) => value.toString(),
+                },
             },
             // Always hidden -- for search
             {
-                accessor: 'failure_reason',
-                Header: 'Failure Reason',
-                searchable: true,
+                id: 'failure_reason',
+                header: 'Failure Reason',
+                accessorKey: 'failure_reason',
+                meta: { searchable: true },
             },
         ],
         [],
@@ -131,31 +141,23 @@ export const LoginHistoryTable = () => {
         events,
     );
 
-    const {
-        headerGroups,
-        rows,
-        prepareRow,
-        state: { sortBy },
-        setHiddenColumns,
-    } = useTable(
-        {
-            columns: columns as any,
-            data,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-            defaultColumn: {
-                Cell: TextCell,
-            },
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
         },
-        useSortBy,
-        useFlexLayout,
-    );
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isExtraSmallScreen,
@@ -166,14 +168,20 @@ export const LoginHistoryTable = () => {
                 columns: ['imageUrl', 'tokens', 'createdAt'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
 
+    const sorting = table.getState().sorting;
+
     useEffect(() => {
+        const sortRule = sorting[0];
+        if (!sortRule) {
+            return;
+        }
         const tableState: PageQueryType = {};
-        tableState.sort = sortBy[0].id;
-        if (sortBy[0].desc) {
+        tableState.sort = sortRule.id;
+        if (sortRule.desc) {
             tableState.order = 'desc';
         }
         if (searchValue) {
@@ -184,17 +192,19 @@ export const LoginHistoryTable = () => {
             replace: true,
         });
         setStoredParams({
-            id: sortBy[0].id,
-            desc: sortBy[0].desc || false,
+            id: sortRule.id,
+            desc: sortRule.desc || false,
         });
-    }, [sortBy, searchValue, setSearchParams]);
+    }, [sorting, searchValue, setSearchParams]);
+
+    const rowCount = table.getRowModel().rows.length;
 
     return (
         <PageContent
             isLoading={loading}
             header={
                 <PageHeader
-                    title={`Login history (${rows.length})`}
+                    title={`Login history (${rowCount})`}
                     actions={
                         <>
                             <ConditionallyRender
@@ -209,7 +219,7 @@ export const LoginHistoryTable = () => {
                                 }
                             />
                             <ConditionallyRender
-                                condition={rows.length > 0}
+                                condition={rowCount > 0}
                                 show={
                                     <>
                                         <ConditionallyRender
@@ -245,14 +255,10 @@ export const LoginHistoryTable = () => {
             }
         >
             <SearchHighlightProvider value={getSearchText(searchValue)}>
-                <VirtualizedTable
-                    rows={rows}
-                    headerGroups={headerGroups}
-                    prepareRow={prepareRow}
-                />
+                <VirtualizedTableV8 tableInstance={table} />
             </SearchHighlightProvider>
             <ConditionallyRender
-                condition={rows.length === 0}
+                condition={rowCount === 0}
                 show={
                     <ConditionallyRender
                         condition={searchValue?.length > 0}

--- a/frontend/src/component/playground/Playground/AdvancedPlaygroundResultsTable/AdvancedPlaygroundResultsTable.tsx
+++ b/frontend/src/component/playground/Playground/AdvancedPlaygroundResultsTable/AdvancedPlaygroundResultsTable.tsx
@@ -1,16 +1,15 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
-    type SortingRule,
-    useFlexLayout,
-    useGlobalFilter,
-    useSortBy,
-    useTable,
-} from 'react-table';
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
-import { sortTypes } from 'utils/sortTypes';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { Search } from 'component/common/Search/Search';
@@ -20,19 +19,18 @@ import { createLocalStorage } from 'utils/createLocalStorage';
 
 import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
 import useLoading from 'hooks/useLoading';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { AdvancedPlaygroundEnvironmentCell } from './AdvancedPlaygroundEnvironmentCell/AdvancedPlaygroundEnvironmentCell.tsx';
 import type {
     AdvancedPlaygroundRequestSchema,
     AdvancedPlaygroundFeatureSchema,
-    AdvancedPlaygroundFeatureSchemaEnvironments,
 } from 'openapi';
 import { capitalizeFirst } from 'utils/capitalizeFirst';
 import { AdvancedPlaygroundEnvironmentDiffCell } from './AdvancedPlaygroundEnvironmentCell/AdvancedPlaygroundEnvironmentDiffCell.tsx';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { countCombinations, getBucket } from './combinationCounter.ts';
 
-const defaultSort: SortingRule<string> = { id: 'name' };
+const defaultSort = { id: 'name', desc: false };
 const { value, setValue } = createLocalStorage(
     'AdvancedPlaygroundResultsTable:v1',
     defaultSort,
@@ -71,89 +69,92 @@ export const AdvancedPlaygroundResultsTable = ({
             ? Object.keys(features[0].environments).length
             : 0;
 
-    const COLUMNS = useMemo(() => {
-        return [
+    const columns = useMemo<
+        ColumnDef<AdvancedPlaygroundFeatureSchema, unknown>[]
+    >(() => {
+        const baseColumns: ColumnDef<
+            AdvancedPlaygroundFeatureSchema,
+            unknown
+        >[] = [
             {
-                Header: 'Name',
-                accessor: 'name',
-                searchable: true,
-                minWidth: 160,
-                Cell: ({ value, row: { original } }: any) => (
+                id: 'name',
+                header: 'Name',
+                accessorKey: 'name',
+                cell: ({ getValue, row: { original } }) => (
                     <LinkCell
-                        title={value}
-                        to={`/projects/${original?.projectId}/features/${value}`}
+                        title={String(getValue() ?? '')}
+                        to={`/projects/${original?.projectId}/features/${getValue()}`}
                     />
                 ),
+                meta: { searchable: true, minWidth: 160 },
             },
             {
-                Header: 'Project ID',
-                accessor: 'projectId',
-                sortType: 'alphanumeric',
-                filterName: 'projectId',
-                searchable: true,
-                minWidth: 150,
-                Cell: ({ value }: any) => (
-                    <LinkCell title={value} to={`/projects/${value}`} />
-                ),
+                id: 'projectId',
+                header: 'Project ID',
+                accessorKey: 'projectId',
+                sortingFn: 'alphanumeric',
+                cell: ({ getValue }) => {
+                    const v = String(getValue() ?? '');
+                    return <LinkCell title={v} to={`/projects/${v}`} />;
+                },
+                meta: {
+                    filterName: 'projectId',
+                    searchable: true,
+                    minWidth: 150,
+                },
             },
-            ...(input?.environments?.map((name: string) => {
-                return {
-                    Header: loading ? () => '' : capitalizeFirst(name),
-                    maxWidth: 150,
+            ...(input?.environments?.map(
+                (
+                    name: string,
+                ): ColumnDef<AdvancedPlaygroundFeatureSchema, unknown> => ({
                     id: `environments.${name}`,
-                    align: 'flex-start',
-                    Cell: ({ row }: any) => (
+                    header: loading ? '' : capitalizeFirst(name),
+                    cell: ({ row }) => (
                         <AdvancedPlaygroundEnvironmentCell
                             value={row.original.environments[name]}
                         />
                     ),
-                };
-            }) || []),
-            ...(environmentsCount > 1
-                ? [
-                      {
-                          Header: 'Diff',
-                          minWidth: 150,
-                          id: 'diff',
-                          align: 'left',
-                          Cell: ({
-                              row,
-                          }: {
-                              row: {
-                                  original: {
-                                      environments: AdvancedPlaygroundFeatureSchemaEnvironments;
-                                  };
-                              };
-                          }) => (
-                              <AdvancedPlaygroundEnvironmentDiffCell
-                                  value={row.original.environments}
-                              />
-                          ),
-                      },
-                  ]
-                : []),
+                    meta: { maxWidth: 150, align: 'left' },
+                }),
+            ) || []),
         ];
-    }, [input]);
+
+        if (environmentsCount > 1) {
+            baseColumns.push({
+                id: 'diff',
+                header: 'Diff',
+                cell: ({ row }) => (
+                    <AdvancedPlaygroundEnvironmentDiffCell
+                        value={row.original.environments}
+                    />
+                ),
+                meta: { minWidth: 150, align: 'left' },
+            });
+        }
+
+        return baseColumns;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [input, loading]);
 
     const {
         data: searchedData,
         getSearchText,
         getSearchContext,
-    } = useSearch(COLUMNS, searchValue, features || []);
+    } = useSearch(columns, searchValue, features || []);
 
     const data = useMemo(() => {
         return loading
-            ? Array(5).fill({
+            ? (Array(5).fill({
                   name: 'Feature name',
                   projectId: 'Feature Project',
                   environments: { name: 'Feature Environments', variants: [] },
                   enabled: true,
-              })
+              }) as AdvancedPlaygroundFeatureSchema[])
             : searchedData;
     }, [searchedData, loading]);
 
     const [initialState] = useState(() => ({
-        sortBy: [
+        sorting: [
             {
                 id: searchParams.get('sort') || value.id,
                 desc: searchParams.has('order')
@@ -163,50 +164,47 @@ export const AdvancedPlaygroundResultsTable = ({
         ],
     }));
 
-    const {
-        headerGroups,
-        rows,
-        state: { sortBy },
-        prepareRow,
-        setHiddenColumns,
-    } = useTable(
-        {
-            initialState,
-            columns: COLUMNS as any,
-            data: data as any,
-            sortTypes,
-            autoResetGlobalFilter: false,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-            defaultColumn: {
-                Cell: HighlightCell,
-            },
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <HighlightCell value={String(getValue() ?? '')} />
+            ),
         },
-        useGlobalFilter,
-        useFlexLayout,
-        useSortBy,
-    );
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isSmallScreen,
                 columns: ['projectId'],
             },
         ],
-        setHiddenColumns,
-        COLUMNS,
+        table.setColumnVisibility,
+        columns,
     );
+
+    const sorting = table.getState().sorting;
+    const rows = table.getRowModel().rows;
 
     useEffect(() => {
         if (loading) {
             return;
         }
+        const sortRule = sorting[0];
+        if (!sortRule) {
+            return;
+        }
         const tableState = Object.fromEntries(searchParams);
-        tableState.sort = sortBy[0].id;
-        if (sortBy[0].desc) {
+        tableState.sort = sortRule.id;
+        if (sortRule.desc) {
             tableState.order = 'desc';
         } else if (tableState.order) {
             delete tableState.order;
@@ -220,10 +218,10 @@ export const AdvancedPlaygroundResultsTable = ({
         setSearchParams(tableState, {
             replace: true,
         });
-        setValue({ id: sortBy[0].id, desc: sortBy[0].desc || false });
+        setValue({ id: sortRule.id, desc: sortRule.desc || false });
 
         // eslint-disable-next-line react-hooks/exhaustive-deps -- don't re-render after search params change
-    }, [loading, sortBy, searchValue]);
+    }, [loading, sorting, searchValue]);
 
     return (
         <>
@@ -268,11 +266,7 @@ export const AdvancedPlaygroundResultsTable = ({
                         <SearchHighlightProvider
                             value={getSearchText(searchValue)}
                         >
-                            <VirtualizedTable
-                                rows={rows}
-                                headerGroups={headerGroups}
-                                prepareRow={prepareRow}
-                            />
+                            <VirtualizedTableV8 tableInstance={table} />
                         </SearchHighlightProvider>
                         <ConditionallyRender
                             condition={

--- a/frontend/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantInformation/VariantInformation.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantInformation/VariantInformation.tsx
@@ -3,10 +3,15 @@ import { Table, TableBody, TableCell, TableRow } from 'component/common/Table';
 import { useMemo, type FC } from 'react';
 import type { IFeatureVariant } from 'interfaces/featureToggle';
 import { calculateVariantWeight } from 'component/common/util';
-import { useGlobalFilter, useSortBy, useTable } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
-import { SortableTableHeader } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { IconCell } from 'component/common/Table/cells/IconCell/IconCell';
@@ -15,6 +20,12 @@ interface IVariantInformationProps {
     variants: IFeatureVariant[];
     selectedVariant: string;
 }
+
+type VariantRow = {
+    name: string;
+    weight: string;
+    selected: boolean;
+};
 
 const StyledBox = styled('div')(({ theme }) => ({
     padding: theme.spacing(4),
@@ -29,42 +40,70 @@ const StyledCheckIcon = styled(CheckCircleOutlined)(({ theme }) => ({
     color: theme.palette.success.main,
 }));
 
+const COLUMNS: ColumnDef<VariantRow, unknown>[] = [
+    {
+        id: 'Icon',
+        cell: ({
+            row: {
+                original: { selected },
+            },
+        }) => (
+            <ConditionallyRender
+                condition={selected}
+                show={<IconCell icon={<StyledCheckIcon />} />}
+            />
+        ),
+        meta: { maxWidth: 25 },
+    },
+    {
+        id: 'name',
+        header: 'Name',
+        accessorKey: 'name',
+        cell: ({
+            row: {
+                original: { name },
+            },
+        }) => <TextCell>{name}</TextCell>,
+        meta: { maxWidth: 175, width: 175 },
+    },
+    {
+        id: 'weight',
+        header: 'Weight',
+        accessorKey: 'weight',
+        sortingFn: 'alphanumeric',
+        cell: ({
+            row: {
+                original: { weight },
+            },
+        }) => <TextCell>{weight}</TextCell>,
+        meta: { maxWidth: 75 },
+    },
+];
+
 export const VariantInformation: FC<IVariantInformationProps> = ({
     variants,
     selectedVariant,
 }) => {
     const theme = useTheme();
-    const data = useMemo(() => {
-        return variants.map((variant) => {
-            return {
-                name: variant.name,
-                weight: `${calculateVariantWeight(variant.weight)}%`,
-                selected: variant.name === selectedVariant,
-            };
-        });
+    const data = useMemo<VariantRow[]>(() => {
+        return variants.map((variant) => ({
+            name: variant.name,
+            weight: `${calculateVariantWeight(variant.weight)}%`,
+            selected: variant.name === selectedVariant,
+        }));
     }, [variants, selectedVariant]);
 
-    const initialState = useMemo(
-        () => ({
-            sortBy: [{ id: 'name', desc: false }],
-        }),
-        [],
-    );
-
-    const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-        useTable(
-            {
-                initialState,
-                columns: COLUMNS as any,
-                data: data as any,
-                sortTypes,
-                autoResetGlobalFilter: false,
-                autoResetSortBy: false,
-                disableSortRemove: true,
-            },
-            useGlobalFilter,
-            useSortBy,
-        );
+    const table = useReactTable({
+        columns: COLUMNS,
+        data,
+        initialState: {
+            sorting: [{ id: 'name', desc: false }],
+        },
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
 
     return (
         <StyledBox>
@@ -84,34 +123,24 @@ export const VariantInformation: FC<IVariantInformationProps> = ({
                 properties to ensure that the user receives the same experience.
             </StyledTypography>
 
-            <Table {...getTableProps()} rowHeight='dense'>
-                <SortableTableHeader headerGroups={headerGroups as any} />
-                <TableBody {...getTableBodyProps()}>
-                    {rows.map((row: any) => {
+            <Table rowHeight='dense'>
+                <SortableTableHeaderV8 tableInstance={table} />
+                <TableBody>
+                    {table.getRowModel().rows.map((row) => {
                         const styles = {} as { [key: string]: string };
-
                         if (!row.original.selected) {
                             styles.color = theme.palette.text.secondary;
                         }
-
-                        prepareRow(row);
-                        const { key, ...rowProps } = row.getRowProps();
                         return (
-                            <TableRow hover key={key} {...rowProps}>
-                                {row.cells.map((cell: any) => {
-                                    const { key, ...cellProps } =
-                                        cell.getCellProps();
-
-                                    return (
-                                        <TableCell
-                                            key={key}
-                                            {...cellProps}
-                                            style={styles}
-                                        >
-                                            {cell.render('Cell')}
-                                        </TableCell>
-                                    );
-                                })}
+                            <TableRow hover key={row.id}>
+                                {row.getVisibleCells().map((cell) => (
+                                    <TableCell key={cell.id} style={styles}>
+                                        {flexRender(
+                                            cell.column.columnDef.cell,
+                                            cell.getContext(),
+                                        )}
+                                    </TableCell>
+                                ))}
                             </TableRow>
                         );
                     })}
@@ -120,47 +149,3 @@ export const VariantInformation: FC<IVariantInformationProps> = ({
         </StyledBox>
     );
 };
-
-const COLUMNS = [
-    {
-        id: 'Icon',
-        Cell: ({
-            row: {
-                original: { selected },
-            },
-        }: any) => (
-            <>
-                <ConditionallyRender
-                    condition={selected}
-                    show={<IconCell icon={<StyledCheckIcon />} />}
-                />
-            </>
-        ),
-        maxWidth: 25,
-        disableGlobalFilter: true,
-    },
-    {
-        Header: 'Name',
-        accessor: 'name',
-        searchable: true,
-        Cell: ({
-            row: {
-                original: { name },
-            },
-        }: any) => <TextCell>{name}</TextCell>,
-        maxWidth: 175,
-        width: 175,
-    },
-    {
-        Header: 'Weight',
-        accessor: 'weight',
-        sortType: 'alphanumeric',
-        searchable: true,
-        maxWidth: 75,
-        Cell: ({
-            row: {
-                original: { weight },
-            },
-        }: any) => <TextCell>{weight}</TextCell>,
-    },
-];

--- a/frontend/src/component/project/Project/CreateProject/CreateProjectForm/ConfigButtons/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProjectForm/ConfigButtons/ChangeRequestTable.tsx
@@ -1,14 +1,13 @@
 import { useMemo } from 'react';
-import { type HeaderGroup, useGlobalFilter, useTable } from 'react-table';
-import { Box, Switch, styled } from '@mui/material';
 import {
-    SortableTableHeader,
-    Table,
-    TableBody,
-    TableCell,
-    TableRow,
-} from 'component/common/Table';
-import { sortTypes } from 'utils/sortTypes';
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { Box, Switch, styled } from '@mui/material';
+import { Table, TableBody, TableCell, TableRow } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import GeneralSelect from 'component/common/GeneralSelect/GeneralSelect';
@@ -32,6 +31,14 @@ const StyledTable = styled(Table)(({ theme }) => ({
         borderBottom: 'none',
     },
 }));
+
+type EnvironmentRow = {
+    environment: string;
+    type: string;
+    changeRequestEnabled: boolean;
+    requiredApprovals: number;
+    configurable: boolean;
+};
 
 type TableProps = {
     environments: {
@@ -74,66 +81,79 @@ export const ChangeRequestTable = (props: TableProps) => {
             };
         });
 
-    function onRequiredApprovalsChange(original: any, approvals: string) {
+    function onRequiredApprovalsChange(
+        original: EnvironmentRow,
+        approvals: string,
+    ) {
         props.enableEnvironment(original.environment, Number(approvals));
     }
 
-    const columns = useMemo(
+    const data = useMemo<EnvironmentRow[]>(
+        () =>
+            props.environments.map((env) => ({
+                environment: env.name,
+                type: env.type,
+                changeRequestEnabled: env.changeRequestEnabled,
+                requiredApprovals: env.requiredApprovals ?? 1,
+                configurable: env.configurable,
+            })),
+        [props.environments],
+    );
+
+    const columns = useMemo<ColumnDef<EnvironmentRow, unknown>[]>(
         () => [
             {
-                Header: 'Environment',
-                accessor: 'environment',
-                disableSortBy: true,
+                id: 'environment',
+                header: 'Environment',
+                accessorKey: 'environment',
+                enableSorting: false,
             },
             {
-                Header: 'Type',
-                accessor: 'type',
-                disableGlobalFilter: true,
-                disableSortBy: true,
+                id: 'type',
+                header: 'Type',
+                accessorKey: 'type',
+                enableSorting: false,
             },
             {
-                Header: 'Required approvals',
-                Cell: ({ row: { original } }: any) => {
-                    return (
-                        <ConditionallyRender
-                            condition={original.changeRequestEnabled}
-                            show={
-                                <StyledBox data-loading>
-                                    <GeneralSelect
-                                        label={`Set required approvals for ${original.environment}`}
-                                        visuallyHideLabel
-                                        id={`cr-approvals-${original.environment}`}
-                                        sx={{ width: '140px' }}
-                                        options={approvalOptions}
-                                        value={original.requiredApprovals || 1}
-                                        onChange={(approvals) => {
-                                            onRequiredApprovalsChange(
-                                                original,
-                                                approvals,
-                                            );
-                                        }}
-                                        disabled={!original.configurable}
-                                        IconComponent={
-                                            KeyboardArrowDownOutlined
-                                        }
-                                        fullWidth
-                                    />
-                                </StyledBox>
-                            }
-                        />
-                    );
-                },
-                width: 100,
-                disableGlobalFilter: true,
-                disableSortBy: true,
+                id: 'requiredApprovals',
+                header: 'Required approvals',
+                cell: ({ row: { original } }) => (
+                    <ConditionallyRender
+                        condition={original.changeRequestEnabled}
+                        show={
+                            <StyledBox data-loading>
+                                <GeneralSelect
+                                    label={`Set required approvals for ${original.environment}`}
+                                    visuallyHideLabel
+                                    id={`cr-approvals-${original.environment}`}
+                                    sx={{ width: '140px' }}
+                                    options={approvalOptions}
+                                    value={String(
+                                        original.requiredApprovals || 1,
+                                    )}
+                                    onChange={(approvals) => {
+                                        onRequiredApprovalsChange(
+                                            original,
+                                            approvals,
+                                        );
+                                    }}
+                                    disabled={!original.configurable}
+                                    IconComponent={KeyboardArrowDownOutlined}
+                                    fullWidth
+                                />
+                            </StyledBox>
+                        }
+                    />
+                ),
+                enableSorting: false,
+                meta: { width: 100 },
             },
             {
-                Header: 'Status',
-                accessor: 'changeRequestEnabled',
                 id: 'changeRequestEnabled',
-                align: 'center',
-
-                Cell: ({ value, row: { original } }: any) => {
+                header: 'Status',
+                accessorKey: 'changeRequestEnabled',
+                cell: ({ getValue, row: { original } }) => {
+                    const value = Boolean(getValue());
                     return (
                         <StyledBox data-loading>
                             <Switch
@@ -157,62 +177,43 @@ export const ChangeRequestTable = (props: TableProps) => {
                         </StyledBox>
                     );
                 },
-                width: 100,
-                disableGlobalFilter: true,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { width: 100, align: 'center' },
             },
         ],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [],
     );
 
-    const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-        useTable(
-            {
-                // @ts-expect-error
-                columns,
-                data: props.environments.map((env) => {
-                    return {
-                        environment: env.name,
-                        type: env.type,
-                        changeRequestEnabled: env.changeRequestEnabled,
-                        requiredApprovals: env.requiredApprovals ?? 1,
-                        configurable: env.configurable,
-                    };
-                }),
+    const table = useReactTable({
+        columns,
+        data,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
+        },
+        getCoreRowModel: getCoreRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
 
-                sortTypes,
-                autoResetGlobalFilter: false,
-                disableSortRemove: true,
-                defaultColumn: {
-                    Cell: TextCell,
-                },
-            },
-            useGlobalFilter,
-        );
     return (
-        <StyledTable {...getTableProps()}>
-            <SortableTableHeader
-                headerGroups={headerGroups as HeaderGroup<object>[]}
-            />
-            <TableBody {...getTableBodyProps()}>
-                {rows.map((row) => {
-                    prepareRow(row);
-                    const { key, ...rowProps } = row.getRowProps();
-                    return (
-                        <TableRow hover key={key} {...rowProps}>
-                            {row.cells.map((cell) => {
-                                const { key, ...cellProps } =
-                                    cell.getCellProps();
-
-                                return (
-                                    <TableCell key={key} {...cellProps}>
-                                        {cell.render('Cell')}
-                                    </TableCell>
-                                );
-                            })}
-                        </TableRow>
-                    );
-                })}
+        <StyledTable>
+            <SortableTableHeaderV8 tableInstance={table} />
+            <TableBody>
+                {table.getRowModel().rows.map((row) => (
+                    <TableRow hover key={row.id}>
+                        {row.getVisibleCells().map((cell) => (
+                            <TableCell key={cell.id}>
+                                {flexRender(
+                                    cell.column.columnDef.cell,
+                                    cell.getContext(),
+                                )}
+                            </TableCell>
+                        ))}
+                    </TableRow>
+                ))}
             </TableBody>
         </StyledTable>
     );

--- a/frontend/src/component/project/Project/ProjectDoraMetrics/ProjectDoraMetrics.tsx
+++ b/frontend/src/component/project/Project/ProjectDoraMetrics/ProjectDoraMetrics.tsx
@@ -1,22 +1,34 @@
 import { Box, Tooltip, useMediaQuery } from '@mui/material';
 import { useProjectDoraMetrics } from 'hooks/api/getters/useProjectDoraMetrics/useProjectDoraMetrics';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import { useMemo } from 'react';
-import { useTable, useGlobalFilter, useSortBy } from 'react-table';
+import { useMemo, useState } from 'react';
+import {
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    getFilteredRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import {
     Table,
-    SortableTableHeader,
     TableBody,
     TableCell,
     TableRow,
     TablePlaceholder,
 } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { Badge } from 'component/common/Badge/Badge';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import theme from 'themes/theme';
+
+type DoraFeatureRow = {
+    name: string;
+    timeToProduction: number;
+};
 
 const resolveDoraMetrics = (input: number) => {
     const ONE_MONTH = 30;
@@ -42,52 +54,51 @@ export const ProjectDoraMetrics = () => {
     const projectId = useRequiredPathParam('projectId');
 
     const { dora, loading } = useProjectDoraMetrics(projectId);
+    const [globalFilter, setGlobalFilter] = useState('');
 
-    const data = useMemo(() => {
+    const data = useMemo<DoraFeatureRow[]>(() => {
         if (loading) {
             return Array(5).fill({
                 name: 'Featurename',
-                timeToProduction: 'Data for production',
+                timeToProduction: 0,
             });
         }
 
         return dora.features;
     }, [dora, loading]);
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<DoraFeatureRow, unknown>[]>(
         () => [
             {
-                Header: 'Name',
-                accessor: 'name',
-                width: '40%',
-                Cell: ({
+                id: 'name',
+                header: 'Name',
+                accessorKey: 'name',
+                cell: ({
                     row: {
                         original: { name },
                     },
-                }: any) => {
-                    return (
-                        <Box
-                            data-loading
-                            sx={{
-                                pl: 2,
-                                pr: 1,
-                                paddingTop: 2,
-                                paddingBottom: 2,
-                                display: 'flex',
-                                alignItems: 'center',
-                            }}
-                        >
-                            {name}
-                        </Box>
-                    );
-                },
-                sortType: 'alphanumeric',
+                }) => (
+                    <Box
+                        data-loading
+                        sx={{
+                            pl: 2,
+                            pr: 1,
+                            paddingTop: 2,
+                            paddingBottom: 2,
+                            display: 'flex',
+                            alignItems: 'center',
+                        }}
+                    >
+                        {name}
+                    </Box>
+                ),
+                sortingFn: 'alphanumeric',
+                meta: { width: '40%' },
             },
             {
-                Header: 'Time to production',
                 id: 'timetoproduction',
-                align: 'center',
-                Cell: ({ row: { original } }: any) => (
+                header: 'Time to production',
+                cell: ({ row: { original } }) => (
                     <Tooltip
                         title='The time from the feature flag of type release was created until it was turned on in a production environment'
                         arrow
@@ -100,15 +111,14 @@ export const ProjectDoraMetrics = () => {
                         </Box>
                     </Tooltip>
                 ),
-                width: 200,
-                disableGlobalFilter: true,
-                disableSortBy: true,
+                enableGlobalFilter: false,
+                enableSorting: false,
+                meta: { width: 200, align: 'center' },
             },
             {
-                Header: `Deviation`,
                 id: 'deviation',
-                align: 'center',
-                Cell: ({ row: { original } }: any) => (
+                header: 'Deviation',
+                cell: ({ row: { original } }) => (
                     <Tooltip
                         title={`Deviation from project average. Average for this project is: ${
                             dora.projectAverage || 0
@@ -128,15 +138,14 @@ export const ProjectDoraMetrics = () => {
                         </Box>
                     </Tooltip>
                 ),
-                width: 300,
-                disableGlobalFilter: true,
-                disableSortBy: true,
+                enableGlobalFilter: false,
+                enableSorting: false,
+                meta: { width: 300, align: 'center' },
             },
             {
-                Header: 'DORA',
                 id: 'dora',
-                align: 'center',
-                Cell: ({ row: { original } }: any) => (
+                header: 'DORA',
+                cell: ({ row: { original } }) => (
                     <Tooltip
                         title='Dora score. High = less than a week to production. Medium = less than a month to production. Low = Less than 6 months to production'
                         arrow
@@ -149,54 +158,49 @@ export const ProjectDoraMetrics = () => {
                         </Box>
                     </Tooltip>
                 ),
-                width: 200,
-                disableGlobalFilter: true,
-                disableSortBy: true,
+                enableGlobalFilter: false,
+                enableSorting: false,
+                meta: { width: 200, align: 'center' },
             },
         ],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [JSON.stringify(dora.features), loading],
     );
 
     const initialState = useMemo(
         () => ({
-            sortBy: [{ id: 'name', desc: false }],
+            sorting: [{ id: 'name', desc: false }],
         }),
         [],
     );
 
     const isExtraSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
-    const {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
         state: { globalFilter },
-        setHiddenColumns,
-    } = useTable(
-        {
-            columns: columns as any[], // TODO: fix after `react-table` v8 update
-            data,
-            initialState,
-            autoResetGlobalFilter: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-        },
-        useGlobalFilter,
-        useSortBy,
-    );
+        onGlobalFilterChange: setGlobalFilter,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isExtraSmallScreen,
                 columns: ['deviation'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
+
+    const rows = table.getRowModel().rows;
 
     return (
         <>
@@ -208,27 +212,21 @@ export const ProjectDoraMetrics = () => {
                     />
                 }
             >
-                <Table {...getTableProps()}>
-                    <SortableTableHeader headerGroups={headerGroups} />
-                    <TableBody {...getTableBodyProps()}>
-                        {rows.map((row) => {
-                            prepareRow(row);
-                            const { key, ...rowProps } = row.getRowProps();
-                            return (
-                                <TableRow hover key={key} {...rowProps}>
-                                    {row.cells.map((cell) => {
-                                        const { key, ...cellProps } =
-                                            cell.getCellProps();
-
-                                        return (
-                                            <TableCell key={key} {...cellProps}>
-                                                {cell.render('Cell')}
-                                            </TableCell>
-                                        );
-                                    })}
-                                </TableRow>
-                            );
-                        })}
+                <Table>
+                    <SortableTableHeaderV8 tableInstance={table} />
+                    <TableBody>
+                        {rows.map((row) => (
+                            <TableRow hover key={row.id}>
+                                {row.getVisibleCells().map((cell) => (
+                                    <TableCell key={cell.id}>
+                                        {flexRender(
+                                            cell.column.columnDef.cell,
+                                            cell.getContext(),
+                                        )}
+                                    </TableCell>
+                                ))}
+                            </TableRow>
+                        ))}
                     </TableBody>
                 </Table>
                 <ConditionallyRender

--- a/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ChangeRequestConfiguration/ChangeRequestTable.tsx
@@ -1,14 +1,13 @@
 import { type FC, useContext, useMemo, useState } from 'react';
-import { type HeaderGroup, useGlobalFilter, useTable } from 'react-table';
-import { Alert, Box, styled, Typography } from '@mui/material';
 import {
-    SortableTableHeader,
-    Table,
-    TableBody,
-    TableCell,
-    TableRow,
-} from 'component/common/Table';
-import { sortTypes } from 'utils/sortTypes';
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { Alert, Box, styled, Typography } from '@mui/material';
+import { Table, TableBody, TableCell, TableRow } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
@@ -31,6 +30,7 @@ import { useTheme } from '@mui/material/styles';
 import AccessContext from 'contexts/AccessContext';
 import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
 import { PROJECT_CHANGE_REQUEST_WRITE } from '../../../../providers/AccessProvider/permissions.ts';
+import type { IChangeRequestEnvironmentConfig as IChangeRequestRow } from 'component/changeRequest/changeRequest.types';
 
 const StyledBox = styled(Box)(({ theme }) => ({
     padding: theme.spacing(1),
@@ -116,7 +116,10 @@ export const ChangeRequestTable: FC = () => {
             };
         });
 
-    function onRequiredApprovalsChange(original: any, approvals: string) {
+    function onRequiredApprovalsChange(
+        original: IChangeRequestRow,
+        approvals: string,
+    ) {
         updateConfiguration({
             project: projectId,
             environment: original.environment,
@@ -125,28 +128,30 @@ export const ChangeRequestTable: FC = () => {
         });
     }
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<IChangeRequestRow, unknown>[]>(
         () => [
             {
-                Header: 'Environment',
-                accessor: 'environment',
-                disableSortBy: true,
+                id: 'environment',
+                header: 'Environment',
+                accessorKey: 'environment',
+                enableSorting: false,
             },
             {
-                Header: 'Type',
-                accessor: 'type',
-                disableGlobalFilter: true,
-                disableSortBy: true,
+                id: 'type',
+                header: 'Type',
+                accessorKey: 'type',
+                enableSorting: false,
             },
             {
-                Header: 'Required approvals',
-                Cell: ({ row: { original } }: any) =>
+                id: 'requiredApprovals',
+                header: 'Required approvals',
+                cell: ({ row: { original } }) =>
                     original.changeRequestEnabled ? (
                         <StyledBox data-loading>
                             <GeneralSelect
                                 sx={{ width: '140px', marginLeft: 1 }}
                                 options={approvalOptions}
-                                value={original.requiredApprovals || 1}
+                                value={String(original.requiredApprovals || 1)}
                                 onChange={(approvals) => {
                                     onRequiredApprovalsChange(
                                         original,
@@ -167,20 +172,16 @@ export const ChangeRequestTable: FC = () => {
                             />
                         </StyledBox>
                     ) : null,
-                width: 100,
-                disableGlobalFilter: true,
-                disableSortBy: true,
+                enableSorting: false,
             },
             {
-                Header: 'Status',
-                accessor: 'changeRequestEnabled',
                 id: 'changeRequestEnabled',
-                align: 'center',
-
-                Cell: ({ value, row: { original } }: any) => (
+                header: 'Status',
+                accessorKey: 'changeRequestEnabled',
+                cell: ({ getValue, row: { original } }) => (
                     <StyledBox data-loading>
                         <PermissionSwitch
-                            checked={value}
+                            checked={Boolean(getValue())}
                             projectId={projectId}
                             permission={[
                                 UPDATE_PROJECT,
@@ -197,29 +198,27 @@ export const ChangeRequestTable: FC = () => {
                         />
                     </StyledBox>
                 ),
-                width: 100,
-                disableGlobalFilter: true,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { align: 'center' },
             },
         ],
-        [],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [projectId],
     );
 
-    const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-        useTable(
-            {
-                // @ts-expect-error
-                columns,
-                data,
-                sortTypes,
-                autoResetGlobalFilter: false,
-                disableSortRemove: true,
-                defaultColumn: {
-                    Cell: TextCell,
-                },
-            },
-            useGlobalFilter,
-        );
+    const table = useReactTable({
+        columns,
+        data,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
+        },
+        getCoreRowModel: getCoreRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
+
     return (
         <PageContent
             header={
@@ -235,28 +234,21 @@ export const ChangeRequestTable: FC = () => {
                 in that environment needs to be approved before it will be
                 applied
             </Alert>
-            <Table {...getTableProps()}>
-                <SortableTableHeader
-                    headerGroups={headerGroups as HeaderGroup<object>[]}
-                />
-                <TableBody {...getTableBodyProps()}>
-                    {rows.map((row) => {
-                        prepareRow(row);
-                        const { key, ...rowProps } = row.getRowProps();
-                        return (
-                            <TableRow hover key={key} {...rowProps}>
-                                {row.cells.map((cell) => {
-                                    const { key, ...cellProps } =
-                                        cell.getCellProps();
-                                    return (
-                                        <TableCell key={key} {...cellProps}>
-                                            {cell.render('Cell')}
-                                        </TableCell>
-                                    );
-                                })}
-                            </TableRow>
-                        );
-                    })}
+            <Table>
+                <SortableTableHeaderV8 tableInstance={table} />
+                <TableBody>
+                    {table.getRowModel().rows.map((row) => (
+                        <TableRow hover key={row.id}>
+                            {row.getVisibleCells().map((cell) => (
+                                <TableCell key={cell.id}>
+                                    {flexRender(
+                                        cell.column.columnDef.cell,
+                                        cell.getContext(),
+                                    )}
+                                </TableCell>
+                            ))}
+                        </TableRow>
+                    ))}
                 </TableBody>
             </Table>
             <Dialogue

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsTable.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectActions/ProjectActionsTable/ProjectActionsTable.tsx
@@ -1,14 +1,20 @@
 import { useMemo, useState } from 'react';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { useMediaQuery } from '@mui/material';
-import { useFlexLayout, useSortBy, useTable } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { sortingFns } from 'utils/sortingFns';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import theme from 'themes/theme';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { useActions } from 'hooks/api/getters/useActions/useActions';
 import { useActionsApi } from 'hooks/api/actions/useActionsApi/useActionsApi';
 import type { IActionSet } from 'interfaces/action';
@@ -85,17 +91,13 @@ export const ProjectActionsTable = ({
     const isExtraSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
     const isMediumScreen = useMediaQuery(theme.breakpoints.down('lg'));
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<IActionSet, unknown>[]>(
         () => [
             {
-                Header: 'Name',
-                accessor: 'name',
-                minWidth: 60,
-                Cell: ({
-                    row: { original: action },
-                }: {
-                    row: { original: IActionSet };
-                }) => (
+                id: 'name',
+                header: 'Name',
+                accessorKey: 'name',
+                cell: ({ row: { original: action } }) => (
                     <LinkCell
                         title={action.name}
                         subtitle={action.description}
@@ -105,15 +107,12 @@ export const ProjectActionsTable = ({
                         }}
                     />
                 ),
+                meta: { minWidth: 60 },
             },
             {
                 id: 'source',
-                Header: 'Source',
-                Cell: ({
-                    row: { original: action },
-                }: {
-                    row: { original: IActionSet };
-                }) => (
+                header: 'Source',
+                cell: ({ row: { original: action } }) => (
                     <ProjectActionsSourceCell
                         action={action}
                         signalEndpoints={signalEndpoints}
@@ -122,37 +121,27 @@ export const ProjectActionsTable = ({
             },
             {
                 id: 'filters',
-                Header: 'Filters',
-                Cell: ({
-                    row: { original: action },
-                }: {
-                    row: { original: IActionSet };
-                }) => <ProjectActionsFiltersCell action={action} />,
-                maxWidth: 90,
+                header: 'Filters',
+                cell: ({ row: { original: action } }) => (
+                    <ProjectActionsFiltersCell action={action} />
+                ),
+                meta: { maxWidth: 90 },
             },
             {
                 id: 'actor',
-                Header: 'Service account',
-                Cell: ({
-                    row: { original: action },
-                }: {
-                    row: { original: IActionSet };
-                }) => (
+                header: 'Service account',
+                cell: ({ row: { original: action } }) => (
                     <ProjectActionsActorCell
                         action={action}
                         serviceAccounts={serviceAccounts}
                     />
                 ),
-                minWidth: 160,
+                meta: { minWidth: 160 },
             },
             {
                 id: 'actions',
-                Header: 'Actions',
-                Cell: ({
-                    row: { original: action },
-                }: {
-                    row: { original: IActionSet };
-                }) => (
+                header: 'Actions',
+                cell: ({ row: { original: action } }) => (
                     <ProjectActionsActionsCell
                         action={action}
                         onCreateAction={() => {
@@ -161,16 +150,13 @@ export const ProjectActionsTable = ({
                         }}
                     />
                 ),
-                maxWidth: 130,
+                meta: { maxWidth: 130 },
             },
             {
-                Header: 'Enabled',
-                accessor: 'enabled',
-                Cell: ({
-                    row: { original: action },
-                }: {
-                    row: { original: IActionSet };
-                }) => (
+                id: 'enabled',
+                header: 'Enabled',
+                accessorKey: 'enabled',
+                cell: ({ row: { original: action } }) => (
                     <ToggleCell
                         checked={action.enabled}
                         setChecked={(enabled) =>
@@ -178,19 +164,13 @@ export const ProjectActionsTable = ({
                         }
                     />
                 ),
-                sortType: 'boolean',
-                width: 90,
-                maxWidth: 90,
+                sortingFn: sortingFns.boolean,
+                meta: { width: 90, maxWidth: 90 },
             },
             {
                 id: 'table-actions',
-                Header: '',
-                align: 'center',
-                Cell: ({
-                    row: { original: action },
-                }: {
-                    row: { original: IActionSet };
-                }) => (
+                header: '',
+                cell: ({ row: { original: action } }) => (
                     <ProjectActionsTableActionsCell
                         actionId={action.id}
                         onOpenEvents={() => {
@@ -207,36 +187,35 @@ export const ProjectActionsTable = ({
                         }}
                     />
                 ),
-                width: 50,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { width: 50, align: 'center' },
             },
         ],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [signalEndpoints, serviceAccounts],
     );
 
     const [initialState] = useState({
-        sortBy: [{ id: 'name', desc: true }],
+        sorting: [{ id: 'name', desc: true }],
     });
 
-    const { headerGroups, rows, prepareRow, setHiddenColumns } = useTable(
-        {
-            columns: columns as any,
-            data: actions,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-            defaultColumn: {
-                Cell: TextCell,
-            },
+    const table = useReactTable({
+        columns,
+        data: actions,
+        initialState,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
         },
-        useSortBy,
-        useFlexLayout,
-    );
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isMediumScreen,
@@ -247,19 +226,17 @@ export const ProjectActionsTable = ({
                 columns: ['filters', 'actions'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
 
+    const rowCount = table.getRowModel().rows.length;
+
     return (
         <>
-            <VirtualizedTable
-                rows={rows}
-                headerGroups={headerGroups}
-                prepareRow={prepareRow}
-            />
+            <VirtualizedTableV8 tableInstance={table} />
             <ConditionallyRender
-                condition={rows.length === 0}
+                condition={rowCount === 0}
                 show={
                     <TablePlaceholder>
                         No actions available. Get started by adding one.

--- a/frontend/src/component/project/ProjectAccess/ProjectGroupView/ProjectGroupView.tsx
+++ b/frontend/src/component/project/ProjectAccess/ProjectGroupView/ProjectGroupView.tsx
@@ -7,7 +7,8 @@ import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import PermissionIconButton from 'component/common/PermissionIconButton/PermissionIconButton';
 import { Search } from 'component/common/Search/Search';
 import { SidebarModal } from 'component/common/SidebarModal/SidebarModal';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
@@ -19,13 +20,12 @@ import { useSearch } from 'hooks/useSearch';
 import type { IGroup, IGroupUser } from 'interfaces/group';
 import { type FC, useState } from 'react';
 import {
-    type SortingRule,
-    useFlexLayout,
-    useSortBy,
-    useTable,
-} from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 
 const StyledPageContent = styled(PageContent)(({ theme }) => ({
     height: '100vh',
@@ -54,55 +54,59 @@ const StyledTitle = styled('div')(({ theme }) => ({
     },
 }));
 
-const defaultSort: SortingRule<string> = { id: 'joinedAt', desc: true };
+const defaultSort = { id: 'joinedAt', desc: true };
 
-const columns = [
+const columns: ColumnDef<IGroupUser, unknown>[] = [
     {
-        Header: 'Avatar',
-        accessor: 'imageUrl',
-        Cell: ({ row: { original: user } }: any) => (
+        id: 'imageUrl',
+        header: 'Avatar',
+        accessorKey: 'imageUrl',
+        cell: ({ row: { original: user } }) => (
             <TextCell>
                 <UserAvatar user={user} />
             </TextCell>
         ),
-        maxWidth: 85,
-        disableSortBy: true,
+        enableSorting: false,
+        meta: { maxWidth: 85 },
     },
     {
         id: 'name',
-        Header: 'Name',
-        accessor: (row: IGroupUser) => row.name || '',
-        Cell: ({ value, row: { original: row } }: any) => (
-            <HighlightCell value={value} subtitle={row.email || row.username} />
+        header: 'Name',
+        accessorFn: (row) => row.name || '',
+        cell: ({ getValue, row: { original: row } }) => (
+            <HighlightCell
+                value={String(getValue() ?? '')}
+                subtitle={row.email || row.username}
+            />
         ),
-        minWidth: 100,
-        searchable: true,
+        meta: { minWidth: 100, searchable: true },
     },
     {
         id: 'joined',
-        Header: 'Joined',
-        accessor: 'joinedAt',
-        Cell: DateCell,
-        maxWidth: 150,
+        header: 'Joined',
+        accessorKey: 'joinedAt',
+        cell: DateCell,
+        meta: { maxWidth: 150 },
     },
     {
         id: 'lastLogin',
-        Header: 'Last login',
-        accessor: 'seenAt',
-        Cell: TimeAgoCell,
-        maxWidth: 150,
+        header: 'Last login',
+        accessorKey: 'seenAt',
+        cell: TimeAgoCell,
+        meta: { maxWidth: 150 },
     },
     // Always hidden -- for search
     {
-        accessor: (row: IGroupUser) => row.username || '',
-        Header: 'Username',
-        searchable: true,
+        id: 'username',
+        accessorFn: (row) => row.username || '',
+        header: 'Username',
+        meta: { searchable: true },
     },
-    // Always hidden -- for search
     {
-        accessor: (row: IGroupUser) => row.email || '',
-        Header: 'Email',
-        searchable: true,
+        id: 'email',
+        accessorFn: (row) => row.email || '',
+        header: 'Email',
+        meta: { searchable: true },
     },
 ];
 
@@ -131,13 +135,13 @@ export const ProjectGroupView: FC<IProjectGroupViewProps> = ({
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
     const [initialState] = useState(() => ({
-        sortBy: [
+        sorting: [
             {
                 id: defaultSort.id,
                 desc: defaultSort.desc,
             },
         ],
-        hiddenColumns: ['Username', 'Email'],
+        columnVisibility: { username: false, email: false },
     }));
     const [searchValue, setSearchValue] = useState('');
 
@@ -147,31 +151,29 @@ export const ProjectGroupView: FC<IProjectGroupViewProps> = ({
         group?.users ?? [],
     );
 
-    const { headerGroups, rows, prepareRow, setHiddenColumns } = useTable(
-        {
-            columns: columns as any[],
-            data,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-        },
-        useSortBy,
-        useFlexLayout,
-    );
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isSmallScreen,
                 columns: hiddenColumnsSmall,
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
+
+    const rows = table.getRowModel().rows;
 
     return (
         <SidebarModal
@@ -250,11 +252,7 @@ export const ProjectGroupView: FC<IProjectGroupViewProps> = ({
                 }
             >
                 <SearchHighlightProvider value={getSearchText(searchValue)}>
-                    <VirtualizedTable
-                        rows={rows}
-                        headerGroups={headerGroups}
-                        prepareRow={prepareRow}
-                    />
+                    <VirtualizedTableV8 tableInstance={table} />
                 </SearchHighlightProvider>
                 <ConditionallyRender
                     condition={rows.length === 0}

--- a/frontend/src/component/project/ProjectEnvironment/EnvironmentHideDialog/ProjectEnvironmentTableSingle/ProjectEnvironmentTableSingle.tsx
+++ b/frontend/src/component/project/ProjectEnvironment/EnvironmentHideDialog/ProjectEnvironmentTableSingle/ProjectEnvironmentTableSingle.tsx
@@ -1,7 +1,13 @@
 import { styled, TableBody, TableRow } from '@mui/material';
 import type { IProjectEnvironment } from 'interfaces/environments';
-import { useTable } from 'react-table';
-import { SortableTableHeader, Table, TableCell } from 'component/common/Table';
+import {
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { Table, TableCell } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
 import { EnvironmentIconCell } from 'component/environments/EnvironmentTable/EnvironmentIconCell/EnvironmentIconCell';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { useMemo } from 'react';
@@ -26,72 +32,71 @@ export const ProjectEnvironmentTableSingle = ({
     environment,
     warnEnabledToggles,
 }: IProjectEnvironmentTableSingleProps) => {
-    const COLUMNS = useMemo(
+    const columns = useMemo<ColumnDef<IProjectEnvironment, unknown>[]>(
         () => [
             {
                 id: 'Icon',
-                width: '1%',
-                Cell: ({
-                    row: { original },
-                }: {
-                    row: { original: IProjectEnvironment };
-                }) => <EnvironmentIconCell environment={original} />,
-            },
-            {
-                Header: 'Name',
-                accessor: 'name',
-                Cell: TextCell,
-            },
-            {
-                Header: 'Type',
-                accessor: 'type',
-                Cell: TextCell,
-            },
-            {
-                Header: 'Toggles enabled',
-                accessor: 'projectEnabledToggleCount',
-                Cell: ({ value }: { value: number }) => (
-                    <TextCell>
-                        <StyledToggleWarning warning={value > 0}>
-                            {value === 1 ? '1 toggle' : `${value} toggles`}
-                        </StyledToggleWarning>
-                    </TextCell>
+                cell: ({ row: { original } }) => (
+                    <EnvironmentIconCell environment={original} />
                 ),
-                align: 'center',
+                meta: { width: '1%' },
+            },
+            {
+                id: 'name',
+                header: 'Name',
+                accessorKey: 'name',
+                cell: TextCell,
+            },
+            {
+                id: 'type',
+                header: 'Type',
+                accessorKey: 'type',
+                cell: TextCell,
+            },
+            {
+                id: 'projectEnabledToggleCount',
+                header: 'Toggles enabled',
+                accessorKey: 'projectEnabledToggleCount',
+                cell: ({ getValue }) => {
+                    const value = (getValue() as number | undefined) ?? 0;
+                    return (
+                        <TextCell>
+                            <StyledToggleWarning warning={value > 0}>
+                                {value === 1 ? '1 toggle' : `${value} toggles`}
+                            </StyledToggleWarning>
+                        </TextCell>
+                    );
+                },
+                meta: { align: 'center' },
             },
         ],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [warnEnabledToggles],
     );
 
-    const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-        useTable({
-            columns: COLUMNS as any,
-            data: [environment],
-            disableSortBy: true,
-        });
+    const table = useReactTable({
+        columns,
+        data: [environment],
+        getCoreRowModel: getCoreRowModel(),
+        enableSorting: false,
+    });
 
     return (
-        <StyledTable {...getTableProps()} rowHeight='compact'>
-            <SortableTableHeader headerGroups={headerGroups as any} />
-            <TableBody {...getTableBodyProps()}>
-                {rows.map((row) => {
-                    prepareRow(row);
-                    const { key, ...rowProps } = row.getRowProps();
-                    return (
-                        <TableRow hover key={key} {...rowProps}>
-                            {row.cells.map((cell) => {
-                                const { key, ...cellProps } =
-                                    cell.getCellProps();
-
-                                return (
-                                    <TableCell key={key} {...cellProps}>
-                                        {cell.render('Cell')}
-                                    </TableCell>
-                                );
-                            })}
-                        </TableRow>
-                    );
-                })}
+        <StyledTable rowHeight='compact'>
+            <SortableTableHeaderV8 tableInstance={table} />
+            <TableBody>
+                {table.getRowModel().rows.map((row) => (
+                    <TableRow hover key={row.id}>
+                        {row.getVisibleCells().map((cell) => (
+                            <TableCell key={cell.id}>
+                                {flexRender(
+                                    cell.column.columnDef.cell,
+                                    cell.getContext(),
+                                )}
+                            </TableCell>
+                        ))}
+                    </TableRow>
+                ))}
             </TableBody>
         </StyledTable>
     );

--- a/frontend/src/component/project/ProjectList/ProjectsListTable/ProjectsListTable.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectsListTable/ProjectsListTable.tsx
@@ -1,4 +1,4 @@
-import { VirtualizedTable } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { TimeAgoCell } from 'component/common/Table/cells/TimeAgoCell/TimeAgoCell';
@@ -7,7 +7,11 @@ import { useFavoriteProjectsApi } from 'hooks/api/actions/useFavoriteProjectsApi
 import useProjects from 'hooks/api/getters/useProjects/useProjects';
 import type { ProjectSchema, ProjectSchemaOwners } from 'openapi';
 import { useCallback, useMemo } from 'react';
-import { useFlexLayout, useTable } from 'react-table';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { formatDateYMDHMS } from 'utils/formatDate';
 import { ProjectsListTableNameCell } from './ProjectsListTableNameCell.tsx';
 import { useMediaQuery } from '@mui/material';
@@ -32,111 +36,117 @@ export const ProjectsListTable = ({ projects }: ProjectsListTableProps) => {
             }
             refetch();
         },
-        [refetch],
+        [refetch, favorite, unfavorite],
     );
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<ProjectSchema, unknown>[]>(
         () => [
             {
-                Header: 'Project name',
-                accessor: 'name',
-                minWidth: 200,
-                searchable: true,
-                Cell: ({ row }: { row: { original: ProjectSchema } }) => (
+                id: 'name',
+                header: 'Project name',
+                accessorKey: 'name',
+                cell: ({ row }) => (
                     <ProjectsListTableNameCell
                         row={row}
                         isFavorite={Boolean(row.original.favorite)}
                         onFavorite={() => onFavorite(row.original)}
                     />
                 ),
+                meta: { minWidth: 200, searchable: true },
             },
             {
-                Header: 'Last updated',
-                accessor: (row: ProjectSchema) =>
-                    row.lastUpdatedAt || row.createdAt,
-                Cell: ({ value, column }) => (
+                id: 'lastUpdatedAt',
+                header: 'Last updated',
+                accessorFn: (row) => row.lastUpdatedAt || row.createdAt,
+                cell: ({ getValue, column }) => (
                     <TimeAgoCell
-                        value={value}
+                        value={String(getValue() ?? '')}
                         column={column}
                         dateFormat={formatDateYMDHMS}
                     />
                 ),
-                width: 150,
+                meta: { width: 150 },
             },
             {
-                Header: 'Flags',
-                accessor: 'featureCount',
-                Cell: ({ value }: { value: number }) => (
-                    <TextCell>
-                        {value} flag{value === 1 ? '' : 's'}
-                    </TextCell>
+                id: 'featureCount',
+                header: 'Flags',
+                accessorKey: 'featureCount',
+                cell: ({ getValue }) => {
+                    const value = getValue() as number;
+                    return (
+                        <TextCell>
+                            {value} flag{value === 1 ? '' : 's'}
+                        </TextCell>
+                    );
+                },
+                meta: { width: 90 },
+            },
+            {
+                id: 'technicalDebt',
+                header: 'Technical debt',
+                accessorKey: 'technicalDebt',
+                cell: ({ getValue }) => (
+                    <TextCell>{`${getValue() as number}%`}</TextCell>
                 ),
-                width: 90,
+                meta: { width: 130 },
             },
             {
-                Header: 'Technical debt',
-                accessor: 'technicalDebt',
-                Cell: ({ value }: { value: number }) => (
-                    <TextCell>{value}%</TextCell>
-                ),
-                width: 130,
-            },
-            {
-                Header: 'Last seen',
-                accessor: 'lastReportedFlagUsage',
-                Cell: ({ value }: { value: Date }) => (
+                id: 'lastReportedFlagUsage',
+                header: 'Last seen',
+                accessorKey: 'lastReportedFlagUsage',
+                cell: ({ getValue }) => (
                     <ProjectListTableLastSeenCell
-                        value={value}
+                        value={getValue() as Date | undefined}
                         hideLabel={isMediumScreen}
                     />
                 ),
-                width: isMediumScreen ? 100 : 140,
+                meta: { width: isMediumScreen ? 100 : 140 },
             },
             {
-                Header: 'Owner',
-                accessor: 'owners',
-                Cell: ({ value }: { value: ProjectSchemaOwners }) => (
-                    <TextCell>
-                        <ProjectOwners
-                            owners={value?.filter(
-                                (owner) => owner.ownerType !== 'system',
-                            )}
-                        />
-                    </TextCell>
-                ),
+                id: 'owners',
+                header: 'Owner',
+                accessorKey: 'owners',
+                cell: ({ getValue }) => {
+                    const value = getValue() as ProjectSchemaOwners | undefined;
+                    return (
+                        <TextCell>
+                            <ProjectOwners
+                                owners={value?.filter(
+                                    (owner) => owner.ownerType !== 'system',
+                                )}
+                            />
+                        </TextCell>
+                    );
+                },
+                meta: { width: 150 },
             },
             {
-                Header: 'Members',
-                accessor: 'memberCount',
-                Cell: ({ value }: { value: number }) => (
-                    <TextCell>{value} members</TextCell>
+                id: 'memberCount',
+                header: 'Members',
+                accessorKey: 'memberCount',
+                cell: ({ getValue }) => (
+                    <TextCell>{`${getValue() as number} members`}</TextCell>
                 ),
-                width: 120,
+                meta: { width: 120 },
             },
         ],
-        [onFavorite],
+        [onFavorite, isMediumScreen],
     );
 
-    const { headerGroups, rows, prepareRow } = useTable(
-        {
-            columns: columns as any,
-            data: projects,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-            defaultColumn: {
-                Cell: HighlightCell,
-            },
+    const table = useReactTable({
+        columns,
+        data: projects,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <HighlightCell value={String(getValue() ?? '')} />
+            ),
         },
-        useFlexLayout,
-    );
+        getCoreRowModel: getCoreRowModel(),
+        autoResetAll: false,
+        enableSorting: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    return (
-        <VirtualizedTable
-            rows={rows}
-            headerGroups={headerGroups}
-            prepareRow={prepareRow}
-        />
-    );
+    return <VirtualizedTableV8 tableInstance={table} />;
 };

--- a/frontend/src/component/segments/SegmentTable/SegmentTable.tsx
+++ b/frontend/src/component/segments/SegmentTable/SegmentTable.tsx
@@ -1,18 +1,24 @@
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import {
-    SortableTableHeader,
     Table,
     TableBody,
     TableCell,
     TablePlaceholder,
     TableRow,
 } from 'component/common/Table';
-import { useGlobalFilter, useSortBy, useTable } from 'react-table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
+import {
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    getFilteredRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { CreateSegmentButton } from 'component/segments/CreateSegmentButton/CreateSegmentButton';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { useMediaQuery } from '@mui/material';
-import { sortTypes } from 'utils/sortTypes';
 import { useSegments } from 'hooks/api/getters/useSegments/useSegments';
 import { useMemo, useState } from 'react';
 import { SegmentEmpty } from 'component/segments/SegmentEmpty';
@@ -25,21 +31,23 @@ import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import theme from 'themes/theme';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { Search } from 'component/common/Search/Search';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam';
 import { UsedInCell } from 'component/context/ContextList/UsedInCell';
+import type { ISegment } from 'interfaces/segment';
 
 export const SegmentTable = () => {
     const projectId = useOptionalPathParam('projectId');
     const { segments, loading: loadingSegments } = useSegments();
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
+    const [globalFilter, setGlobalFilter] = useState('');
     const [initialState] = useState({
-        sortBy: [{ id: 'createdAt' }],
-        hiddenColumns: ['description'],
+        sorting: [{ id: 'createdAt', desc: false }],
+        columnVisibility: { description: false },
     });
 
-    const data = useMemo(() => {
+    const data = useMemo<ISegment[]>(() => {
         if (!segments) {
             return Array(5).fill({
                 name: 'Segment name',
@@ -57,36 +65,31 @@ export const SegmentTable = () => {
         return segments;
     }, [segments, projectId]);
 
-    const columns = useMemo(() => getColumns(projectId), [projectId]);
-    const {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
-        state: { globalFilter },
-        setGlobalFilter,
-        setHiddenColumns,
-    } = useTable(
-        {
-            initialState,
-            columns: columns as any,
-            data: data as any,
-            sortTypes,
-            autoResetGlobalFilter: false,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            defaultColumn: {
-                Cell: HighlightCell,
-            },
-            getRowId: (row: any) => row.id,
-        },
-        useGlobalFilter,
-        useSortBy,
+    const columns = useMemo<ColumnDef<ISegment, unknown>[]>(
+        () => getColumns(projectId),
+        [projectId],
     );
 
-    useConditionallyHiddenColumns(
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        state: { globalFilter },
+        onGlobalFilterChange: setGlobalFilter,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <HighlightCell value={String(getValue() ?? '')} />
+            ),
+        },
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        getRowId: (row) => String(row.id),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
+
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isSmallScreen,
@@ -97,9 +100,11 @@ export const SegmentTable = () => {
                 columns: ['project'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
+
+    const rows = table.getRowModel().rows;
 
     return (
         <PageContent
@@ -110,7 +115,7 @@ export const SegmentTable = () => {
                         <>
                             <Search
                                 initialValue={globalFilter}
-                                onChange={setGlobalFilter}
+                                onChange={(value) => setGlobalFilter(value)}
                             />
                             <PageHeader.Divider />
                             <CreateSegmentButton />
@@ -130,40 +135,24 @@ export const SegmentTable = () => {
                 elseShow={() => (
                     <>
                         <SearchHighlightProvider value={globalFilter}>
-                            <Table {...getTableProps()} rowHeight='standard'>
-                                <SortableTableHeader
-                                    headerGroups={headerGroups as any}
-                                />
-                                <TableBody {...getTableBodyProps()}>
-                                    {rows.map((row) => {
-                                        prepareRow(row);
-                                        const { key, ...rowProps } =
-                                            row.getRowProps();
-                                        return (
-                                            <TableRow
-                                                hover
-                                                key={key}
-                                                {...rowProps}
-                                            >
-                                                {row.cells.map((cell) => {
-                                                    const {
-                                                        key,
-                                                        ...cellProps
-                                                    } = cell.getCellProps();
-                                                    return (
-                                                        <TableCell
-                                                            key={key}
-                                                            {...cellProps}
-                                                        >
-                                                            {cell.render(
-                                                                'Cell',
-                                                            )}
-                                                        </TableCell>
-                                                    );
-                                                })}
-                                            </TableRow>
-                                        );
-                                    })}
+                            <Table rowHeight='standard'>
+                                <SortableTableHeaderV8 tableInstance={table} />
+                                <TableBody>
+                                    {rows.map((row) => (
+                                        <TableRow hover key={row.id}>
+                                            {row
+                                                .getVisibleCells()
+                                                .map((cell) => (
+                                                    <TableCell key={cell.id}>
+                                                        {flexRender(
+                                                            cell.column
+                                                                .columnDef.cell,
+                                                            cell.getContext(),
+                                                        )}
+                                                    </TableCell>
+                                                ))}
+                                        </TableRow>
+                                    ))}
                                 </TableBody>
                             </Table>
                         </SearchHighlightProvider>
@@ -185,23 +174,23 @@ export const SegmentTable = () => {
     );
 };
 
-const getColumns = (projectId?: string) => [
+const getColumns = (projectId?: string): ColumnDef<ISegment, unknown>[] => [
     {
         id: 'Icon',
-        width: '1%',
-        disableGlobalFilter: true,
-        disableSortBy: true,
-        Cell: () => <IconCell icon={<DonutLarge color='disabled' />} />,
+        enableGlobalFilter: false,
+        enableSorting: false,
+        cell: () => <IconCell icon={<DonutLarge color='disabled' />} />,
+        meta: { width: '1%' },
     },
     {
-        Header: 'Name',
-        accessor: 'name',
-        width: '60%',
-        Cell: ({
+        id: 'name',
+        header: 'Name',
+        accessorKey: 'name',
+        cell: ({
             row: {
                 original: { name, description, id },
             },
-        }: any) => (
+        }) => (
             <LinkCell
                 title={name}
                 to={
@@ -212,53 +201,59 @@ const getColumns = (projectId?: string) => [
                 subtitle={description}
             />
         ),
+        meta: { width: '60%' },
     },
     {
-        Header: 'Used in',
-        width: '60%',
-        Cell: ({ row: { original } }: any) => (
-            <UsedInCell original={original} />
+        id: 'usedIn',
+        header: 'Used in',
+        cell: ({ row: { original } }) => (
+            <UsedInCell original={original as never} />
         ),
+        meta: { width: '60%' },
     },
     {
-        Header: 'Project',
-        accessor: 'project',
-        Cell: ({ value }: { value: string }) => (
-            <ConditionallyRender
-                condition={Boolean(value)}
-                show={<LinkCell title={value} to={`/projects/${value}`} />}
-                elseShow={<TextCell>Global</TextCell>}
-            />
-        ),
-        sortType: 'alphanumeric',
-        maxWidth: 150,
-        filterName: 'project',
-        searchable: true,
+        id: 'project',
+        header: 'Project',
+        accessorKey: 'project',
+        cell: ({ getValue }) => {
+            const value = String(getValue() ?? '');
+            return (
+                <ConditionallyRender
+                    condition={Boolean(value)}
+                    show={<LinkCell title={value} to={`/projects/${value}`} />}
+                    elseShow={<TextCell>Global</TextCell>}
+                />
+            );
+        },
+        sortingFn: 'alphanumeric',
+        meta: { maxWidth: 150, filterName: 'project', searchable: true },
     },
     {
-        Header: 'Created at',
-        accessor: 'createdAt',
-        minWidth: 150,
-        Cell: DateCell,
-        disableGlobalFilter: true,
+        id: 'createdAt',
+        header: 'Created at',
+        accessorKey: 'createdAt',
+        cell: DateCell,
+        enableGlobalFilter: false,
+        meta: { minWidth: 150 },
     },
     {
-        Header: 'Created by',
-        accessor: 'createdBy',
-        width: '25%',
+        id: 'createdBy',
+        header: 'Created by',
+        accessorKey: 'createdBy',
+        meta: { width: '25%' },
     },
     {
-        Header: 'Actions',
         id: 'Actions',
-        align: 'center',
-        width: '1%',
-        disableSortBy: true,
-        disableGlobalFilter: true,
-        Cell: ({ row: { original } }: any) => (
+        header: 'Actions',
+        cell: ({ row: { original } }) => (
             <SegmentActionCell segment={original} />
         ),
+        enableSorting: false,
+        enableGlobalFilter: false,
+        meta: { width: '1%', align: 'center' },
     },
     {
-        accessor: 'description',
+        id: 'description',
+        accessorKey: 'description',
     },
 ];

--- a/frontend/src/component/signals/SignalEndpointsModal/SignalEndpointsForm/SignalEndpointsTokens/SignalEndpointsTokens.tsx
+++ b/frontend/src/component/signals/SignalEndpointsModal/SignalEndpointsForm/SignalEndpointsTokens/SignalEndpointsTokens.tsx
@@ -9,7 +9,8 @@ import {
     useTheme,
 } from '@mui/material';
 import { Search } from 'component/common/Search/Search';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { ActionCell } from 'component/common/Table/cells/ActionCell/ActionCell';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
@@ -19,15 +20,14 @@ import { useSignalEndpointTokens } from 'hooks/api/getters/useSignalEndpointToke
 import { useSearch } from 'hooks/useSearch';
 import { useMemo, useState } from 'react';
 import {
-    useTable,
-    type SortingRule,
-    useSortBy,
-    useFlexLayout,
-} from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { SignalEndpointsTokensCreateDialog } from './SignalEndpointsTokensCreateDialog.tsx';
 import { SignalEndpointsTokensDialog } from './SignalEndpointsTokensDialog.tsx';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { Dialogue } from 'component/common/Dialogue/Dialogue';
 import {
@@ -74,7 +74,7 @@ export type PageQueryType = Partial<
     Record<'sort' | 'order' | 'search', string>
 >;
 
-const defaultSort: SortingRule<string> = { id: 'createdAt', desc: true };
+const defaultSort = { id: 'createdAt', desc: true };
 
 interface ISignalEndpointsTokensProps {
     signalEndpoint: ISignalEndpoint;
@@ -93,7 +93,7 @@ export const SignalEndpointsTokens = ({
         useSignalEndpointTokensApi();
 
     const [initialState] = useState(() => ({
-        sortBy: [defaultSort],
+        sorting: [defaultSort],
     }));
 
     const [searchValue, setSearchValue] = useState('');
@@ -143,26 +143,26 @@ export const SignalEndpointsTokens = ({
         }
     };
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<ISignalEndpointToken, unknown>[]>(
         () => [
             {
-                Header: 'Name',
-                accessor: 'name',
-                Cell: HighlightCell,
-                minWidth: 100,
-                searchable: true,
+                id: 'name',
+                header: 'Name',
+                accessorKey: 'name',
+                cell: HighlightCell,
+                meta: { minWidth: 100, searchable: true },
             },
             {
-                Header: 'Created',
-                accessor: 'createdAt',
-                Cell: DateCell,
-                maxWidth: 150,
+                id: 'createdAt',
+                header: 'Created',
+                accessorKey: 'createdAt',
+                cell: DateCell,
+                meta: { maxWidth: 150 },
             },
             {
-                Header: 'Actions',
                 id: 'Actions',
-                align: 'center',
-                Cell: ({ row: { original: rowToken } }: any) => (
+                header: 'Actions',
+                cell: ({ row: { original: rowToken } }) => (
                     <ActionCell>
                         <Tooltip title='Delete token' arrow describeChild>
                             <span>
@@ -178,11 +178,11 @@ export const SignalEndpointsTokens = ({
                         </Tooltip>
                     </ActionCell>
                 ),
-                maxWidth: 100,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { maxWidth: 100, align: 'center' },
             },
         ],
-        [setSelectedToken, setDeleteOpen],
+        [],
     );
 
     const { data, getSearchText, getSearchContext } = useSearch(
@@ -191,31 +191,29 @@ export const SignalEndpointsTokens = ({
         signalEndpointTokens,
     );
 
-    const { headerGroups, rows, prepareRow, setHiddenColumns } = useTable(
-        {
-            columns: columns as any[],
-            data,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-        },
-        useSortBy,
-        useFlexLayout,
-    );
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isSmallScreen,
                 columns: ['createdAt'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
+
+    const rowCount = table.getRowModel().rows.length;
 
     return (
         <>
@@ -235,14 +233,10 @@ export const SignalEndpointsTokens = ({
                 </Button>
             </StyledHeader>
             <SearchHighlightProvider value={getSearchText(searchValue)}>
-                <VirtualizedTable
-                    rows={rows}
-                    headerGroups={headerGroups}
-                    prepareRow={prepareRow}
-                />
+                <VirtualizedTableV8 tableInstance={table} />
             </SearchHighlightProvider>
             <ConditionallyRender
-                condition={rows.length === 0}
+                condition={rowCount === 0}
                 show={
                     <ConditionallyRender
                         condition={searchValue?.length > 0}

--- a/frontend/src/component/tags/TagTypeList/TagTypeList.tsx
+++ b/frontend/src/component/tags/TagTypeList/TagTypeList.tsx
@@ -3,12 +3,12 @@ import { useNavigate } from 'react-router-dom';
 import { Box, styled } from '@mui/material';
 import {
     Table,
-    SortableTableHeader,
     TableBody,
     TableCell,
     TableRow,
     TablePlaceholder,
 } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
 import Delete from '@mui/icons-material/Delete';
 import Edit from '@mui/icons-material/Edit';
 import Label from '@mui/icons-material/Label';
@@ -25,12 +25,24 @@ import useTagTypes from 'hooks/api/getters/useTagTypes/useTagTypes';
 import useToast from 'hooks/useToast';
 import PermissionIconButton from 'component/common/PermissionIconButton/PermissionIconButton';
 import { formatUnknownError } from 'utils/formatUnknownError';
-import { useTable, useGlobalFilter, useSortBy } from 'react-table';
+import {
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    getFilteredRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { LinkCell } from 'component/common/Table/cells/LinkCell/LinkCell';
-import { sortTypes } from 'utils/sortTypes';
 import { AddTagTypeButton } from './AddTagTypeButton/AddTagTypeButton.tsx';
 import { Search } from 'component/common/Search/Search';
+
+type TagTypeRow = {
+    name: string;
+    description: string;
+    color?: string;
+};
 
 const StyledColorDot = styled('div')<{ $color: string }>(
     ({ theme, $color }) => ({
@@ -52,12 +64,13 @@ export const TagTypeList = () => {
         open: boolean;
         name?: string;
     }>({ open: false });
+    const [globalFilter, setGlobalFilter] = useState('');
     const navigate = useNavigate();
     const { deleteTagType } = useTagTypesApi();
     const { tagTypes, refetch, loading } = useTagTypes();
     const { setToastData, setToastApiError } = useToast();
 
-    const data = useMemo(() => {
+    const data = useMemo<TagTypeRow[]>(() => {
         if (loading) {
             return Array(5).fill({
                 name: 'Tag type name',
@@ -67,16 +80,16 @@ export const TagTypeList = () => {
 
         return tagTypes.map(({ name, description, color }) => ({
             name,
-            description,
-            color,
+            description: description ?? '',
+            color: color ?? undefined,
         }));
     }, [tagTypes, loading]);
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<TagTypeRow, unknown>[]>(
         () => [
             {
                 id: 'Icon',
-                Cell: () => (
+                cell: () => (
                     <Box
                         data-loading
                         sx={{
@@ -89,38 +102,38 @@ export const TagTypeList = () => {
                         <Label color='disabled' />
                     </Box>
                 ),
-                disableGlobalFilter: true,
+                enableGlobalFilter: false,
             },
             {
-                Header: 'Name',
-                accessor: 'name',
-                width: '90%',
-                Cell: ({
+                id: 'name',
+                header: 'Name',
+                accessorKey: 'name',
+                cell: ({
                     row: {
                         original: { name, description, color },
                     },
-                }: any) => {
-                    return (
-                        <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                            <ConditionallyRender
-                                condition={Boolean(color)}
-                                show={<StyledColorDot $color={color} />}
-                            />
-                            <LinkCell
-                                data-loading
-                                title={name}
-                                subtitle={description}
-                            />
-                        </Box>
-                    );
-                },
-                sortType: 'alphanumeric',
+                }) => (
+                    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                        <ConditionallyRender
+                            condition={Boolean(color)}
+                            show={
+                                <StyledColorDot $color={color ?? '#FFFFFF'} />
+                            }
+                        />
+                        <LinkCell
+                            data-loading
+                            title={name}
+                            subtitle={description}
+                        />
+                    </Box>
+                ),
+                sortingFn: 'alphanumeric',
+                meta: { width: '90%' },
             },
             {
-                Header: 'Actions',
                 id: 'Actions',
-                align: 'center',
-                Cell: ({ row: { original } }: any) => (
+                header: 'Actions',
+                cell: ({ row: { original } }) => (
                     <Box
                         sx={{ display: 'flex', justifyContent: 'flex-end' }}
                         data-loading
@@ -134,7 +147,6 @@ export const TagTypeList = () => {
                         >
                             <Edit />
                         </PermissionIconButton>
-
                         <PermissionIconButton
                             permission={DELETE_TAG_TYPE}
                             tooltipProps={{ title: 'Delete tag type' }}
@@ -149,13 +161,14 @@ export const TagTypeList = () => {
                         </PermissionIconButton>
                     </Box>
                 ),
-                width: 150,
-                disableGlobalFilter: true,
-                disableSortBy: true,
+                enableSorting: false,
+                enableGlobalFilter: false,
+                meta: { width: 150, align: 'center' },
             },
             {
-                accessor: 'description',
-                disableSortBy: true,
+                id: 'description',
+                accessorKey: 'description',
+                enableSorting: false,
             },
         ],
         [navigate],
@@ -163,33 +176,24 @@ export const TagTypeList = () => {
 
     const initialState = useMemo(
         () => ({
-            sortBy: [{ id: 'name', desc: false }],
-            hiddenColumns: ['description'],
+            sorting: [{ id: 'name', desc: false }],
+            columnVisibility: { description: false },
         }),
         [],
     );
 
-    const {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
         state: { globalFilter },
-        setGlobalFilter,
-    } = useTable(
-        {
-            columns: columns as any[], // TODO: fix after `react-table` v8 update
-            data,
-            initialState,
-            sortTypes,
-            autoResetGlobalFilter: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-        },
-        useGlobalFilter,
-        useSortBy,
-    );
+        onGlobalFilterChange: setGlobalFilter,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
 
     const deleteTag = async () => {
         try {
@@ -207,6 +211,9 @@ export const TagTypeList = () => {
             setToastApiError(formatUnknownError(error));
         }
     };
+
+    const rows = table.getRowModel().rows;
+
     return (
         <PageContent
             isLoading={loading}
@@ -217,7 +224,7 @@ export const TagTypeList = () => {
                         <>
                             <Search
                                 initialValue={globalFilter}
-                                onChange={setGlobalFilter}
+                                onChange={(value) => setGlobalFilter(value)}
                             />
                             <PageHeader.Divider />
                             <AddTagTypeButton />
@@ -227,26 +234,21 @@ export const TagTypeList = () => {
             }
         >
             <SearchHighlightProvider value={globalFilter}>
-                <Table {...getTableProps()}>
-                    <SortableTableHeader headerGroups={headerGroups} />
-                    <TableBody {...getTableBodyProps()}>
-                        {rows.map((row) => {
-                            prepareRow(row);
-                            const { key, ...rowProps } = row.getRowProps();
-                            return (
-                                <TableRow hover key={key} {...rowProps}>
-                                    {row.cells.map((cell) => {
-                                        const { key, ...cellProps } =
-                                            cell.getCellProps();
-                                        return (
-                                            <TableCell key={key} {...cellProps}>
-                                                {cell.render('Cell')}
-                                            </TableCell>
-                                        );
-                                    })}
-                                </TableRow>
-                            );
-                        })}
+                <Table>
+                    <SortableTableHeaderV8 tableInstance={table} />
+                    <TableBody>
+                        {rows.map((row) => (
+                            <TableRow hover key={row.id}>
+                                {row.getVisibleCells().map((cell) => (
+                                    <TableCell key={cell.id}>
+                                        {flexRender(
+                                            cell.column.columnDef.cell,
+                                            cell.getContext(),
+                                        )}
+                                    </TableCell>
+                                ))}
+                            </TableRow>
+                        ))}
                     </TableBody>
                 </Table>
             </SearchHighlightProvider>

--- a/frontend/src/component/tags/TagTypeList/__tests__/__snapshots__/TagTypeList.test.tsx.snap
+++ b/frontend/src/component/tags/TagTypeList/__tests__/__snapshots__/TagTypeList.test.tsx.snap
@@ -88,7 +88,6 @@ exports[`renders an empty list correctly 1`] = `
       >
         <table
           class="MuiTable-root mui-xfo33b-MuiTable-root"
-          role="table"
         >
           <thead
             class="MuiTableHead-root mui-5x8cdn-MuiTableHead-root"
@@ -96,22 +95,18 @@ exports[`renders an empty list correctly 1`] = `
             <tr
               class="MuiTableRow-root MuiTableRow-head mui-11ykd7w-MuiTableRow-root skeleton"
               data-loading="true"
-              role="row"
             >
               <th
                 class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium mui-v5ykp5-MuiTableCell-root"
                 scope="col"
-                style="width: 150px; min-width: 0; max-width: 9007199254740991px;"
               >
-                <div>
-                   
-                </div>
+                <div />
               </th>
               <th
                 aria-sort="ascending"
                 class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium mui-aoexvr-MuiTableCell-root"
                 scope="col"
-                style="width: 90%; min-width: 0; max-width: 9007199254740991px;"
+                style="width: 90%;"
               >
                 <button
                   aria-label=""
@@ -169,7 +164,7 @@ exports[`renders an empty list correctly 1`] = `
               <th
                 class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium mui-v5ykp5-MuiTableCell-root"
                 scope="col"
-                style="width: 150px; min-width: 0; max-width: 9007199254740991px;"
+                style="width: 150px;"
               >
                 <div
                   style="justify-content: center; text-align: center;"
@@ -181,15 +176,12 @@ exports[`renders an empty list correctly 1`] = `
           </thead>
           <tbody
             class="MuiTableBody-root mui-gmh7jj-MuiTableBody-root"
-            role="rowgroup"
           >
             <tr
               class="MuiTableRow-root MuiTableRow-hover mui-11ykd7w-MuiTableRow-root"
-              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-7n01ps skeleton"
@@ -210,7 +202,6 @@ exports[`renders an empty list correctly 1`] = `
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-70qvj9"
@@ -245,7 +236,6 @@ exports[`renders an empty list correctly 1`] = `
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-1bvc4cc skeleton"
@@ -306,11 +296,9 @@ exports[`renders an empty list correctly 1`] = `
             </tr>
             <tr
               class="MuiTableRow-root MuiTableRow-hover mui-11ykd7w-MuiTableRow-root"
-              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-7n01ps skeleton"
@@ -331,7 +319,6 @@ exports[`renders an empty list correctly 1`] = `
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-70qvj9"
@@ -366,7 +353,6 @@ exports[`renders an empty list correctly 1`] = `
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-1bvc4cc skeleton"
@@ -427,11 +413,9 @@ exports[`renders an empty list correctly 1`] = `
             </tr>
             <tr
               class="MuiTableRow-root MuiTableRow-hover mui-11ykd7w-MuiTableRow-root"
-              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-7n01ps skeleton"
@@ -452,7 +436,6 @@ exports[`renders an empty list correctly 1`] = `
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-70qvj9"
@@ -487,7 +470,6 @@ exports[`renders an empty list correctly 1`] = `
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-1bvc4cc skeleton"
@@ -548,11 +530,9 @@ exports[`renders an empty list correctly 1`] = `
             </tr>
             <tr
               class="MuiTableRow-root MuiTableRow-hover mui-11ykd7w-MuiTableRow-root"
-              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-7n01ps skeleton"
@@ -573,7 +553,6 @@ exports[`renders an empty list correctly 1`] = `
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-70qvj9"
@@ -608,7 +587,6 @@ exports[`renders an empty list correctly 1`] = `
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-1bvc4cc skeleton"
@@ -669,11 +647,9 @@ exports[`renders an empty list correctly 1`] = `
             </tr>
             <tr
               class="MuiTableRow-root MuiTableRow-hover mui-11ykd7w-MuiTableRow-root"
-              role="row"
             >
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-7n01ps skeleton"
@@ -694,7 +670,6 @@ exports[`renders an empty list correctly 1`] = `
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-70qvj9"
@@ -729,7 +704,6 @@ exports[`renders an empty list correctly 1`] = `
               </td>
               <td
                 class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium mui-fdtqkd-MuiTableCell-root"
-                role="cell"
               >
                 <div
                   class="MuiBox-root mui-1bvc4cc skeleton"

--- a/frontend/src/component/unknownFlags/UnknownFlagsTable.tsx
+++ b/frontend/src/component/unknownFlags/UnknownFlagsTable.tsx
@@ -1,12 +1,17 @@
 import { useContext, useMemo, useState } from 'react';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { Alert, styled, useMediaQuery } from '@mui/material';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
-import { useFlexLayout, useSortBy, useTable } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { Search } from 'component/common/Search/Search';
 import { useSearch } from 'hooks/useSearch';
 import { type UnknownFlag, useUnknownFlags } from './hooks/useUnknownFlags.js';
@@ -61,16 +66,17 @@ export const UnknownFlagsTable = () => {
         return project;
     }, [projects, hasAccess]);
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<UnknownFlag, unknown>[]>(
         () => [
             {
-                Header: 'Flag name',
-                accessor: 'name',
-                minWidth: 100,
-                searchable: true,
+                id: 'name',
+                header: 'Flag name',
+                accessorKey: 'name',
+                meta: { minWidth: 100, searchable: true },
             },
             {
-                Header: (
+                id: 'lastSeenAt',
+                header: () => (
                     <StyledHeader>
                         Last reported
                         <HelpIcon
@@ -79,12 +85,13 @@ export const UnknownFlagsTable = () => {
                         />
                     </StyledHeader>
                 ),
-                accessor: 'lastSeenAt',
-                Cell: UnknownFlagsLastReportedCell,
-                width: 170,
+                accessorKey: 'lastSeenAt',
+                cell: UnknownFlagsLastReportedCell,
+                meta: { width: 170 },
             },
             {
-                Header: (
+                id: 'lastEventAt',
+                header: () => (
                     <StyledHeader>
                         Last event
                         <HelpIcon
@@ -93,44 +100,37 @@ export const UnknownFlagsTable = () => {
                         />
                     </StyledHeader>
                 ),
-                accessor: 'lastEventAt',
-                Cell: ({
-                    row: { original: unknownFlag },
-                }: {
-                    row: { original: UnknownFlag };
-                }) => (
+                accessorKey: 'lastEventAt',
+                cell: ({ row: { original: unknownFlag } }) => (
                     <UnknownFlagsLastEventCell
                         unknownFlag={unknownFlag}
                         dateFormat={formatDateYMDHMS}
                     />
                 ),
-                width: 150,
+                meta: { width: 150 },
             },
             {
-                Header: 'Actions',
-                align: 'center',
-                Cell: ({
-                    row: { original: unknownFlag },
-                }: {
-                    row: { original: UnknownFlag };
-                }) => (
+                id: 'Actions',
+                header: 'Actions',
+                cell: ({ row: { original: unknownFlag } }) => (
                     <UnknownFlagsActionsCell
                         unknownFlag={unknownFlag}
                         suggestedProject={suggestedProject}
                     />
                 ),
-                width: 120,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { width: 120, align: 'center' },
             },
             // Always hidden -- for search
             {
-                accessor: (row: UnknownFlag) =>
-                    row.reports.map(({ appName }) => appName).join('\n'),
                 id: 'appNames',
-                searchable: true,
+                accessorFn: (row) =>
+                    row.reports.map(({ appName }) => appName).join('\n'),
+                meta: { searchable: true },
             },
             {
-                accessor: (row: UnknownFlag) =>
+                id: 'environments',
+                accessorFn: (row) =>
                     Array.from(
                         new Set(
                             row.reports.flatMap(({ environments }) =>
@@ -140,16 +140,15 @@ export const UnknownFlagsTable = () => {
                             ),
                         ),
                     ).join('\n'),
-                id: 'environments',
-                searchable: true,
+                meta: { searchable: true },
             },
         ],
         [suggestedProject],
     );
 
     const [initialState] = useState({
-        sortBy: [{ id: 'name', desc: false }],
-        hiddenColumns: ['appNames', 'environments'],
+        sorting: [{ id: 'name', desc: false }],
+        columnVisibility: { appNames: false, environments: false },
     });
 
     const { data, getSearchText } = useSearch(
@@ -158,30 +157,30 @@ export const UnknownFlagsTable = () => {
         unknownFlags,
     );
 
-    const { headerGroups, rows, prepareRow } = useTable(
-        {
-            columns: columns as any,
-            data,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-            defaultColumn: {
-                Cell: HighlightCell,
-            },
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <HighlightCell value={String(getValue() ?? '')} />
+            ),
         },
-        useSortBy,
-        useFlexLayout,
-    );
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
+
+    const rowCount = table.getRowModel().rows.length;
 
     return (
         <PageContent
             isLoading={loading}
             header={
                 <PageHeader
-                    title={`Unknown flags (${rows.length})`}
+                    title={`Unknown flags (${rowCount})`}
                     actions={
                         <>
                             <ConditionallyRender
@@ -240,14 +239,10 @@ export const UnknownFlagsTable = () => {
             </StyledAlert>
 
             <SearchHighlightProvider value={getSearchText(searchValue)}>
-                <VirtualizedTable
-                    rows={rows}
-                    headerGroups={headerGroups}
-                    prepareRow={prepareRow}
-                />
+                <VirtualizedTableV8 tableInstance={table} />
             </SearchHighlightProvider>
             <ConditionallyRender
-                condition={rows.length === 0}
+                condition={rowCount === 0}
                 show={
                     <ConditionallyRender
                         condition={searchValue?.length > 0}

--- a/frontend/src/component/user/Profile/PersonalAPITokensTab/PersonalAPITokensTab.tsx
+++ b/frontend/src/component/user/Profile/PersonalAPITokensTab/PersonalAPITokensTab.tsx
@@ -13,7 +13,8 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { Search } from 'component/common/Search/Search';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { ActionCell } from 'component/common/Table/cells/ActionCell/ActionCell';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
@@ -29,19 +30,17 @@ import type {
 import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
-    useTable,
-    type SortingRule,
-    useSortBy,
-    useFlexLayout,
-    type Column,
-} from 'react-table';
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { createLocalStorage } from 'utils/createLocalStorage';
-import { sortTypes } from 'utils/sortTypes';
 import { CreatePersonalAPIToken } from './CreatePersonalAPIToken/CreatePersonalAPIToken.tsx';
 import { DeletePersonalAPIToken } from './DeletePersonalAPIToken/DeletePersonalAPIToken.tsx';
 import { PersonalAPITokenDialog } from './PersonalAPITokenDialog/PersonalAPITokenDialog.tsx';
 import { TimeAgoCell } from 'component/common/Table/cells/TimeAgoCell/TimeAgoCell';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 
 const StyledAlert = styled(Alert)(({ theme }) => ({
     marginBottom: theme.spacing(3),
@@ -75,7 +74,7 @@ export type PageQueryType = Partial<
     Record<'sort' | 'order' | 'search', string>
 >;
 
-const defaultSort: SortingRule<string> = { id: 'createdAt', desc: true };
+const defaultSort = { id: 'createdAt', desc: true };
 
 const { value: storedParams, setValue: setStoredParams } = createLocalStorage(
     'PersonalAPITokensTable:v1',
@@ -91,7 +90,7 @@ export const PersonalAPITokensTab = () => {
     const [searchParams, setSearchParams] = useSearchParams();
 
     const [initialState] = useState(() => ({
-        sortBy: [
+        sorting: [
             {
                 id: searchParams.get('sort') || storedParams.id,
                 desc: searchParams.has('order')
@@ -109,68 +108,67 @@ export const PersonalAPITokensTab = () => {
     const [newToken, setNewToken] = useState<INewPersonalAPIToken>();
     const [selectedToken, setSelectedToken] = useState<IPersonalAPIToken>();
 
-    const columns = useMemo(
-        () =>
-            [
-                {
-                    Header: 'Description',
-                    accessor: 'description',
-                    Cell: HighlightCell,
-                    minWidth: 100,
-                    searchable: true,
+    const columns = useMemo<ColumnDef<IPersonalAPIToken, unknown>[]>(
+        () => [
+            {
+                id: 'description',
+                header: 'Description',
+                accessorKey: 'description',
+                cell: HighlightCell,
+                meta: { minWidth: 100, searchable: true },
+            },
+            {
+                id: 'expiresAt',
+                header: 'Expires',
+                accessorKey: 'expiresAt',
+                cell: ({ getValue }) => {
+                    const value = String(getValue() ?? '');
+                    const date = new Date(value);
+                    if (date.getFullYear() > new Date().getFullYear() + 100) {
+                        return <TextCell>Never</TextCell>;
+                    }
+                    return <DateCell value={value} />;
                 },
-                {
-                    Header: 'Expires',
-                    accessor: 'expiresAt',
-                    Cell: ({ value }: { value: string }) => {
-                        const date = new Date(value);
-                        if (
-                            date.getFullYear() >
-                            new Date().getFullYear() + 100
-                        ) {
-                            return <TextCell>Never</TextCell>;
-                        }
-                        return <DateCell value={value} />;
-                    },
-                    maxWidth: 150,
-                },
-                {
-                    Header: 'Created',
-                    accessor: 'createdAt',
-                    Cell: DateCell,
-                    maxWidth: 150,
-                },
-                {
-                    Header: 'Last seen',
-                    accessor: 'seenAt',
-                    Cell: TimeAgoCell,
-                    maxWidth: 150,
-                },
-                {
-                    Header: 'Actions',
-                    id: 'Actions',
-                    align: 'center',
-                    Cell: ({ row: { original: rowToken } }: any) => (
-                        <ActionCell>
-                            <Tooltip title='Delete token' arrow describeChild>
-                                <span>
-                                    <IconButton
-                                        onClick={() => {
-                                            setSelectedToken(rowToken);
-                                            setDeleteOpen(true);
-                                        }}
-                                    >
-                                        <Delete />
-                                    </IconButton>
-                                </span>
-                            </Tooltip>
-                        </ActionCell>
-                    ),
-                    maxWidth: 100,
-                    disableSortBy: true,
-                },
-            ] as Column<IPersonalAPIToken>[],
-        [setSelectedToken, setDeleteOpen],
+                meta: { maxWidth: 150 },
+            },
+            {
+                id: 'createdAt',
+                header: 'Created',
+                accessorKey: 'createdAt',
+                cell: DateCell,
+                meta: { maxWidth: 150 },
+            },
+            {
+                id: 'seenAt',
+                header: 'Last seen',
+                accessorKey: 'seenAt',
+                cell: TimeAgoCell,
+                meta: { maxWidth: 150 },
+            },
+            {
+                id: 'Actions',
+                header: 'Actions',
+                cell: ({ row: { original: rowToken } }) => (
+                    <ActionCell>
+                        <Tooltip title='Delete token' arrow describeChild>
+                            <span>
+                                <IconButton
+                                    onClick={() => {
+                                        setSelectedToken(rowToken);
+                                        setDeleteOpen(true);
+                                    }}
+                                >
+                                    <Delete />
+                                </IconButton>
+                            </span>
+                        </Tooltip>
+                    </ActionCell>
+                ),
+                enableSorting: false,
+                meta: { maxWidth: 100, align: 'center' },
+            },
+        ],
+        [],
     );
 
     const {
@@ -187,28 +185,18 @@ export const PersonalAPITokensTab = () => {
         [searchedData, loading],
     );
 
-    const {
-        headerGroups,
-        rows,
-        prepareRow,
-        state: { sortBy },
-        setHiddenColumns,
-    } = useTable<IPersonalAPIToken>(
-        {
-            columns,
-            data,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-        },
-        useSortBy,
-        useFlexLayout,
-    );
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isExtraSmallScreen,
@@ -219,14 +207,20 @@ export const PersonalAPITokensTab = () => {
                 columns: ['createdAt'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
 
+    const sorting = table.getState().sorting;
+
     useEffect(() => {
+        const sortRule = sorting[0];
+        if (!sortRule) {
+            return;
+        }
         const tableState: PageQueryType = {};
-        tableState.sort = sortBy[0].id;
-        if (sortBy[0].desc) {
+        tableState.sort = sortRule.id;
+        if (sortRule.desc) {
             tableState.order = 'desc';
         }
         if (searchValue) {
@@ -236,8 +230,10 @@ export const PersonalAPITokensTab = () => {
         setSearchParams(tableState, {
             replace: true,
         });
-        setStoredParams({ id: sortBy[0].id, desc: sortBy[0].desc || false });
-    }, [sortBy, searchValue, setSearchParams]);
+        setStoredParams({ id: sortRule.id, desc: sortRule.desc || false });
+    }, [sorting, searchValue, setSearchParams]);
+
+    const rows = table.getRowModel().rows;
 
     return (
         <PageContent
@@ -295,11 +291,7 @@ export const PersonalAPITokensTab = () => {
                 your user.
             </StyledAlert>
             <SearchHighlightProvider value={getSearchText(searchValue)}>
-                <VirtualizedTable
-                    rows={rows}
-                    headerGroups={headerGroups}
-                    prepareRow={prepareRow}
-                />
+                <VirtualizedTableV8 tableInstance={table} />
             </SearchHighlightProvider>
             <ConditionallyRender
                 condition={rows.length === 0}

--- a/frontend/src/types/react-table-v8.d.ts
+++ b/frontend/src/types/react-table-v8.d.ts
@@ -9,5 +9,6 @@ declare module '@tanstack/react-table' {
         minWidth?: number | string;
         maxWidth?: number | string;
         styles?: CSSProperties;
+        isDragHandle?: boolean;
     }
 }


### PR DESCRIPTION
## Summary

Third PR in the v7 → v8 stack. Builds on https://github.com/Unleash/unleash/pull/12070.

This PR is mechanical: each commit migrates one or two tables from v7 to
the v8 wrappers introduced in PRs 1–2. No shared infrastructure changes;
no v7 code removed. Per-commit review is friendly because each commit is
self-contained.

## What's in this PR

~14 tables across these areas:

- **Admin/roles**: `RolesTable`, `FeatureTypesList`, `LoginHistoryTable`
- **Feedback**: `FeedbackList`
- **Context/segments/tags**: `ContextList`, `SegmentTable`, `TagTypeList`
- **Variants & change requests**: `VariantInformation`,
  `ChangeRequestTable` (configuration), `UnknownFlagsTable`
- **Projects**: `FeaturesArchiveTable`, project-form `ChangeRequestTable`,
  `ProjectsListTable`
- **Environments & variants**: `EnvironmentVariantsTable`,
  `ProjectDoraMetrics`, `EnvironmentTable`, `EnvironmentRow`,
  `EnvironmentTableSingle`, `ProjectEnvironmentTableSingle`
- **Service accounts / tokens / actions**: `ServiceAccountsTable`,
  `ProjectActionsTable`, `ProjectGroupView`, `SignalEndpointsTokens`,
  `PersonalAPITokensTab`
- **Change requests / playground**: `ChangeRequestsTabs`,
  `AdvancedPlaygroundResultsTable`

## Stack

1. Foundation
2. Shared cells, `useSearch`, first batch of tables
3. **This PR** — leaf table migrations, batch 1
4. Leaf table migrations, batch 2 + API token tables
5. Remove the v7 dependency

## Review notes

- Best reviewed commit-by-commit; each commit handles one table area.
- Look for any drift from the patterns established in PRs 1–2 — every table
  here should be using the v8 wrappers (`SortableTableHeaderV8`,
  `VirtualizedTableV8`) and `useConditionallyHiddenColumnsV8` where
  applicable.
