### PR TITLE
feat: relax bucket requirement on client metrics

### DIFF
--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -285,16 +285,22 @@ export default class ClientMetricsServiceV2 {
             this.config.eventBus.emit(CLIENT_REGISTER, heartbeatEvent);
         }
 
+        const { bucket } = value;
+        // requests carrying only impact metrics may omit the bucket
+        if (!bucket) {
+            return;
+        }
+
         const clientMetrics: IClientMetricsEnv[] = Object.keys(
-            value.bucket.toggles,
+            bucket.toggles,
         ).map((name) => ({
             featureName: name,
             appName: value.appName,
             environment: value.environment ?? 'default',
-            timestamp: value.bucket.stop, //we might need to approximate between start/stop...
-            yes: value.bucket.toggles[name].yes ?? 0,
-            no: value.bucket.toggles[name].no ?? 0,
-            variants: value.bucket.toggles[name].variants,
+            timestamp: bucket.stop, //we might need to approximate between start/stop...
+            yes: bucket.toggles[name].yes ?? 0,
+            no: bucket.toggles[name].no ?? 0,
+            variants: bucket.toggles[name].variants,
         }));
 
         if (clientMetrics.length) {

--- a/src/lib/features/metrics/impact/impact-metrics.e2e.test.ts
+++ b/src/lib/features/metrics/impact/impact-metrics.e2e.test.ts
@@ -20,11 +20,6 @@ const sendImpactMetrics = async (
         .send({
             appName: 'impact-metrics-app',
             instanceId: 'instance-id',
-            bucket: {
-                start: Date.now(),
-                stop: Date.now(),
-                toggles: {},
-            },
             impactMetrics,
         })
         .expect(status);

--- a/src/lib/features/metrics/impact/impact-metrics.e2e.test.ts
+++ b/src/lib/features/metrics/impact/impact-metrics.e2e.test.ts
@@ -11,19 +11,28 @@ import type { NumericMetric, BucketMetric } from './metrics-translator.js';
 let app: IUnleashTest;
 let db: ITestDb;
 
-const sendImpactMetrics = async (
-    impactMetrics: (NumericMetric | BucketMetric)[],
-    status = 202,
-) =>
-    app.request
-        .post('/api/client/metrics')
-        .send({
-            appName: 'impact-metrics-app',
-            instanceId: 'instance-id',
-            bucket: null,
-            impactMetrics,
-        })
-        .expect(status);
+type Bucket = { start: number; stop: number; toggles: object };
+
+type ImpactMetricsBody = {
+    impactMetrics?: (NumericMetric | BucketMetric)[];
+    bucket?: Bucket | null;
+};
+
+const sendMetrics = async (data: ImpactMetricsBody = {}, status = 202) => {
+    const { impactMetrics = [] } = data;
+    const body: Record<string, unknown> = {
+        appName: 'impact-metrics-app',
+        instanceId: 'instance-id',
+        impactMetrics,
+    };
+    // bucket defaults to null when the key is omitted; passing `bucket: undefined`
+    // explicitly drops it from the body.
+    const bucket = 'bucket' in data ? data.bucket : null;
+    if (bucket !== undefined) {
+        body.bucket = bucket;
+    }
+    return app.request.post('/api/client/metrics').send(body).expect(status);
+};
 
 const sendBulkMetricsWithImpact = async (
     impactMetrics: (NumericMetric | BucketMetric)[],
@@ -56,38 +65,42 @@ afterAll(async () => {
 });
 
 test('should store impact metrics in memory and be able to retrieve them', async () => {
-    await sendImpactMetrics([
-        {
-            name: 'labeled_counter',
-            help: 'with labels',
-            type: 'counter',
-            samples: [
-                {
-                    labels: { foo: 'bar' },
-                    value: 5,
-                },
-            ],
-        },
-    ]);
+    await sendMetrics({
+        impactMetrics: [
+            {
+                name: 'labeled_counter',
+                help: 'with labels',
+                type: 'counter',
+                samples: [
+                    {
+                        labels: { foo: 'bar' },
+                        value: 5,
+                    },
+                ],
+            },
+        ],
+    });
 
-    await sendImpactMetrics([
-        {
-            name: 'labeled_counter',
-            help: 'with labels',
-            type: 'counter',
-            samples: [
-                {
-                    labels: { foo: 'bar' },
-                    value: 10,
-                },
-            ],
-        },
-    ]);
+    await sendMetrics({
+        impactMetrics: [
+            {
+                name: 'labeled_counter',
+                help: 'with labels',
+                type: 'counter',
+                samples: [
+                    {
+                        labels: { foo: 'bar' },
+                        value: 10,
+                    },
+                ],
+            },
+        ],
+    });
 
-    await sendImpactMetrics([]);
+    await sendMetrics({ impactMetrics: [] });
     // missing help = no error but value ignored
-    await sendImpactMetrics(
-        [
+    await sendMetrics({
+        impactMetrics: [
             // @ts-expect-error
             {
                 name: 'labeled_counter',
@@ -100,8 +113,7 @@ test('should store impact metrics in memory and be able to retrieve them', async
                 ],
             },
         ],
-        202,
-    );
+    });
 
     const response = await app.request
         .get('/internal-backstage/impact/metrics')
@@ -164,44 +176,59 @@ test('should store impact metrics sent via bulk metrics endpoint', async () => {
     );
 });
 
-test('should store histogram metrics with batch data', async () => {
-    await sendImpactMetrics([
-        {
-            name: 'response_time',
-            help: 'Response time histogram',
-            type: 'histogram',
-            samples: [
-                {
-                    labels: { foo: 'bar' },
-                    count: 10,
-                    sum: 8.5,
-                    buckets: [
-                        { le: 1, count: 7 },
-                        { le: '+Inf', count: 10 },
-                    ],
-                },
-            ],
-        },
-    ]);
+test('accepts impact metrics regardless of bucket shape', async () => {
+    // bucket explicitly null
+    await sendMetrics({ bucket: null });
+    // bucket key omitted from the body entirely
+    await sendMetrics({ bucket: undefined });
+    // bucket present but with no toggles
+    await sendMetrics({
+        bucket: { start: Date.now(), stop: Date.now(), toggles: {} },
+    });
+});
 
-    await sendImpactMetrics([
-        {
-            name: 'response_time',
-            help: 'Response time histogram',
-            type: 'histogram',
-            samples: [
-                {
-                    labels: { foo: 'bar' },
-                    count: 5,
-                    sum: 3.2,
-                    buckets: [
-                        { le: 1, count: 3 },
-                        { le: '+Inf', count: 5 },
-                    ],
-                },
-            ],
-        },
-    ]);
+test('should store histogram metrics with batch data', async () => {
+    await sendMetrics({
+        impactMetrics: [
+            {
+                name: 'response_time',
+                help: 'Response time histogram',
+                type: 'histogram',
+                samples: [
+                    {
+                        labels: { foo: 'bar' },
+                        count: 10,
+                        sum: 8.5,
+                        buckets: [
+                            { le: 1, count: 7 },
+                            { le: '+Inf', count: 10 },
+                        ],
+                    },
+                ],
+            },
+        ],
+    });
+
+    await sendMetrics({
+        impactMetrics: [
+            {
+                name: 'response_time',
+                help: 'Response time histogram',
+                type: 'histogram',
+                samples: [
+                    {
+                        labels: { foo: 'bar' },
+                        count: 5,
+                        sum: 3.2,
+                        buckets: [
+                            { le: 1, count: 3 },
+                            { le: '+Inf', count: 5 },
+                        ],
+                    },
+                ],
+            },
+        ],
+    });
 
     const response = await app.request
         .get('/internal-backstage/impact/metrics')

--- a/src/lib/features/metrics/impact/impact-metrics.e2e.test.ts
+++ b/src/lib/features/metrics/impact/impact-metrics.e2e.test.ts
@@ -20,6 +20,7 @@ const sendImpactMetrics = async (
         .send({
             appName: 'impact-metrics-app',
             instanceId: 'instance-id',
+            bucket: null,
             impactMetrics,
         })
         .expect(status);

--- a/src/lib/features/metrics/shared/schema.test.ts
+++ b/src/lib/features/metrics/shared/schema.test.ts
@@ -123,3 +123,22 @@ test('clientMetricsSchema should accept null variants and default to empty objec
     expect(error).toBeUndefined();
     expect(value.bucket.toggles.Demo.variants).toEqual({});
 });
+
+test('clientMetricsSchema should allow omitted bucket (impact-metrics-only request)', () => {
+    const { error, value } = clientMetricsSchema.validate({
+        appName: 'test',
+    });
+
+    expect(error).toBeUndefined();
+    expect(value.bucket).toBeUndefined();
+});
+
+test('clientMetricsSchema should allow null bucket', () => {
+    const { error, value } = clientMetricsSchema.validate({
+        appName: 'test',
+        bucket: null,
+    });
+
+    expect(error).toBeUndefined();
+    expect(value.bucket).toBeUndefined();
+});

--- a/src/lib/features/metrics/shared/schema.ts
+++ b/src/lib/features/metrics/shared/schema.ts
@@ -19,7 +19,7 @@ export type ValidatedClientMetrics = {
     environment?: string;
     appName: string;
     instanceId: string;
-    bucket: IMetricsBucket;
+    bucket?: IMetricsBucket;
 };
 
 export const clientMetricsSchema = joi
@@ -29,9 +29,12 @@ export const clientMetricsSchema = joi
         environment: joi.string().optional(),
         appName: joi.string().required(),
         instanceId: joi.string().empty(['', null]).default('default'),
+        // bucket is optional: requests carrying only impact metrics may omit it
+        // or send it as null
         bucket: joi
             .object()
-            .required()
+            .empty(null)
+            .optional()
             .keys({
                 start: joi.date().required(),
                 stop: joi.date().required(),

--- a/src/lib/openapi/spec/client-metrics-schema.test.ts
+++ b/src/lib/openapi/spec/client-metrics-schema.test.ts
@@ -44,6 +44,23 @@ test('clientMetricsSchema should ignore additional properties without failing wh
     ).toBeUndefined();
 });
 
+test('clientMetricsSchema is valid when bucket is omitted (e.g. impact-metrics-only request)', () => {
+    expect(
+        validateSchema('#/components/schemas/clientMetricsSchema', {
+            appName: 'a',
+        }),
+    ).toBeUndefined();
+});
+
+test('clientMetricsSchema is valid when bucket is null', () => {
+    expect(
+        validateSchema('#/components/schemas/clientMetricsSchema', {
+            appName: 'a',
+            bucket: null,
+        }),
+    ).toBeUndefined();
+});
+
 test('clientMetricsSchema should fail when required field is missing', () => {
     expect(
         validateSchema('#/components/schemas/clientMetricsSchema', {

--- a/src/lib/openapi/spec/client-metrics-schema.ts
+++ b/src/lib/openapi/spec/client-metrics-schema.ts
@@ -4,7 +4,7 @@ import { dateSchema } from './date-schema.js';
 export const clientMetricsSchema = {
     $id: '#/components/schemas/clientMetricsSchema',
     type: 'object',
-    required: ['appName', 'bucket'],
+    required: ['appName'],
     description:
         'Client usage metrics, accumulated in buckets of hour by hour by default',
     properties: {
@@ -59,9 +59,10 @@ export const clientMetricsSchema = {
         },
         bucket: {
             type: 'object',
+            nullable: true,
             required: ['start', 'stop', 'toggles'],
             description:
-                'Holds all metrics gathered over a window of time. Typically 1 hour wide',
+                'Holds all metrics gathered over a window of time. Typically 1 hour wide. May be omitted or null when the request only carries impact metrics.',
             properties: {
                 start: {
                     $ref: '#/components/schemas/dateSchema',

--- a/src/test/e2e/api/client/metrics.e2e.test.ts
+++ b/src/test/e2e/api/client/metrics.e2e.test.ts
@@ -47,7 +47,7 @@ test('should require valid send metrics', async () => {
     return app.request
         .post('/api/client/metrics')
         .send({
-            appName: 'test',
+            instanceId: 'test',
         })
         .expect(400);
 });

--- a/src/test/e2e/api/client/metricsV2.e2e.test.ts
+++ b/src/test/e2e/api/client/metricsV2.e2e.test.ts
@@ -49,7 +49,7 @@ test('should require valid send metrics', async () => {
         .post('/api/client/metrics')
         .set('Authorization', defaultToken.secret)
         .send({
-            appName: 'test',
+            instanceId: 'test',
         })
         .expect(400);
 });


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

When impact metrics are used but no impression events are captured client metrics will have impact metrics sent over the wire but some SDKs will send null bucket. This PR makes our schema more forgiving.

I'm also considering adding impact metrics validation in openapi because today we only do this in joi (I guess we gave impact metrics enough time to stabilize and be part of official openapi schema)


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
