### PR TITLE
refactor: phase 4 of react-table v7 -> v8 migration

### DIFF
--- a/frontend/src/component/admin/apiToken/ApiTokenPage/ApiTokenPage.tsx
+++ b/frontend/src/component/admin/apiToken/ApiTokenPage/ApiTokenPage.tsx
@@ -24,45 +24,42 @@ export const ApiTokenPage = () => {
     const { tokens, loading, refetch } = useApiTokens();
     const { deleteToken } = useApiTokensApi();
 
-    const {
-        headerGroups,
-        rows,
-        prepareRow,
-        state: { globalFilter },
-        setGlobalFilter,
-        setHiddenColumns,
-        columns,
-    } = useApiTokenTable(tokens, (props) => {
-        const READ_PERMISSION =
-            props.row.original.type === 'client'
-                ? READ_CLIENT_API_TOKEN
-                : props.row.original.type === 'frontend'
-                  ? READ_FRONTEND_API_TOKEN
-                  : ADMIN;
-        const DELETE_PERMISSION =
-            props.row.original.type === 'client'
-                ? DELETE_CLIENT_API_TOKEN
-                : props.row.original.type === 'frontend'
-                  ? DELETE_FRONTEND_API_TOKEN
-                  : ADMIN;
+    const { table, columns, globalFilter, setGlobalFilter } = useApiTokenTable(
+        tokens,
+        (props) => {
+            const READ_PERMISSION =
+                props.row.original.type === 'client'
+                    ? READ_CLIENT_API_TOKEN
+                    : props.row.original.type === 'frontend'
+                      ? READ_FRONTEND_API_TOKEN
+                      : ADMIN;
+            const DELETE_PERMISSION =
+                props.row.original.type === 'client'
+                    ? DELETE_CLIENT_API_TOKEN
+                    : props.row.original.type === 'frontend'
+                      ? DELETE_FRONTEND_API_TOKEN
+                      : ADMIN;
 
-        return (
-            <ActionCell>
-                <CopyApiTokenButton
-                    token={props.row.original}
-                    permission={READ_PERMISSION}
-                />
-                <RemoveApiTokenButton
-                    token={props.row.original}
-                    permission={DELETE_PERMISSION}
-                    onRemove={async () => {
-                        await deleteToken(props.row.original.secret);
-                        refetch();
-                    }}
-                />
-            </ActionCell>
-        );
-    });
+            return (
+                <ActionCell>
+                    <CopyApiTokenButton
+                        token={props.row.original}
+                        permission={READ_PERMISSION}
+                    />
+                    <RemoveApiTokenButton
+                        token={props.row.original}
+                        permission={DELETE_PERMISSION}
+                        onRemove={async () => {
+                            await deleteToken(props.row.original.secret);
+                            refetch();
+                        }}
+                    />
+                </ActionCell>
+            );
+        },
+    );
+
+    const rowCount = table.getRowModel().rows.length;
 
     return (
         <PermissionGuard
@@ -75,7 +72,7 @@ export const ApiTokenPage = () => {
             <PageContent
                 header={
                     <PageHeader
-                        title={`API access (${rows.length})`}
+                        title={`API access (${rowCount})`}
                         actions={
                             <>
                                 <Search
@@ -98,10 +95,7 @@ export const ApiTokenPage = () => {
             >
                 <ApiTokenTable
                     loading={loading}
-                    headerGroups={headerGroups}
-                    setHiddenColumns={setHiddenColumns}
-                    prepareRow={prepareRow}
-                    rows={rows}
+                    table={table}
                     columns={columns}
                     globalFilter={globalFilter}
                 />

--- a/frontend/src/component/admin/groups/Group/Group.tsx
+++ b/frontend/src/component/admin/groups/Group/Group.tsx
@@ -2,19 +2,19 @@ import { useEffect, useMemo, useState, type FC } from 'react';
 import { IconButton, Tooltip, useMediaQuery, useTheme } from '@mui/material';
 import { useSearchParams, Link } from 'react-router-dom';
 import {
-    type SortingRule,
-    useFlexLayout,
-    useSortBy,
-    useTable,
-} from 'react-table';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { useGroup } from 'hooks/api/getters/useGroup/useGroup';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
-import { sortTypes } from 'utils/sortTypes';
 import { createLocalStorage } from 'utils/createLocalStorage';
 import type { IGroupUser } from 'interfaces/group';
 import { useSearch } from 'hooks/useSearch';
@@ -53,7 +53,7 @@ export type PageQueryType = Partial<
     Record<'sort' | 'order' | 'search', string>
 >;
 
-const defaultSort: SortingRule<string> = { id: 'joinedAt', desc: true };
+const defaultSort = { id: 'joinedAt', desc: true };
 
 const { value: storedParams, setValue: setStoredParams } = createLocalStorage(
     'Group:v1',
@@ -75,57 +75,57 @@ export const Group: FC = () => {
     } = useScimSettings();
     const isScimGroup = scimEnabled && Boolean(group?.scimId);
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<IGroupUser, unknown>[]>(
         () => [
             {
-                Header: 'Avatar',
-                accessor: 'imageUrl',
-                Cell: ({ row: { original: user } }: any) => (
+                id: 'imageUrl',
+                header: 'Avatar',
+                accessorKey: 'imageUrl',
+                cell: ({ row: { original: user } }) => (
                     <TextCell>
                         <UserAvatar user={user} />
                     </TextCell>
                 ),
-                maxWidth: 85,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { maxWidth: 85 },
             },
             {
                 id: 'name',
-                Header: 'Name',
-                accessor: (row: IGroupUser) => row.name || '',
-                Cell: ({ value, row: { original: row } }: any) => (
+                header: 'Name',
+                accessorFn: (row) => row.name || '',
+                cell: ({ getValue, row: { original: row } }) => (
                     <HighlightCell
-                        value={value}
+                        value={String(getValue() ?? '')}
                         subtitle={row.email || row.username}
                     />
                 ),
-                minWidth: 100,
-                searchable: true,
+                meta: { minWidth: 100, searchable: true },
             },
             {
-                Header: 'Joined',
-                accessor: 'joinedAt',
-                Cell: DateCell,
-                maxWidth: 150,
+                id: 'joinedAt',
+                header: 'Joined',
+                accessorKey: 'joinedAt',
+                cell: DateCell,
+                meta: { maxWidth: 150 },
             },
             {
                 id: 'createdBy',
-                Header: 'Added by',
-                accessor: 'createdBy',
-                Cell: HighlightCell,
-                minWidth: 90,
-                searchable: true,
+                header: 'Added by',
+                accessorKey: 'createdBy',
+                cell: HighlightCell,
+                meta: { minWidth: 90, searchable: true },
             },
             {
-                Header: 'Last login',
-                accessor: 'seenAt',
-                Cell: TimeAgoCell,
-                maxWidth: 150,
+                id: 'seenAt',
+                header: 'Last login',
+                accessorKey: 'seenAt',
+                cell: TimeAgoCell,
+                meta: { maxWidth: 150 },
             },
             {
-                Header: 'Actions',
                 id: 'Actions',
-                align: 'center',
-                Cell: ({ row: { original: rowUser } }: any) => (
+                header: 'Actions',
+                cell: ({ row: { original: rowUser } }) => (
                     <ActionCell>
                         <Tooltip
                             title={
@@ -151,28 +151,29 @@ export const Group: FC = () => {
                         </Tooltip>
                     </ActionCell>
                 ),
-                maxWidth: 100,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { maxWidth: 100, align: 'center' },
             },
             // Always hidden -- for search
             {
-                accessor: (row: IGroupUser) => row.username || '',
-                Header: 'Username',
-                searchable: true,
+                id: 'username',
+                header: 'Username',
+                accessorFn: (row) => row.username || '',
+                meta: { searchable: true },
             },
-            // Always hidden -- for search
             {
-                accessor: (row: IGroupUser) => row.email || '',
-                Header: 'Email',
-                searchable: true,
+                id: 'email',
+                header: 'Email',
+                accessorFn: (row) => row.email || '',
+                meta: { searchable: true },
             },
         ],
-        [setSelectedUser, setRemoveUserOpen],
+        [isScimGroup],
     );
 
     const [searchParams, setSearchParams] = useSearchParams();
     const [initialState] = useState(() => ({
-        sortBy: [
+        sorting: [
             {
                 id: searchParams.get('sort') || storedParams.id,
                 desc: searchParams.has('order')
@@ -180,7 +181,7 @@ export const Group: FC = () => {
                     : storedParams.desc,
             },
         ],
-        hiddenColumns: ['Username', 'Email'],
+        columnVisibility: { username: false, email: false },
         globalFilter: searchParams.get('search') || '',
     }));
     const [searchValue, setSearchValue] = useState(initialState.globalFilter);
@@ -199,29 +200,28 @@ export const Group: FC = () => {
         [searchedData, loading],
     );
 
-    const {
-        headerGroups,
-        rows,
-        prepareRow,
-        state: { sortBy },
-    } = useTable(
-        {
-            columns: columns as any[],
-            data,
-            initialState,
-            sortTypes,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-        },
-        useSortBy,
-        useFlexLayout,
-    );
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
+
+    const sorting = table.getState().sorting;
+    const rows = table.getRowModel().rows;
 
     useEffect(() => {
+        const sortRule = sorting[0];
+        if (!sortRule) {
+            return;
+        }
         const tableState: PageQueryType = {};
-        tableState.sort = sortBy[0].id;
-        if (sortBy[0].desc) {
+        tableState.sort = sortRule.id;
+        if (sortRule.desc) {
             tableState.order = 'desc';
         }
         if (searchValue) {
@@ -231,8 +231,8 @@ export const Group: FC = () => {
         setSearchParams(tableState, {
             replace: true,
         });
-        setStoredParams({ id: sortBy[0].id, desc: sortBy[0].desc || false });
-    }, [sortBy, searchValue, setSearchParams]);
+        setStoredParams({ id: sortRule.id, desc: sortRule.desc || false });
+    }, [sorting, searchValue, setSearchParams]);
 
     return (
         <ConditionallyRender
@@ -342,11 +342,7 @@ export const Group: FC = () => {
                         <SearchHighlightProvider
                             value={getSearchText(searchValue)}
                         >
-                            <VirtualizedTable
-                                rows={rows}
-                                headerGroups={headerGroups}
-                                prepareRow={prepareRow}
-                            />
+                            <VirtualizedTableV8 tableInstance={table} />
                         </SearchHighlightProvider>
                         <ConditionallyRender
                             condition={rows.length === 0}

--- a/frontend/src/component/admin/users/UsersList/UsersList.tsx
+++ b/frontend/src/component/admin/users/UsersList/UsersList.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import ChangePassword from './ChangePassword/ChangePassword.tsx';
 import ResetPassword from './ResetPassword/ResetPassword.tsx';
 import DeleteUser from './DeleteUser/DeleteUser.tsx';
@@ -18,8 +19,13 @@ import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { Button, IconButton, Tooltip, useMediaQuery } from '@mui/material';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { UserTypeCell } from './UserTypeCell/UserTypeCell.tsx';
-import { useFlexLayout, useSortBy, useTable } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { sortingFns } from 'utils/sortingFns';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { Link, useNavigate } from 'react-router-dom';
@@ -29,7 +35,7 @@ import { TimeAgoCell } from 'component/common/Table/cells/TimeAgoCell/TimeAgoCel
 import { UsersActionsCell } from './UsersActionsCell/UsersActionsCell.tsx';
 import { Search } from 'component/common/Search/Search';
 import { UserAvatar } from 'component/common/UserAvatar/UserAvatar';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { UserLimitWarning } from './UserLimitWarning/UserLimitWarning.tsx';
 import { RoleCell } from 'component/common/Table/cells/RoleCell/RoleCell';
 import { useSearch } from 'hooks/useSearch';
@@ -121,95 +127,90 @@ const UsersList = () => {
         setInviteLink('');
     };
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<IUser, unknown>[]>(
         () => [
             {
-                Header: 'Avatar',
-                accessor: 'imageUrl',
-                Cell: ({ row: { original: user } }: any) => (
+                id: 'imageUrl',
+                header: 'Avatar',
+                accessorKey: 'imageUrl',
+                cell: ({ row: { original: user } }) => (
                     <TextCell>
                         <UserAvatar user={user} />
                     </TextCell>
                 ),
-                disableSortBy: true,
-                maxWidth: 80,
+                enableSorting: false,
+                meta: { maxWidth: 80 },
             },
             {
                 id: 'name',
-                Header: 'Name',
-                accessor: (row: any) => row.name || '',
-                minWidth: 180,
-                Cell: ({ row: { original: user } }: any) => (
+                header: 'Name',
+                accessorFn: (row) => row.name || '',
+                cell: ({ row: { original: user } }) => (
                     <HighlightCell
-                        value={user.name}
+                        value={user.name ?? ''}
                         subtitle={user.email || user.username}
                     />
                 ),
-                searchable: true,
+                meta: { minWidth: 180, searchable: true },
             },
             ...(showUserDeviceCount
                 ? [
                       {
                           id: 'warning',
-                          Header: ' ',
-                          accessor: (row: any) => row.name || '',
-                          maxWidth: 40,
-                          Cell: ({ row: { original: user } }: any) => (
+                          header: ' ',
+                          accessorFn: (row: IUser) => row.name || '',
+                          cell: ({ row: { original: user } }) => (
                               <UserSessionsCell count={user.activeSessions} />
                           ),
-                          searchable: false,
-                          disableSortBy: true,
-                      },
+                          enableSorting: false,
+                          meta: { maxWidth: 40 },
+                      } satisfies ColumnDef<IUser, unknown>,
                   ]
                 : []),
             {
                 id: 'role',
-                Header: 'Role',
-                accessor: (row: any) =>
+                header: 'Role',
+                accessorFn: (row) =>
                     roles.find((role: IRole) => role.id === row.rootRole)
                         ?.name || '',
-                Cell: ({
-                    row: { original: user },
-                    value,
-                }: {
-                    row: { original: IUser };
-                    value: string;
-                }) => <RoleCell value={value} role={user.rootRole} />,
-                maxWidth: 120,
+                cell: ({ getValue, row: { original: user } }) => (
+                    <RoleCell
+                        value={String(getValue() ?? '')}
+                        role={user.rootRole}
+                    />
+                ),
+                meta: { maxWidth: 120 },
             },
             {
-                Header: 'Created',
-                accessor: 'createdAt',
-                Cell: DateCell,
-                width: 120,
-                maxWidth: 120,
+                id: 'createdAt',
+                header: 'Created',
+                accessorKey: 'createdAt',
+                cell: DateCell,
+                meta: { width: 120, maxWidth: 120 },
             },
             {
                 id: 'last-login',
-                Header: 'Last login',
-                accessor: 'seenAt',
-                Cell: TimeAgoCell,
-                maxWidth: 150,
+                header: 'Last login',
+                accessorKey: 'seenAt',
+                cell: TimeAgoCell,
+                meta: { maxWidth: 150 },
             },
             {
                 id: 'type',
-                Header: 'Type',
-                accessor: 'paid',
-                maxWidth: 100,
-                Cell: ({ row: { original: user } }: any) => (
-                    <UserTypeCell value={isBillingUsers && user.paid} />
+                header: 'Type',
+                accessorKey: 'paid',
+                cell: ({ row: { original: user } }) => (
+                    <UserTypeCell
+                        value={Boolean(isBillingUsers && user.paid)}
+                    />
                 ),
-                sortType: 'boolean',
+                sortingFn: sortingFns.boolean,
+                meta: { maxWidth: 100 },
             },
             {
-                Header: '',
                 id: 'Actions',
-                align: 'center',
-                Cell: ({
-                    row: { original: user },
-                }: {
-                    row: { original: IUser };
-                }) => (
+                header: '',
+                cell: ({ row: { original: user } }) => (
                     <UsersActionsCell
                         onEdit={() => {
                             navigate(`/admin/users/${user.id}/edit`);
@@ -224,33 +225,38 @@ const UsersList = () => {
                         userId={user.id}
                     />
                 ),
-                width: 80,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { width: 80, align: 'center' },
             },
             // Always hidden -- for search
             {
-                accessor: 'username',
-                Header: 'Username',
-                searchable: true,
+                id: 'username',
+                header: 'Username',
+                accessorKey: 'username',
+                meta: { searchable: true },
             },
-            // Always hidden -- for search
             {
-                accessor: 'email',
-                Header: 'Email',
-                searchable: true,
+                id: 'email',
+                header: 'Email',
+                accessorKey: 'email',
+                meta: { searchable: true },
             },
         ],
-        [roles, navigate, isBillingUsers],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [roles, navigate, isBillingUsers, showUserDeviceCount, scimEnabled],
     );
 
     const initialState = useMemo(() => {
+        const hidden: Record<string, boolean> = {
+            username: false,
+            email: false,
+        };
+        if (!isBillingUsers) {
+            hidden.type = false;
+        }
         return {
-            sortBy: [{ id: 'createdAt', desc: true }],
-            hiddenColumns: [
-                'username',
-                'email',
-                ...(isBillingUsers ? [] : ['type']),
-            ],
+            sorting: [{ id: 'createdAt', desc: true }],
+            columnVisibility: hidden,
         };
     }, [isBillingUsers]);
 
@@ -260,25 +266,23 @@ const UsersList = () => {
         isBillingUsers ? planUsers : users,
     );
 
-    const { headerGroups, rows, prepareRow, setHiddenColumns } = useTable(
-        {
-            columns: columns as any,
-            data,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-            defaultColumn: {
-                Cell: TextCell,
-            },
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
         },
-        useSortBy,
-        useFlexLayout,
-    );
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: !isBillingUsers || isSmallScreen,
@@ -293,16 +297,18 @@ const UsersList = () => {
                 columns: ['createdAt', 'last-login', 'warning'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
+
+    const rowCount = table.getRowModel().rows.length;
 
     return (
         <PageContent
             isLoading={loading}
             header={
                 <PageHeader
-                    title={`Users (${rows.length})`}
+                    title={`Users (${rowCount})`}
                     actions={
                         <>
                             <Search
@@ -345,15 +351,11 @@ const UsersList = () => {
             <UsersHeader />
             <AccessRequestsTable />
             <SearchHighlightProvider value={getSearchText(searchValue)}>
-                <VirtualizedTable
-                    rows={rows}
-                    headerGroups={headerGroups}
-                    prepareRow={prepareRow}
-                />
+                <VirtualizedTableV8 tableInstance={table} />
             </SearchHighlightProvider>
 
             <ConditionallyRender
-                condition={rows.length === 0}
+                condition={rowCount === 0}
                 show={
                     <ConditionallyRender
                         condition={searchValue?.length > 0}

--- a/frontend/src/component/application/ConnectedInstances/ConnectedInstances.tsx
+++ b/frontend/src/component/application/ConnectedInstances/ConnectedInstances.tsx
@@ -82,8 +82,7 @@ export const ConnectedInstances: FC = () => {
         return connectedInstances.instances.map(map);
     }, [JSON.stringify(connectedInstances), currentEnvironment]);
 
-    const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-        useConnectedInstancesTable(tableData);
+    const { table } = useConnectedInstancesTable(tableData);
 
     return (
         <Box>
@@ -118,14 +117,7 @@ export const ConnectedInstances: FC = () => {
                     }
                 />
             </Box>
-            <ConnectedInstancesTable
-                loading={loading}
-                headerGroups={headerGroups}
-                prepareRow={prepareRow}
-                getTableBodyProps={getTableBodyProps}
-                getTableProps={getTableProps}
-                rows={rows}
-            />
+            <ConnectedInstancesTable loading={loading} table={table} />
         </Box>
     );
 };

--- a/frontend/src/component/application/ConnectedInstances/ConnectedInstancesTable.tsx
+++ b/frontend/src/component/application/ConnectedInstances/ConnectedInstancesTable.tsx
@@ -1,62 +1,37 @@
-import type {
-    Row,
-    TablePropGetter,
-    TableProps,
-    TableBodyPropGetter,
-    TableBodyProps,
-    HeaderGroup,
-} from 'react-table';
-import {
-    SortableTableHeader,
-    TableCell,
-    TablePlaceholder,
-} from 'component/common/Table';
+import { type Table as TableType, flexRender } from '@tanstack/react-table';
+import { TableCell, TablePlaceholder } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
 import { Box, Table, TableBody, TableRow } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
-type ConnectedInstancesTableProps = {
+type ConnectedInstancesTableProps<T> = {
     loading: boolean;
-    rows: Row<object>[];
-    prepareRow: (row: Row<object>) => void;
-    getTableProps: (
-        propGetter?: TablePropGetter<object> | undefined,
-    ) => TableProps;
-    getTableBodyProps: (
-        propGetter?: TableBodyPropGetter<object> | undefined,
-    ) => TableBodyProps;
-    headerGroups: HeaderGroup<object>[];
+    table: TableType<T>;
 };
-export const ConnectedInstancesTable = ({
+
+export const ConnectedInstancesTable = <T,>({
     loading,
-    rows,
-    getTableProps,
-    getTableBodyProps,
-    headerGroups,
-    prepareRow,
-}: ConnectedInstancesTableProps) => {
+    table,
+}: ConnectedInstancesTableProps<T>) => {
+    const rows = table.getRowModel().rows;
     return (
         <>
             <Box sx={{ overflowX: 'auto' }}>
-                <Table {...getTableProps()}>
-                    <SortableTableHeader headerGroups={headerGroups as any} />
-                    <TableBody {...getTableBodyProps()}>
-                        {rows.map((row) => {
-                            prepareRow(row);
-                            const { key, ...rowProps } = row.getRowProps();
-                            return (
-                                <TableRow hover key={key} {...rowProps}>
-                                    {row.cells.map((cell) => {
-                                        const { key, ...cellProps } =
-                                            cell.getCellProps();
-                                        return (
-                                            <TableCell key={key} {...cellProps}>
-                                                {cell.render('Cell')}
-                                            </TableCell>
-                                        );
-                                    })}
-                                </TableRow>
-                            );
-                        })}
+                <Table>
+                    <SortableTableHeaderV8 tableInstance={table} />
+                    <TableBody>
+                        {rows.map((row) => (
+                            <TableRow hover key={row.id}>
+                                {row.getVisibleCells().map((cell) => (
+                                    <TableCell key={cell.id}>
+                                        {flexRender(
+                                            cell.column.columnDef.cell,
+                                            cell.getContext(),
+                                        )}
+                                    </TableCell>
+                                ))}
+                            </TableRow>
+                        ))}
                     </TableBody>
                 </Table>
             </Box>

--- a/frontend/src/component/application/ConnectedInstances/useConnectedInstancesTable.tsx
+++ b/frontend/src/component/application/ConnectedInstances/useConnectedInstancesTable.tsx
@@ -1,7 +1,11 @@
 import { useMemo } from 'react';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
-import { useTable, useGlobalFilter, useSortBy } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { TimeAgoCell } from 'component/common/Table/cells/TimeAgoCell/TimeAgoCell';
 
 type ConnectedInstancesTableData = {
@@ -15,78 +19,53 @@ export const useConnectedInstancesTable = (
     instanceData: ConnectedInstancesTableData[],
 ) => {
     const initialState = useMemo(
-        () => ({ sortBy: [{ id: 'lastSeen', desc: true }] }),
+        () => ({ sorting: [{ id: 'lastSeen', desc: true }] }),
         [],
     );
 
-    const COLUMNS = useMemo(() => {
-        return [
+    const columns = useMemo<ColumnDef<ConnectedInstancesTableData, unknown>[]>(
+        () => [
             {
-                Header: 'Instances',
-                accessor: 'instanceId',
-                Cell: HighlightCell,
-                styles: {
-                    width: '45%',
-                },
+                id: 'instanceId',
+                header: 'Instances',
+                accessorKey: 'instanceId',
+                cell: HighlightCell,
+                meta: { styles: { width: '45%' } },
             },
             {
-                Header: 'SDK',
-                accessor: 'sdkVersion',
-                Cell: HighlightCell,
-                styles: {
-                    width: '20%',
-                },
+                id: 'sdkVersion',
+                header: 'SDK',
+                accessorKey: 'sdkVersion',
+                cell: HighlightCell,
+                meta: { styles: { width: '20%' } },
             },
             {
-                Header: 'Last seen',
-                accessor: 'lastSeen',
-                Cell: TimeAgoCell,
-                styles: {
-                    width: '20%',
-                },
+                id: 'lastSeen',
+                header: 'Last seen',
+                accessorKey: 'lastSeen',
+                cell: TimeAgoCell,
+                meta: { styles: { width: '20%' } },
             },
             {
-                Header: 'IP',
-                accessor: 'ip',
-                Cell: HighlightCell,
-                styles: {
-                    width: '15%',
-                },
+                id: 'ip',
+                header: 'IP',
+                accessorKey: 'ip',
+                cell: HighlightCell,
+                meta: { styles: { width: '15%' } },
             },
-        ];
-    }, []);
-
-    const {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
-        state,
-        setGlobalFilter,
-        setHiddenColumns,
-    } = useTable(
-        {
-            columns: COLUMNS as any,
-            data: instanceData as any,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            disableSortRemove: true,
-        },
-        useGlobalFilter,
-        useSortBy,
+        ],
+        [],
     );
 
-    return {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
-        state,
-        setGlobalFilter,
-        setHiddenColumns,
-        columns: COLUMNS,
-    };
+    const table = useReactTable({
+        columns,
+        data: instanceData,
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
+
+    return { table, columns };
 };

--- a/frontend/src/component/archive/ArchiveTable/ArchiveTable.tsx
+++ b/frontend/src/component/archive/ArchiveTable/ArchiveTable.tsx
@@ -1,16 +1,15 @@
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import {
-    type SortingRule,
-    useFlexLayout,
-    useRowSelect,
-    useSortBy,
-    useTable,
-} from 'react-table';
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { Alert, useMediaQuery } from '@mui/material';
-import { sortTypes } from 'utils/sortTypes';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
@@ -27,21 +26,21 @@ import { FeatureArchivedCell } from 'component/archive/ArchiveTable/FeatureArchi
 import { useSearchParams } from 'react-router-dom';
 import { ArchivedFeatureDeleteConfirm } from 'component/archive/ArchiveTable/ArchivedFeatureActionCell/ArchivedFeatureDeleteConfirm/ArchivedFeatureDeleteConfirm';
 import type { IFeatureToggle } from 'interfaces/featureToggle';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { FeatureEnvironmentSeenCell } from 'component/common/Table/cells/FeatureSeenCell/FeatureEnvironmentSeenCell';
 import { ArchivedFeatureReviveConfirm } from 'component/archive/ArchiveTable/ArchivedFeatureActionCell/ArchivedFeatureReviveConfirm/ArchivedFeatureReviveConfirm';
+
+type SortDescriptor = { id: string; desc?: boolean };
 
 export interface IFeaturesArchiveTableProps {
     archivedFeatures: FeatureSearchResponseSchema[];
     title: string;
     refetch: () => void;
     loading: boolean;
-    storedParams: SortingRule<string>;
+    storedParams: SortDescriptor;
     setStoredParams: (
-        newValue:
-            | SortingRule<string>
-            | ((prev: SortingRule<string>) => SortingRule<string>),
-    ) => SortingRule<string>;
+        newValue: SortDescriptor | ((prev: SortDescriptor) => SortDescriptor),
+    ) => SortDescriptor;
 }
 
 export const ArchiveTable = ({
@@ -66,86 +65,99 @@ export const ArchiveTable = ({
         searchParams.get('search') || '',
     );
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<FeatureSearchResponseSchema, unknown>[]>(
         () => [
             {
-                Header: 'Seen',
-                accessor: 'lastSeenAt',
-                Cell: ({ row: { original: feature } }: any) => {
-                    return <FeatureEnvironmentSeenCell feature={feature} />;
-                },
-                align: 'center',
-                maxWidth: 80,
+                id: 'lastSeenAt',
+                header: 'Seen',
+                accessorKey: 'lastSeenAt',
+                cell: ({ row: { original: feature } }) => (
+                    <FeatureEnvironmentSeenCell feature={feature} />
+                ),
+                meta: { align: 'center', maxWidth: 80 },
             },
             {
-                Header: 'Type',
-                accessor: 'type',
-                width: 85,
-                canSort: true,
-                Cell: FeatureTypeCell,
-                align: 'center',
+                id: 'type',
+                header: 'Type',
+                accessorKey: 'type',
+                cell: ({ getValue }) => (
+                    <FeatureTypeCell value={getValue() as string} />
+                ),
+                meta: { width: 85, align: 'center' },
             },
             {
-                Header: 'Name',
-                accessor: 'name',
-                searchable: true,
-                minWidth: 100,
-                Cell: ({ value, row: { original } }: any) => (
+                id: 'name',
+                header: 'Name',
+                accessorKey: 'name',
+                cell: ({ getValue, row: { original } }) => (
                     <HighlightCell
-                        value={value}
-                        subtitle={original.description}
+                        value={String(getValue() ?? '')}
+                        subtitle={original.description ?? undefined}
                     />
                 ),
-                sortType: 'alphanumeric',
+                sortingFn: 'alphanumeric',
+                meta: { searchable: true, minWidth: 100 },
             },
             {
-                Header: 'Created',
-                accessor: 'createdAt',
-                width: 150,
-                Cell: DateCell,
+                id: 'createdAt',
+                header: 'Created',
+                accessorKey: 'createdAt',
+                cell: DateCell,
+                meta: { width: 150 },
             },
             {
-                Header: 'Archived',
-                accessor: 'archivedAt',
-                width: 150,
-                Cell: FeatureArchivedCell,
-            },
-            {
-                Header: 'Project ID',
-                accessor: 'project',
-                sortType: 'alphanumeric',
-                filterName: 'project',
-                searchable: true,
-                maxWidth: 170,
-                Cell: ({ value }: any) => (
-                    <LinkCell title={value} to={`/projects/${value}`} />
+                id: 'archivedAt',
+                header: 'Archived',
+                accessorKey: 'archivedAt',
+                cell: ({ getValue }) => (
+                    <FeatureArchivedCell value={getValue() as string} />
                 ),
+                meta: { width: 150 },
             },
             {
-                Header: 'Actions',
+                id: 'project',
+                header: 'Project ID',
+                accessorKey: 'project',
+                sortingFn: 'alphanumeric',
+                cell: ({ getValue }) => {
+                    const value = String(getValue() ?? '');
+                    return <LinkCell title={value} to={`/projects/${value}`} />;
+                },
+                meta: {
+                    filterName: 'project',
+                    searchable: true,
+                    maxWidth: 170,
+                },
+            },
+            {
                 id: 'Actions',
-                align: 'center',
-                maxWidth: 120,
-                canSort: false,
-                Cell: ({ row: { original: feature } }: any) => (
+                header: 'Actions',
+                cell: ({ row: { original: feature } }) => (
                     <ArchivedFeatureActionCell
                         project={feature.project}
                         onRevive={() => {
-                            setRevivedFeature(feature);
+                            setRevivedFeature(
+                                feature as unknown as IFeatureToggle,
+                            );
                             setReviveModalOpen(true);
                         }}
                         onDelete={() => {
-                            setDeletedFeature(feature);
+                            setDeletedFeature(
+                                feature as unknown as IFeatureToggle,
+                            );
                             setDeleteModalOpen(true);
                         }}
                     />
                 ),
+                enableSorting: false,
+                meta: { align: 'center', maxWidth: 120 },
             },
             // Always hidden -- for search
             {
-                accessor: 'description',
+                id: 'description',
                 header: 'Description',
-                searchable: true,
+                accessorKey: 'description',
+                meta: { searchable: true },
             },
         ],
         [],
@@ -163,44 +175,34 @@ export const ArchiveTable = ({
     );
 
     const [initialState] = useState(() => ({
-        sortBy: [
+        sorting: [
             {
                 id: searchParams.get('sort') || storedParams.id,
                 desc: searchParams.has('order')
                     ? searchParams.get('order') === 'desc'
-                    : storedParams.desc,
+                    : Boolean(storedParams.desc),
             },
         ],
-        hiddenColumns: ['description'],
-        selectedRowIds: {},
+        columnVisibility: { description: false },
     }));
 
-    const getRowId = useCallback((row: any) => row.name, []);
-
-    const {
-        headerGroups,
-        rows,
-        state: { sortBy },
-        prepareRow,
-        setHiddenColumns,
-    } = useTable(
-        {
-            columns: columns as any[], // TODO: fix after `react-table` v8 update
-            data,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSelectedRows: false,
-            disableSortRemove: true,
-            autoResetSortBy: false,
-            getRowId,
-        },
-        useFlexLayout,
-        useSortBy,
-        useRowSelect,
+    const getRowId = useCallback(
+        (row: FeatureSearchResponseSchema) => row.name,
+        [],
     );
 
-    useConditionallyHiddenColumns(
+    const table = useReactTable({
+        columns,
+        data: data as FeatureSearchResponseSchema[],
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getRowId,
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
+
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isSmallScreen,
@@ -211,17 +213,24 @@ export const ArchiveTable = ({
                 columns: ['lastSeenAt', 'stale'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
+
+    const sorting = table.getState().sorting;
+    const rows = table.getRowModel().rows;
 
     useEffect(() => {
         if (loading) {
             return;
         }
+        const sortRule = sorting[0];
+        if (!sortRule) {
+            return;
+        }
         const tableState: Record<string, string> = {};
-        tableState.sort = sortBy[0].id;
-        if (sortBy[0].desc) {
+        tableState.sort = sortRule.id;
+        if (sortRule.desc) {
             tableState.order = 'desc';
         }
         if (searchValue) {
@@ -231,8 +240,9 @@ export const ArchiveTable = ({
         setSearchParams(tableState, {
             replace: true,
         });
-        setStoredParams({ id: sortBy[0].id, desc: sortBy[0].desc || false });
-    }, [loading, sortBy, searchValue]);
+        setStoredParams({ id: sortRule.id, desc: sortRule.desc || false });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [loading, sorting, searchValue]);
 
     return (
         <>
@@ -259,11 +269,7 @@ export const ArchiveTable = ({
                     </Alert>
                 )}
                 <SearchHighlightProvider value={getSearchText(searchValue)}>
-                    <VirtualizedTable
-                        rows={rows}
-                        headerGroups={headerGroups}
-                        prepareRow={prepareRow}
-                    />
+                    <VirtualizedTableV8 tableInstance={table} />
                 </SearchHighlightProvider>
                 <ConditionallyRender
                     condition={rows.length === 0}

--- a/frontend/src/component/common/ApiTokenTable/ApiTokenTable.tsx
+++ b/frontend/src/component/common/ApiTokenTable/ApiTokenTable.tsx
@@ -1,5 +1,6 @@
-import type { Row, HeaderGroup } from 'react-table';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import type { Table as TableType, ColumnDef } from '@tanstack/react-table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { Box, useMediaQuery, Link, styled, Typography } from '@mui/material';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { ApiTokenDocs } from 'component/admin/apiToken/ApiTokenDocs/ApiTokenDocs';
@@ -7,8 +8,9 @@ import { ApiTokenDocs } from 'component/admin/apiToken/ApiTokenDocs/ApiTokenDocs
 import theme from 'themes/theme';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { ApiUrls } from 'component/admin/apiToken/ApiUrls/ApiUrls';
+import type { IApiToken } from 'hooks/api/getters/useApiTokens/useApiTokens';
 
 const hiddenColumnsNotExtraLarge = ['Icon', 'createdAt', 'seenAt'];
 const hiddenColumnsCompact = ['Icon', 'project', 'seenAt'];
@@ -16,12 +18,9 @@ const hiddenColumnsCompact = ['Icon', 'project', 'seenAt'];
 interface IApiTokenTableProps {
     compact?: boolean;
     loading: boolean;
-    setHiddenColumns: (param: any) => void;
-    columns: any[];
-    rows: Row<object>[];
-    prepareRow: (row: Row<object>) => void;
-    headerGroups: HeaderGroup<object>[];
-    globalFilter: any;
+    table: TableType<IApiToken>;
+    columns: ColumnDef<IApiToken, unknown>[];
+    globalFilter: string;
 }
 
 const StyledTitle = styled(Typography)(({ theme }) => ({
@@ -33,17 +32,14 @@ const StyledTitle = styled(Typography)(({ theme }) => ({
 
 export const ApiTokenTable = ({
     compact = false,
-    setHiddenColumns,
+    table,
     columns,
     loading,
-    rows,
-    headerGroups,
     globalFilter,
-    prepareRow,
 }: IApiTokenTableProps) => {
     const isNotExtraLarge = useMediaQuery(theme.breakpoints.down('xl'));
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isNotExtraLarge,
@@ -54,14 +50,16 @@ export const ApiTokenTable = ({
                 columns: hiddenColumnsCompact,
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
+
+    const rowCount = table.getRowModel().rows.length;
 
     return (
         <>
             <ConditionallyRender
-                condition={rows.length > 0}
+                condition={rowCount > 0}
                 show={
                     <Box sx={{ mb: 4 }}>
                         <ApiTokenDocs />
@@ -75,15 +73,11 @@ export const ApiTokenTable = ({
             <Box sx={{ overflowX: 'auto' }}>
                 <StyledTitle variant='h2'>API Tokens</StyledTitle>
                 <SearchHighlightProvider value={globalFilter}>
-                    <VirtualizedTable
-                        rows={rows}
-                        headerGroups={headerGroups}
-                        prepareRow={prepareRow}
-                    />
+                    <VirtualizedTableV8 tableInstance={table} />
                 </SearchHighlightProvider>
             </Box>
             <ConditionallyRender
-                condition={rows.length === 0 && !loading}
+                condition={rowCount === 0 && !loading}
                 show={
                     <ConditionallyRender
                         condition={globalFilter?.length > 0}

--- a/frontend/src/component/common/ApiTokenTable/useApiTokenTable.tsx
+++ b/frontend/src/component/common/ApiTokenTable/useApiTokenTable.tsx
@@ -1,141 +1,140 @@
-import { useMemo, type JSX } from 'react';
+import { useMemo, useState, type JSX } from 'react';
 import type { IApiToken } from 'hooks/api/getters/useApiTokens/useApiTokens';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import { HighlightCell } from 'component/common/Table/cells/HighlightCell/HighlightCell';
 import { TimeAgoCell } from 'component/common/Table/cells/TimeAgoCell/TimeAgoCell';
 import {
-    useTable,
-    useGlobalFilter,
-    useSortBy,
-    useFlexLayout,
-} from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+    type CellContext,
+    type ColumnDef,
+    getCoreRowModel,
+    getFilteredRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
 import { ProjectsList } from 'component/admin/apiToken/ProjectsList/ProjectsList';
 import { ApiTokenIcon } from 'component/admin/apiToken/ApiTokenIcon/ApiTokenIcon';
 
+type ActionCellProps = {
+    row: { original: IApiToken };
+};
+
 export const useApiTokenTable = (
     tokens: IApiToken[],
-    getActionCell: (props: any) => JSX.Element,
+    getActionCell: (props: ActionCellProps) => JSX.Element,
 ) => {
+    const [globalFilter, setGlobalFilter] = useState('');
+
     const initialState = useMemo(
-        () => ({ sortBy: [{ id: 'createdAt', desc: true }] }),
+        () => ({ sorting: [{ id: 'createdAt', desc: true }] }),
         [],
     );
 
-    // biome-ignore lint/correctness/useExhaustiveDependencies: getActionCell is intentionally omitted — callers pass inline functions; including it would defeat memoization
-    const COLUMNS = useMemo(() => {
-        return [
+    // biome-ignore lint/correctness/useExhaustiveDependencies: getActionCell is intentionally omitted -- callers pass inline functions; including it would defeat memoization
+    const columns = useMemo<ColumnDef<IApiToken, unknown>[]>(
+        () => [
             {
                 id: 'Icon',
-                Cell: (props: any) => (
+                cell: ({ row }) => (
                     <ApiTokenIcon
-                        secret={props.row.original.secret}
-                        project={props.row.original.project}
-                        projects={props.row.original.projects}
+                        secret={row.original.secret}
+                        project={row.original.project}
+                        projects={row.original.projects}
                     />
                 ),
-                disableSortBy: true,
-                disableGlobalFilter: true,
-                width: 50,
+                enableSorting: false,
+                enableGlobalFilter: false,
+                meta: { width: 50 },
             },
             {
-                Header: 'Token name',
-                accessor: 'tokenName',
-                Cell: HighlightCell,
-                minWidth: 35,
+                id: 'tokenName',
+                header: 'Token name',
+                accessorKey: 'tokenName',
+                cell: HighlightCell,
+                meta: { minWidth: 35 },
             },
             {
-                Header: 'Type',
-                accessor: 'type',
-                Cell: ({
-                    value,
-                }: {
-                    value: 'client' | 'backend' | 'admin' | 'frontend';
-                }) => (
-                    <HighlightCell
-                        value={tokenDescriptions[value.toLowerCase()].label}
-                        subtitle={tokenDescriptions[value.toLowerCase()].title}
-                        subtitleTooltip
-                    />
-                ),
-                width: 180,
+                id: 'type',
+                header: 'Type',
+                accessorKey: 'type',
+                cell: ({ getValue }) => {
+                    const value = String(getValue() ?? '').toLowerCase();
+                    const description = tokenDescriptions[value];
+                    return (
+                        <HighlightCell
+                            value={description?.label ?? ''}
+                            subtitle={description?.title}
+                            subtitleTooltip
+                        />
+                    );
+                },
+                meta: { width: 180 },
             },
             {
-                Header: 'Project',
-                accessor: 'project',
-                Cell: (props: any) => (
+                id: 'project',
+                header: 'Project',
+                accessorKey: 'project',
+                cell: ({ row }) => (
                     <ProjectsList
-                        project={props.row.original.project}
-                        projects={props.row.original.projects}
+                        project={row.original.project}
+                        projects={row.original.projects}
                     />
                 ),
-                width: 160,
+                meta: { width: 160 },
             },
             {
-                Header: 'Environment',
-                accessor: 'environment',
-                Cell: HighlightCell,
-                width: 120,
+                id: 'environment',
+                header: 'Environment',
+                accessorKey: 'environment',
+                cell: HighlightCell,
+                meta: { width: 120 },
             },
             {
-                Header: 'Created',
-                accessor: 'createdAt',
-                Cell: DateCell,
-                width: 150,
-                disableGlobalFilter: true,
+                id: 'createdAt',
+                header: 'Created',
+                accessorKey: 'createdAt',
+                cell: DateCell,
+                enableGlobalFilter: false,
+                meta: { width: 150 },
             },
             {
-                Header: 'Last seen',
-                accessor: 'seenAt',
-                Cell: TimeAgoCell,
-                width: 140,
-                disableGlobalFilter: true,
+                id: 'seenAt',
+                header: 'Last seen',
+                accessorKey: 'seenAt',
+                cell: TimeAgoCell,
+                enableGlobalFilter: false,
+                meta: { width: 140 },
             },
             {
-                Header: 'Actions',
-                width: 120,
                 id: 'Actions',
-                align: 'center',
-                disableSortBy: true,
-                disableGlobalFilter: true,
-                Cell: getActionCell,
+                header: 'Actions',
+                cell: (info: CellContext<IApiToken, unknown>) =>
+                    getActionCell({ row: info.row }),
+                enableSorting: false,
+                enableGlobalFilter: false,
+                meta: { width: 120, align: 'center' },
             },
-        ];
-    }, []);
-
-    const {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
-        state,
-        setGlobalFilter,
-        setHiddenColumns,
-    } = useTable(
-        {
-            columns: COLUMNS as any,
-            data: tokens as any,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            disableSortRemove: true,
-        },
-        useGlobalFilter,
-        useSortBy,
-        useFlexLayout,
+        ],
+        [],
     );
 
+    const table = useReactTable({
+        columns,
+        data: tokens,
+        initialState,
+        state: { globalFilter },
+        onGlobalFilterChange: setGlobalFilter,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
+
     return {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
-        state,
+        table,
+        columns,
+        globalFilter,
         setGlobalFilter,
-        setHiddenColumns,
-        columns: COLUMNS,
     };
 };
 

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectApiAccess/ProjectApiAccess.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectApiAccess/ProjectApiAccess.tsx
@@ -39,50 +39,47 @@ export const ProjectApiAccess = () => {
 
     usePageTitle(`Project api access – ${projectName}`);
 
-    const {
-        headerGroups,
-        rows,
-        prepareRow,
-        state: { globalFilter },
-        setGlobalFilter,
-        setHiddenColumns,
-        columns,
-    } = useApiTokenTable(tokens, (props) => (
-        <ActionCell>
-            <CopyApiTokenButton
-                token={props.row.original}
-                permission={READ_PROJECT_API_TOKEN}
-                project={projectId}
-                track={() =>
-                    trackEvent('project_api_tokens', {
-                        props: { eventType: 'api_key_copied' },
-                    })
-                }
-            />
-            <RemoveApiTokenButton
-                token={props.row.original}
-                permission={DELETE_PROJECT_API_TOKEN}
-                project={projectId}
-                onRemove={async () => {
-                    await deleteProjectToken(
-                        props.row.original.secret,
-                        projectId,
-                    );
-                    trackEvent('project_api_tokens', {
-                        props: { eventType: 'api_key_deleted' },
-                    });
-                    refetchProjectTokens();
-                }}
-            />
-        </ActionCell>
-    ));
+    const { table, columns, globalFilter, setGlobalFilter } = useApiTokenTable(
+        tokens,
+        (props) => (
+            <ActionCell>
+                <CopyApiTokenButton
+                    token={props.row.original}
+                    permission={READ_PROJECT_API_TOKEN}
+                    project={projectId}
+                    track={() =>
+                        trackEvent('project_api_tokens', {
+                            props: { eventType: 'api_key_copied' },
+                        })
+                    }
+                />
+                <RemoveApiTokenButton
+                    token={props.row.original}
+                    permission={DELETE_PROJECT_API_TOKEN}
+                    project={projectId}
+                    onRemove={async () => {
+                        await deleteProjectToken(
+                            props.row.original.secret,
+                            projectId,
+                        );
+                        trackEvent('project_api_tokens', {
+                            props: { eventType: 'api_key_deleted' },
+                        });
+                        refetchProjectTokens();
+                    }}
+                />
+            </ActionCell>
+        ),
+    );
+
+    const rowCount = table.getRowModel().rows.length;
 
     return (
         <div style={{ width: '100%', overflow: 'hidden' }}>
             <PageContent
                 header={
                     <PageHeader
-                        title={`API access (${rows.length})`}
+                        title={`API access (${rowCount})`}
                         actions={
                             <>
                                 <Search
@@ -112,10 +109,7 @@ export const ProjectApiAccess = () => {
                         <ApiTokenTable
                             compact
                             loading={loading}
-                            headerGroups={headerGroups}
-                            setHiddenColumns={setHiddenColumns}
-                            prepareRow={prepareRow}
-                            rows={rows}
+                            table={table}
                             columns={columns}
                             globalFilter={globalFilter}
                         />

--- a/frontend/src/component/project/ProjectAccess/ProjectAccessTable/ProjectAccessTable.tsx
+++ b/frontend/src/component/project/ProjectAccess/ProjectAccessTable/ProjectAccessTable.tsx
@@ -1,16 +1,16 @@
 import { useEffect, useMemo, useState, type FC } from 'react';
 import {
-    type SortingRule,
-    useFlexLayout,
-    useSortBy,
-    useTable,
-} from 'react-table';
-import { VirtualizedTable, TablePlaceholder } from 'component/common/Table';
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { styled, useMediaQuery, useTheme } from '@mui/material';
 import Add from '@mui/icons-material/Add';
 import Delete from '@mui/icons-material/Delete';
 import Edit from '@mui/icons-material/Edit';
-import { sortTypes } from 'utils/sortTypes';
 import useProjectAccess, {
     ENTITY_TYPE,
     type IProjectAccess,
@@ -25,7 +25,7 @@ import { ActionCell } from 'component/common/Table/cells/ActionCell/ActionCell';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { useSearch } from 'hooks/useSearch';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import {
     Link,
     Route,
@@ -64,7 +64,7 @@ export type PageQueryType = Partial<
     Record<'sort' | 'order' | 'search', string>
 >;
 
-const defaultSort: SortingRule<string> = { id: 'added', desc: true };
+const defaultSort = { id: 'added', desc: true };
 
 const { value: storedParams, setValue: setStoredParams } = createLocalStorage(
     'ProjectAccess:v1',
@@ -113,30 +113,30 @@ export const ProjectAccessTable: FC = () => {
             ? `${roles.length} roles`
             : access?.roles.find(({ id }) => id === roles[0])?.name || '';
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<IProjectAccess, unknown>[]>(
         () => [
             {
-                Header: 'Avatar',
-                accessor: 'imageUrl',
-                Cell: ({ row: { original: row } }: any) => (
+                id: 'imageUrl',
+                header: 'Avatar',
+                cell: ({ row: { original: row } }) => (
                     <StyledUserAvatars>
                         <ConditionallyRender
                             condition={row.type === ENTITY_TYPE.GROUP}
                             show={<StyledEmptyAvatar />}
                         />
                         <StyledGroupAvatar user={row.entity}>
-                            {row.entity.users?.length}
+                            {(row.entity as IGroup).users?.length}
                         </StyledGroupAvatar>
                     </StyledUserAvatars>
                 ),
-                maxWidth: 85,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { maxWidth: 85 },
             },
             {
                 id: 'name',
-                Header: 'Name',
-                accessor: (row: IProjectAccess) => row.entity.name || '',
-                Cell: ({ value, row: { original: row } }: any) => (
+                header: 'Name',
+                accessorFn: (row) => row.entity.name || '',
+                cell: ({ getValue, row: { original: row } }) => (
                     <ConditionallyRender
                         condition={row.type === ENTITY_TYPE.GROUP}
                         show={
@@ -145,48 +145,47 @@ export const ProjectAccessTable: FC = () => {
                                     setSelectedRow(row);
                                     setGroupOpen(true);
                                 }}
-                                title={value}
-                                subtitle={`${row.entity.users?.length} users`}
+                                title={String(getValue() ?? '')}
+                                subtitle={`${(row.entity as IGroup).users?.length} users`}
                             />
                         }
                         elseShow={
                             <HighlightCell
-                                value={value}
+                                value={String(getValue() ?? '')}
                                 subtitle={
-                                    row.entity?.email || row.entity?.username
+                                    (row.entity as IUser)?.email ||
+                                    (row.entity as IUser)?.username
                                 }
                             />
                         }
                     />
                 ),
-                minWidth: 100,
-                searchable: true,
+                meta: { minWidth: 100, searchable: true },
             },
             {
                 id: 'role',
-                Header: 'Role',
-                accessor: (row: IProjectAccess) => roleText(row.entity.roles),
-                Cell: ({
-                    value,
-                    row: { original: row },
-                }: {
-                    row: { original: IProjectAccess };
-                    value: string;
-                }) => <RoleCell value={value} roles={row.entity.roles} />,
-                maxWidth: 175,
-                filterName: 'role',
+                header: 'Role',
+                accessorFn: (row) => roleText(row.entity.roles),
+                cell: ({ getValue, row: { original: row } }) => (
+                    <RoleCell
+                        value={String(getValue() ?? '')}
+                        roles={row.entity.roles}
+                    />
+                ),
+                meta: { maxWidth: 175, filterName: 'role' },
             },
             {
                 id: 'added',
-                Header: 'Added',
-                accessor: 'entity.addedAt',
-                Cell: TimeAgoCell,
-                maxWidth: 130,
+                header: 'Added',
+                accessorFn: (row) =>
+                    (row.entity as { addedAt?: string | null }).addedAt,
+                cell: TimeAgoCell,
+                meta: { maxWidth: 130 },
             },
             {
                 id: 'lastLogin',
-                Header: 'Last login',
-                accessor: (row: IProjectAccess) => {
+                header: 'Last login',
+                accessorFn: (row) => {
                     if (row.type !== ENTITY_TYPE.GROUP) {
                         const userRow = row.entity as IUser;
                         return userRow.seenAt || '';
@@ -197,20 +196,14 @@ export const ProjectAccessTable: FC = () => {
                         .sort()
                         .reverse()[0];
                 },
-                Cell: TimeAgoCell,
-                maxWidth: 130,
+                cell: TimeAgoCell,
+                meta: { maxWidth: 130 },
             },
             {
                 id: 'actions',
-                Header: 'Actions',
-                disableSortBy: true,
-                align: 'center',
-                maxWidth: 150,
-                Cell: ({
-                    row: { original: row },
-                }: {
-                    row: { original: IProjectAccess };
-                }) => (
+                header: 'Actions',
+                enableSorting: false,
+                cell: ({ row: { original: row } }) => (
                     <ActionCell>
                         <PermissionIconButton
                             data-testid={PA_EDIT_BUTTON_ID}
@@ -251,32 +244,35 @@ export const ProjectAccessTable: FC = () => {
                         </PermissionIconButton>
                     </ActionCell>
                 ),
+                meta: { maxWidth: 150, align: 'center' },
             },
             // Always hidden -- for search
             {
-                accessor: (row: IProjectAccess) =>
+                id: 'username',
+                header: 'Username',
+                accessorFn: (row) =>
                     row.type !== ENTITY_TYPE.GROUP
                         ? (row.entity as IUser)?.username || ''
                         : '',
-                Header: 'Username',
-                searchable: true,
+                meta: { searchable: true },
             },
-            // Always hidden -- for search
             {
-                accessor: (row: IProjectAccess) =>
+                id: 'email',
+                header: 'Email',
+                accessorFn: (row) =>
                     row.type !== ENTITY_TYPE.GROUP
                         ? (row.entity as IUser)?.email || ''
                         : '',
-                Header: 'Email',
-                searchable: true,
+                meta: { searchable: true },
             },
         ],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [access, projectId],
     );
 
     const [searchParams, setSearchParams] = useSearchParams();
     const [initialState] = useState(() => ({
-        sortBy: [
+        sorting: [
             {
                 id: searchParams.get('sort') || storedParams.id,
                 desc: searchParams.has('order')
@@ -284,7 +280,7 @@ export const ProjectAccessTable: FC = () => {
                     : storedParams.desc,
             },
         ],
-        hiddenColumns: ['Username', 'Email'],
+        columnVisibility: { username: false, email: false },
         globalFilter: searchParams.get('search') || '',
     }));
     const [searchValue, setSearchValue] = useState(initialState.globalFilter);
@@ -295,31 +291,23 @@ export const ProjectAccessTable: FC = () => {
         access?.rows ?? [],
     );
 
-    const {
-        headerGroups,
-        rows,
-        prepareRow,
-        setHiddenColumns,
-        state: { sortBy },
-    } = useTable(
-        {
-            columns: columns as any[],
-            data,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-            defaultColumn: {
-                Cell: TextCell,
-            },
+    const table = useReactTable({
+        columns,
+        data,
+        initialState,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
         },
-        useSortBy,
-        useFlexLayout,
-    );
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isSmallScreen,
@@ -330,14 +318,21 @@ export const ProjectAccessTable: FC = () => {
                 columns: hiddenColumnsMedium,
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
 
+    const sorting = table.getState().sorting;
+    const rows = table.getRowModel().rows;
+
     useEffect(() => {
+        const sortRule = sorting[0];
+        if (!sortRule) {
+            return;
+        }
         const tableState: PageQueryType = {};
-        tableState.sort = sortBy[0].id;
-        if (sortBy[0].desc) {
+        tableState.sort = sortRule.id;
+        if (sortRule.desc) {
             tableState.order = 'desc';
         }
         if (searchValue) {
@@ -347,8 +342,8 @@ export const ProjectAccessTable: FC = () => {
         setSearchParams(tableState, {
             replace: true,
         });
-        setStoredParams({ id: sortBy[0].id, desc: sortBy[0].desc || false });
-    }, [sortBy, searchValue, setSearchParams]);
+        setStoredParams({ id: sortRule.id, desc: sortRule.desc || false });
+    }, [sorting, searchValue, setSearchParams]);
 
     const removeAccess = async (userOrGroup?: IProjectAccess) => {
         if (!userOrGroup) return;
@@ -440,11 +435,7 @@ export const ProjectAccessTable: FC = () => {
             }
         >
             <SearchHighlightProvider value={getSearchText(searchValue)}>
-                <VirtualizedTable
-                    rows={rows}
-                    headerGroups={headerGroups}
-                    prepareRow={prepareRow}
-                />
+                <VirtualizedTableV8 tableInstance={table} />
             </SearchHighlightProvider>
             <ConditionallyRender
                 condition={rows.length === 0}

--- a/frontend/src/component/project/ProjectEnvironment/ProjectEnvironment.tsx
+++ b/frontend/src/component/project/ProjectEnvironment/ProjectEnvironment.tsx
@@ -14,13 +14,15 @@ import type { IProjectEnvironment } from 'interfaces/environments';
 import { getEnabledEnvs } from './helpers.ts';
 import { usePageTitle } from 'hooks/usePageTitle';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import { useGlobalFilter, useTable } from 'react-table';
 import {
-    SortableTableHeader,
-    Table,
-    TableCell,
-    TablePlaceholder,
-} from 'component/common/Table';
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    getFilteredRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { Table, TableCell, TablePlaceholder } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { Search } from 'component/common/Search/Search';
 import { EnvironmentNameCell } from 'component/environments/EnvironmentTable/EnvironmentNameCell/EnvironmentNameCell';
@@ -68,6 +70,7 @@ const ProjectEnvironmentList = () => {
     const [selectedEnvironment, setSelectedEnvironment] =
         useState<IProjectEnvironment>();
     const [hideDialog, setHideDialog] = useState(false);
+    const [globalFilter, setGlobalFilter] = useState('');
     const { isOss } = useUiConfig();
 
     const projectEnvironments = useMemo<IProjectEnvironment[]>(
@@ -172,34 +175,36 @@ const ProjectEnvironmentList = () => {
             : 'Make it visible';
     };
 
-    const COLUMNS = useMemo(
+    const columns = useMemo<ColumnDef<IProjectEnvironment, unknown>[]>(
         () => [
             {
-                Header: 'Name',
-                accessor: 'name',
-                Cell: ({ row: { original } }: any) => (
+                id: 'name',
+                header: 'Name',
+                accessorKey: 'name',
+                cell: ({ row: { original } }) => (
                     <EnvironmentNameCell environment={original} />
                 ),
             },
             {
-                Header: 'Type',
-                accessor: 'type',
-                Cell: HighlightCell,
+                id: 'type',
+                header: 'Type',
+                accessorKey: 'type',
+                cell: HighlightCell,
             },
             {
-                Header: 'Project API tokens',
-                accessor: (row: IProjectEnvironment) =>
+                id: 'projectApiTokenCount',
+                header: 'Project API tokens',
+                accessorFn: (row) =>
                     row.projectApiTokenCount === 1
                         ? '1 token'
                         : `${row.projectApiTokenCount} tokens`,
-                Cell: TextCell,
+                cell: TextCell,
             },
             {
-                Header: 'Visible in project',
-                accessor: 'enabled',
-                align: 'center',
-                width: 1,
-                Cell: ({ row: { original } }: any) => (
+                id: 'enabled',
+                header: 'Visible in project',
+                accessorKey: 'enabled',
+                cell: ({ row: { original } }) => (
                     <ActionCell>
                         <PermissionSwitch
                             tooltip={buildToolTip(original)}
@@ -207,33 +212,31 @@ const ProjectEnvironmentList = () => {
                             disabled={envIsDisabled(original)}
                             projectId={projectId}
                             permission={UPDATE_PROJECT}
-                            checked={original.projectVisible}
+                            checked={Boolean(original.projectVisible)}
                             onChange={() => toggleEnv(original)}
                         />
                     </ActionCell>
                 ),
-                disableGlobalFilter: true,
+                enableGlobalFilter: false,
+                meta: { align: 'center' },
             },
         ],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [projectEnvironments],
     );
 
-    const {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows,
-        prepareRow,
+    const table = useReactTable({
+        columns,
+        data: projectEnvironments,
         state: { globalFilter },
-        setGlobalFilter,
-    } = useTable(
-        {
-            columns: COLUMNS as any,
-            data: projectEnvironments,
-            disableSortBy: true,
-        },
-        useGlobalFilter,
-    );
+        onGlobalFilterChange: setGlobalFilter,
+        getCoreRowModel: getCoreRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        enableSorting: false,
+        autoResetAll: false,
+    });
+
+    const rows = table.getRowModel().rows;
 
     const header = (
         <PageHeader
@@ -242,7 +245,7 @@ const ProjectEnvironmentList = () => {
                 <>
                     <Search
                         initialValue={globalFilter}
-                        onChange={setGlobalFilter}
+                        onChange={(value) => setGlobalFilter(value)}
                     />
                     {!isOss() ? (
                         <>
@@ -281,32 +284,21 @@ const ProjectEnvironmentList = () => {
                     .
                 </StyledAlert>
                 <SearchHighlightProvider value={globalFilter}>
-                    <Table {...getTableProps()} rowHeight='compact'>
-                        <SortableTableHeader
-                            headerGroups={headerGroups as any}
-                        />
-                        <TableBody {...getTableBodyProps()}>
-                            {rows.map((row) => {
-                                prepareRow(row);
-                                const { key, ...rowProps } = row.getRowProps();
-                                return (
-                                    <TableRow hover key={key} {...rowProps}>
-                                        {row.cells.map((cell) => {
-                                            const { key, ...cellProps } =
-                                                cell.getCellProps();
-
-                                            return (
-                                                <TableCell
-                                                    key={key}
-                                                    {...cellProps}
-                                                >
-                                                    {cell.render('Cell')}
-                                                </TableCell>
-                                            );
-                                        })}
-                                    </TableRow>
-                                );
-                            })}
+                    <Table rowHeight='compact'>
+                        <SortableTableHeaderV8 tableInstance={table} />
+                        <TableBody>
+                            {rows.map((row) => (
+                                <TableRow hover key={row.id}>
+                                    {row.getVisibleCells().map((cell) => (
+                                        <TableCell key={cell.id}>
+                                            {flexRender(
+                                                cell.column.columnDef.cell,
+                                                cell.getContext(),
+                                            )}
+                                        </TableCell>
+                                    ))}
+                                </TableRow>
+                            ))}
                         </TableBody>
                     </Table>
                 </SearchHighlightProvider>

--- a/frontend/src/component/signals/SignalEndpointsTable/SignalEndpointsTable.tsx
+++ b/frontend/src/component/signals/SignalEndpointsTable/SignalEndpointsTable.tsx
@@ -1,16 +1,22 @@
 import { useMemo, useState } from 'react';
-import { TablePlaceholder, VirtualizedTable } from 'component/common/Table';
+import { TablePlaceholder } from 'component/common/Table';
+import { VirtualizedTableV8 } from 'component/common/Table/VirtualizedTable/VirtualizedTableV8';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { Alert, Button, styled, useMediaQuery } from '@mui/material';
 import ReviewsOutlined from '@mui/icons-material/ReviewsOutlined';
-import { useFlexLayout, useSortBy, useTable } from 'react-table';
-import { sortTypes } from 'utils/sortTypes';
+import {
+    type ColumnDef,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { sortingFns } from 'utils/sortingFns';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import theme from 'themes/theme';
-import { useConditionallyHiddenColumns } from 'hooks/useConditionallyHiddenColumns';
+import { useConditionallyHiddenColumnsV8 } from 'hooks/useConditionallyHiddenColumnsV8';
 import { useSignalEndpoints } from 'hooks/api/getters/useSignalEndpoints/useSignalEndpoints';
 import { useSignalEndpointsApi } from 'hooks/api/actions/useSignalEndpointsApi/useSignalEndpointsApi';
 import type { ISignalEndpoint } from 'interfaces/signal';
@@ -93,16 +99,13 @@ export const SignalEndpointsTable = () => {
 
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<ISignalEndpoint, unknown>[]>(
         () => [
             {
-                Header: 'Name',
-                accessor: 'name',
-                Cell: ({
-                    row: { original: signalEndpoint },
-                }: {
-                    row: { original: ISignalEndpoint };
-                }) => (
+                id: 'name',
+                header: 'Name',
+                accessorKey: 'name',
+                cell: ({ row: { original: signalEndpoint } }) => (
                     <LinkCell
                         title={signalEndpoint.name}
                         onClick={() => {
@@ -112,53 +115,44 @@ export const SignalEndpointsTable = () => {
                         subtitle={signalEndpoint.description}
                     />
                 ),
-                width: 240,
+                meta: { width: 240 },
             },
             {
-                Header: 'URL',
-                accessor: (row: ISignalEndpoint) =>
+                id: 'url',
+                header: 'URL',
+                accessorFn: (row) =>
                     `${uiConfig.unleashUrl}/api/signal-endpoint/${row.name}`,
-                minWidth: 200,
+                meta: { minWidth: 200 },
             },
             {
                 id: 'tokens',
-                Header: 'Tokens',
-                accessor: (row: ISignalEndpoint) =>
+                header: 'Tokens',
+                accessorFn: (row) =>
                     row.tokens?.map(({ name }) => name).join('\n') || '',
-                Cell: ({
-                    row: { original: signalEndpoint },
-                    value,
-                }: {
-                    row: { original: ISignalEndpoint };
-                    value: string;
-                }) => (
+                cell: ({ getValue, row: { original: signalEndpoint } }) => (
                     <SignalEndpointsTokensCell
                         signalEndpoint={signalEndpoint}
-                        value={value}
+                        value={String(getValue() ?? '')}
                         onCreateToken={() => {
                             setSelectedSignalEndpoint(signalEndpoint);
                             setModalOpen(true);
                         }}
                     />
                 ),
-                searchable: true,
-                maxWidth: 120,
+                meta: { searchable: true, maxWidth: 120 },
             },
             {
-                Header: 'Created',
-                accessor: 'createdAt',
-                Cell: DateCell,
-                width: 120,
-                maxWidth: 120,
+                id: 'createdAt',
+                header: 'Created',
+                accessorKey: 'createdAt',
+                cell: DateCell,
+                meta: { width: 120, maxWidth: 120 },
             },
             {
-                Header: 'Enabled',
-                accessor: 'enabled',
-                Cell: ({
-                    row: { original: signalEndpoint },
-                }: {
-                    row: { original: ISignalEndpoint };
-                }) => (
+                id: 'enabled',
+                header: 'Enabled',
+                accessorKey: 'enabled',
+                cell: ({ row: { original: signalEndpoint } }) => (
                     <ToggleCell
                         checked={signalEndpoint.enabled}
                         setChecked={(enabled) =>
@@ -166,19 +160,13 @@ export const SignalEndpointsTable = () => {
                         }
                     />
                 ),
-                sortType: 'boolean',
-                width: 90,
-                maxWidth: 90,
+                sortingFn: sortingFns.boolean,
+                meta: { width: 90, maxWidth: 90 },
             },
             {
-                Header: 'Actions',
                 id: 'Actions',
-                align: 'center',
-                Cell: ({
-                    row: { original: signalEndpoint },
-                }: {
-                    row: { original: ISignalEndpoint };
-                }) => (
+                header: 'Actions',
+                cell: ({ row: { original: signalEndpoint } }) => (
                     <SignalEndpointsActionsCell
                         signalEndpointId={signalEndpoint.id}
                         onCopyToClipboard={() => {
@@ -204,45 +192,46 @@ export const SignalEndpointsTable = () => {
                         }}
                     />
                 ),
-                width: 90,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { width: 90, align: 'center' },
             },
         ],
-        [],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [uiConfig.unleashUrl],
     );
 
     const [initialState] = useState({
-        sortBy: [{ id: 'createdAt', desc: true }],
+        sorting: [{ id: 'createdAt', desc: true }],
     });
 
-    const { headerGroups, rows, prepareRow, setHiddenColumns } = useTable(
-        {
-            columns: columns as any,
-            data: signalEndpoints,
-            initialState,
-            sortTypes,
-            autoResetHiddenColumns: false,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            disableMultiSort: true,
-            defaultColumn: {
-                Cell: TextCell,
-            },
+    const table = useReactTable({
+        columns,
+        data: signalEndpoints,
+        initialState,
+        defaultColumn: {
+            cell: ({ getValue }) => (
+                <TextCell value={String(getValue() ?? '')} />
+            ),
         },
-        useSortBy,
-        useFlexLayout,
-    );
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+        enableMultiSort: false,
+    });
 
-    useConditionallyHiddenColumns(
+    useConditionallyHiddenColumnsV8(
         [
             {
                 condition: isSmallScreen,
                 columns: ['createdAt'],
             },
         ],
-        setHiddenColumns,
+        table.setColumnVisibility,
         columns,
     );
+
+    const rowCount = table.getRowModel().rows.length;
 
     return (
         <PageContent
@@ -333,13 +322,9 @@ export const SignalEndpointsTable = () => {
 
             <PermissionGuard permissions={ADMIN}>
                 <>
-                    <VirtualizedTable
-                        rows={rows}
-                        headerGroups={headerGroups}
-                        prepareRow={prepareRow}
-                    />
+                    <VirtualizedTableV8 tableInstance={table} />
                     <ConditionallyRender
-                        condition={rows.length === 0}
+                        condition={rowCount === 0}
                         show={
                             <TablePlaceholder>
                                 No signal endpoints available. Get started by

--- a/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
+++ b/frontend/src/component/strategies/StrategiesList/StrategiesList.tsx
@@ -4,12 +4,12 @@ import { Alert, Box, Link, Typography, styled } from '@mui/material';
 import Extension from '@mui/icons-material/Extension';
 import {
     Table,
-    SortableTableHeader,
     TableBody,
     TableCell,
     TableRow,
     TablePlaceholder,
 } from 'component/common/Table';
+import { SortableTableHeaderV8 } from 'component/common/Table/SortableTableHeader/SortableTableHeaderV8';
 import { ActionCell } from 'component/common/Table/cells/ActionCell/ActionCell';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { PageContent } from 'component/common/PageContent/PageContent';
@@ -22,8 +22,14 @@ import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import type { IStrategy } from 'interfaces/strategy';
 import { LinkCell } from 'component/common/Table/cells/LinkCell/LinkCell';
-import { sortTypes } from 'utils/sortTypes';
-import { useTable, useSortBy } from 'react-table';
+import {
+    type ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    getSortedRowModel,
+    useReactTable,
+    type Table as TableType,
+} from '@tanstack/react-table';
 import { StrategySwitch } from './StrategySwitch/StrategySwitch.tsx';
 import { StrategyEditButton } from './StrategyEditButton/StrategyEditButton.tsx';
 import { StrategyDeleteButton } from './StrategyDeleteButton/StrategyDeleteButton.tsx';
@@ -38,6 +44,14 @@ interface IDialogueMetaData {
     title: string;
     onConfirm: () => void;
 }
+
+type StrategyRow = {
+    name: string;
+    description: string;
+    editable: boolean;
+    deprecated: boolean;
+    advanced?: boolean;
+};
 
 const StyledBadge = styled(Badge)(({ theme }) => ({
     marginLeft: theme.spacing(1),
@@ -114,6 +128,26 @@ const RecommendationAlert = () => (
     </Alert>
 );
 
+const StrategyTable = ({ table }: { table: TableType<StrategyRow> }) => (
+    <Table>
+        <SortableTableHeaderV8 tableInstance={table} />
+        <TableBody>
+            {table.getRowModel().rows.map((row) => (
+                <TableRow hover key={row.id}>
+                    {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                            {flexRender(
+                                cell.column.columnDef.cell,
+                                cell.getContext(),
+                            )}
+                        </TableCell>
+                    ))}
+                </TableRow>
+            ))}
+        </TableBody>
+    </Table>
+);
+
 export const StrategiesList = () => {
     const navigate = useNavigate();
     const [dialogueMetaData, setDialogueMetaData] = useState<IDialogueMetaData>(
@@ -131,11 +165,18 @@ export const StrategiesList = () => {
 
     usePageTitle('Strategy types');
 
-    const data = useMemo(() => {
+    const data = useMemo<{
+        all: StrategyRow[];
+        standard: StrategyRow[];
+        advanced: StrategyRow[];
+        custom: StrategyRow[];
+    }>(() => {
         if (loading) {
-            const mock = Array(5).fill({
+            const mock: StrategyRow[] = Array(5).fill({
                 name: 'Context name',
                 description: 'Context description when loading',
+                editable: false,
+                deprecated: false,
             });
             return {
                 all: mock,
@@ -145,10 +186,10 @@ export const StrategiesList = () => {
             };
         }
 
-        const all = strategies.map(
+        const all: StrategyRow[] = strategies.map(
             ({ name, description, editable, deprecated, advanced }) => ({
                 name,
-                description,
+                description: description ?? '',
                 editable,
                 deprecated,
                 advanced,
@@ -241,11 +282,11 @@ export const StrategiesList = () => {
         [navigate],
     );
 
-    const columns = useMemo(
+    const columns = useMemo<ColumnDef<StrategyRow, unknown>[]>(
         () => [
             {
                 id: 'Icon',
-                Cell: () => (
+                cell: () => (
                     <Box
                         data-loading
                         sx={{
@@ -261,43 +302,40 @@ export const StrategiesList = () => {
             },
             {
                 id: 'Name',
-                Header: 'Name',
-                accessor: (row: any) => formatStrategyName(row.name),
-                width: '90%',
-                Cell: ({
+                header: 'Name',
+                accessorFn: (row) => formatStrategyName(row.name),
+                cell: ({
                     row: {
                         original: { name, description, deprecated },
                     },
-                }: any) => {
-                    return (
-                        <LinkCell
-                            data-loading
-                            title={formatStrategyName(name)}
-                            subtitle={description}
-                            to={`/strategies/${name}`}
-                        >
-                            <ConditionallyRender
-                                condition={deprecated}
-                                show={() => (
-                                    <StyledBadge color='disabled'>
-                                        Disabled
-                                    </StyledBadge>
-                                )}
-                            />
-                        </LinkCell>
-                    );
-                },
-                sortType: 'alphanumeric',
+                }) => (
+                    <LinkCell
+                        data-loading
+                        title={formatStrategyName(name)}
+                        subtitle={description}
+                        to={`/strategies/${name}`}
+                    >
+                        <ConditionallyRender
+                            condition={deprecated}
+                            show={() => (
+                                <StyledBadge color='disabled'>
+                                    Disabled
+                                </StyledBadge>
+                            )}
+                        />
+                    </LinkCell>
+                ),
+                sortingFn: 'alphanumeric',
+                meta: { width: '90%' },
             },
             {
-                Header: 'Actions',
                 id: 'Actions',
-                align: 'center',
-                Cell: ({ row: { original } }: any) => (
+                header: 'Actions',
+                cell: ({ row: { original } }) => (
                     <ActionCell>
                         <StrategySwitch
                             deprecated={original.deprecated}
-                            onToggle={onToggle(original)}
+                            onToggle={onToggle(original as IStrategy)}
                         />
                         <ConditionallyRender
                             condition={original.editable}
@@ -305,13 +343,19 @@ export const StrategiesList = () => {
                                 <>
                                     <ActionCell.Divider />
                                     <StrategyEditButton
-                                        strategy={original}
-                                        onClick={() => onEditStrategy(original)}
+                                        strategy={original as IStrategy}
+                                        onClick={() =>
+                                            onEditStrategy(
+                                                original as IStrategy,
+                                            )
+                                        }
                                     />
                                     <StrategyDeleteButton
-                                        strategy={original}
+                                        strategy={original as IStrategy}
                                         onClick={() =>
-                                            onDeleteStrategy(original)
+                                            onDeleteStrategy(
+                                                original as IStrategy,
+                                            )
                                         }
                                     />
                                 </>
@@ -319,17 +363,13 @@ export const StrategiesList = () => {
                         />
                     </ActionCell>
                 ),
-                width: 150,
-                minWidth: 120,
-                disableSortBy: true,
+                enableSorting: false,
+                meta: { width: 150, minWidth: 120, align: 'center' },
             },
             {
-                accessor: 'description',
-                disableSortBy: true,
-            },
-            {
-                accessor: 'sortOrder',
-                sortType: 'number',
+                id: 'description',
+                accessorKey: 'description',
+                enableSorting: false,
             },
         ],
         [onToggle, onEditStrategy, onDeleteStrategy],
@@ -337,68 +377,41 @@ export const StrategiesList = () => {
 
     const initialState = useMemo(
         () => ({
-            sortBy: [{ id: 'Name', desc: false }],
-            hiddenColumns: ['description', 'sortOrder'],
+            sorting: [{ id: 'Name', desc: false }],
+            columnVisibility: { description: false },
         }),
         [],
     );
 
-    const {
-        getTableProps,
-        getTableBodyProps,
-        headerGroups,
-        rows: standardRows,
-        prepareRow,
-    } = useTable(
-        {
-            columns: columns as any[], // TODO: fix after `react-table` v8 update
-            data: data.standard,
-            initialState,
-            sortTypes,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            autoResetHiddenColumns: false,
-        },
-        useSortBy,
-    );
+    const standardTable = useReactTable({
+        columns,
+        data: data.standard,
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
 
-    const {
-        getTableProps: advancedGetTableProps,
-        getTableBodyProps: advancedGetTableBodyProps,
-        headerGroups: advancedHeaderGroups,
-        rows: advancedRows,
-        prepareRow: advancedPrepareRow,
-    } = useTable(
-        {
-            columns: columns as any[], // TODO: fix after `react-table` v8 update
-            data: data.advanced,
-            initialState,
-            sortTypes,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            autoResetHiddenColumns: false,
-        },
-        useSortBy,
-    );
+    const advancedTable = useReactTable({
+        columns,
+        data: data.advanced,
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
 
-    const {
-        getTableProps: customGetTableProps,
-        getTableBodyProps: customGetTableBodyProps,
-        headerGroups: customHeaderGroups,
-        rows: customRows,
-        prepareRow: customPrepareRow,
-    } = useTable(
-        {
-            columns: columns as any[], // TODO: fix after `react-table` v8 update
-            data: data.custom,
-            initialState,
-            sortTypes,
-            autoResetSortBy: false,
-            disableSortRemove: true,
-            autoResetHiddenColumns: false,
-        },
-        useSortBy,
-    );
+    const customTable = useReactTable({
+        columns,
+        data: data.custom,
+        initialState,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        autoResetAll: false,
+        enableSortingRemoval: false,
+    });
 
     const onDialogConfirm = () => {
         dialogueMetaData?.onConfirm();
@@ -426,34 +439,11 @@ export const StrategiesList = () => {
             >
                 <Box>
                     <RecommendationAlert />
-                    <Table {...getTableProps()}>
-                        <SortableTableHeader headerGroups={headerGroups} />
-                        <TableBody {...getTableBodyProps()}>
-                            {standardRows.map((row) => {
-                                prepareRow(row);
-                                const { key, ...rowProps } = row.getRowProps();
-                                return (
-                                    <TableRow hover key={key} {...rowProps}>
-                                        {row.cells.map((cell) => {
-                                            const { key, ...cellProps } =
-                                                cell.getCellProps();
-
-                                            return (
-                                                <TableCell
-                                                    key={key}
-                                                    {...cellProps}
-                                                >
-                                                    {cell.render('Cell')}
-                                                </TableCell>
-                                            );
-                                        })}
-                                    </TableRow>
-                                );
-                            })}
-                        </TableBody>
-                    </Table>
+                    <StrategyTable table={standardTable} />
                     <ConditionallyRender
-                        condition={standardRows.length === 0}
+                        condition={
+                            standardTable.getRowModel().rows.length === 0
+                        }
                         show={
                             <TablePlaceholder>
                                 No strategies available.
@@ -493,36 +483,11 @@ export const StrategiesList = () => {
                     <StyledSubtitle>
                         <span>Advanced strategies</span>
                     </StyledSubtitle>
-                    <Table {...advancedGetTableProps()}>
-                        <SortableTableHeader
-                            headerGroups={advancedHeaderGroups}
-                        />
-                        <TableBody {...advancedGetTableBodyProps()}>
-                            {advancedRows.map((row) => {
-                                advancedPrepareRow(row);
-                                const { key, ...rowProps } = row.getRowProps();
-                                return (
-                                    <TableRow hover key={key} {...rowProps}>
-                                        {row.cells.map((cell) => {
-                                            const { key, ...cellProps } =
-                                                cell.getCellProps();
-
-                                            return (
-                                                <TableCell
-                                                    key={key}
-                                                    {...cellProps}
-                                                >
-                                                    {cell.render('Cell')}
-                                                </TableCell>
-                                            );
-                                        })}
-                                    </TableRow>
-                                );
-                            })}
-                        </TableBody>
-                    </Table>
+                    <StrategyTable table={advancedTable} />
                     <ConditionallyRender
-                        condition={advancedRows.length === 0}
+                        condition={
+                            advancedTable.getRowModel().rows.length === 0
+                        }
                         show={
                             <TablePlaceholder>
                                 No advanced strategies available.
@@ -535,36 +500,9 @@ export const StrategiesList = () => {
                         <span>Custom strategies</span>
                         <AddStrategyButton />
                     </StyledSubtitle>
-                    <Table {...customGetTableProps()}>
-                        <SortableTableHeader
-                            headerGroups={customHeaderGroups}
-                        />
-                        <TableBody {...customGetTableBodyProps()}>
-                            {customRows.map((row) => {
-                                customPrepareRow(row);
-                                const { key, ...rowProps } = row.getRowProps();
-                                return (
-                                    <TableRow hover key={key} {...rowProps}>
-                                        {row.cells.map((cell) => {
-                                            const { key, ...cellProps } =
-                                                cell.getCellProps();
-
-                                            return (
-                                                <TableCell
-                                                    key={key}
-                                                    {...cellProps}
-                                                >
-                                                    {cell.render('Cell')}
-                                                </TableCell>
-                                            );
-                                        })}
-                                    </TableRow>
-                                );
-                            })}
-                        </TableBody>
-                    </Table>
+                    <StrategyTable table={customTable} />
                     <ConditionallyRender
-                        condition={customRows.length === 0}
+                        condition={customTable.getRowModel().rows.length === 0}
                         show={<CustomStrategyInfo />}
                     />
                 </Box>


### PR DESCRIPTION
## Summary

Fourth PR in the v7 → v8 stack. Builds on https://github.com/Unleash/unleash/pull/12071.

Two parts:

1. The remaining single-file leaf table migrations (phases 3m–3s).
2. The API token tables (phase 4) — the most architecturally non-trivial
   conversion in the stack, because they're driven by dedicated hooks
   (`useApiTokenTable`, `useConnectedInstancesTable`) that needed to be
   migrated alongside the components that consume them.

After this PR, every table in the app is on v8 and nothing in
`/frontend/src` should still import from `react-table`.

## What's in this PR

**Remaining leaf tables** (phases 3m–3s, one per commit)
- `ArchiveTable`
- `ProjectEnvironment`
- `UsersList`
- `Group`
- `SignalEndpointsTable`
- `ProjectAccessTable`
- `StrategiesList`

**API token / connected instances** (phase 4)
- `ApiTokenTable` + `useApiTokenTable`
- `ConnectedInstancesTable` + `useConnectedInstancesTable`
- `ApiTokenPage` and `ProjectApiAccess` updated for the new hook shapes.

## Stack

1. Foundation
2. Shared cells, `useSearch`, first batch of tables
3. Leaf table migrations, batch 1
4. **This PR** — leaf table migrations, batch 2 + API token tables
5. Remove the v7 dependency

## Review notes

- The API-token hook changes are the most interesting diff in this PR —
  v8's `useReactTable` returns a `table` object rather than v7's flat
  `{ headerGroups, rows, prepareRow, ... }` destructure, so the hook's
  public shape changed and consumers had to be updated.
- A quick `rg "from 'react-table'"` over `/frontend/src` should come back
  empty after this PR.
