### PR TITLE
Docs/add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,265 @@
+# =============================================================================
+# Unleash Environment Configuration
+#
+# Copy this file to .env and fill in the values for your environment.
+# Docs: https://docs.getunleash.io/deploy/configuring-unleash
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Server
+# -----------------------------------------------------------------------------
+
+# The public URL where Unleash is reachable (used in emails/links)
+UNLEASH_URL=http://localhost:4242
+
+# Port and host to listen on
+HTTP_PORT=4242
+# HTTP_HOST=0.0.0.0
+
+# Base path if served behind a sub-path (e.g. /unleash)
+# BASE_URI_PATH=
+
+# Session secret - change this to a long random string in production!
+UNLEASH_SECRET=super-secret
+
+# Log level: debug | info | warn | error
+LOG_LEVEL=error
+
+# Node environment: development | production | test
+NODE_ENV=production
+
+# -----------------------------------------------------------------------------
+# Database
+# -----------------------------------------------------------------------------
+
+# Preferred: full connection string (overrides individual fields below)
+DATABASE_URL=postgres://unleash_user:password@localhost:5432/unleash
+
+# Or configure individual fields:
+# DATABASE_HOST=localhost
+# DATABASE_PORT=5432
+# DATABASE_NAME=unleash
+# DATABASE_USERNAME=unleash_user
+# DATABASE_PASSWORD=password
+# DATABASE_SCHEMA=public
+
+# Path to a file containing the DATABASE_URL (alternative to DATABASE_URL)
+# DATABASE_URL_FILE=
+
+# Connection pool size
+DATABASE_POOL_MIN=0
+DATABASE_POOL_MAX=4
+DATABASE_POOL_IDLE_TIMEOUT_MS=30000
+
+# Disable automatic database migrations on startup (useful for managed deployments)
+# DATABASE_DISABLE_MIGRATION=false
+
+# Application name reported to Postgres
+# DATABASE_APPLICATION_NAME=unleash
+
+# SSL - set to false to disable, or a JSON object for advanced config
+DATABASE_SSL=false
+# DATABASE_SSL_REJECT_UNAUTHORIZED=true
+# DATABASE_SSL_CA_FILE=/path/to/ca.pem
+# DATABASE_SSL_CERT_FILE=/path/to/client-cert.pem
+# DATABASE_SSL_KEY_FILE=/path/to/client-key.pem
+
+# -----------------------------------------------------------------------------
+# Authentication
+# -----------------------------------------------------------------------------
+
+# Auth type: open-source | demo | custom | none
+AUTH_TYPE=open-source
+
+# Enable/disable API token authentication
+AUTH_ENABLE_API_TOKEN=true
+
+# Override the default admin credentials on first startup
+# UNLEASH_DEFAULT_ADMIN_USERNAME=admin
+# UNLEASH_DEFAULT_ADMIN_PASSWORD=
+
+# Pre-create API tokens at startup (comma-separated)
+# INIT_ADMIN_API_TOKENS=
+# INIT_BACKEND_API_TOKENS=default:development.my-backend-token
+# INIT_FRONTEND_API_TOKENS=default:development.my-frontend-token
+
+# -----------------------------------------------------------------------------
+# Email / SMTP
+# -----------------------------------------------------------------------------
+
+# EMAIL_HOST=smtp.example.com
+# EMAIL_PORT=587
+# EMAIL_SECURE=false
+# EMAIL_USER=
+# EMAIL_PASSWORD=
+# EMAIL_SENDER=Unleash <noreply@getunleash.io>
+
+# -----------------------------------------------------------------------------
+# Frontend API
+# -----------------------------------------------------------------------------
+
+# Allowed CORS origins for the Frontend API (comma-separated, * = all)
+# UNLEASH_FRONTEND_API_ORIGINS=*
+
+# How often (ms) the Frontend API refreshes feature toggle data
+# FRONTEND_API_REFRESH_INTERVAL_MS=2700000
+
+# -----------------------------------------------------------------------------
+# Rate Limiting
+# -----------------------------------------------------------------------------
+
+# CLIENT_METRICS_RATE_LIMIT_PER_MINUTE=6000
+# REGISTER_CLIENT_RATE_LIMIT_PER_MINUTE=6000
+# FRONTEND_METRICS_RATE_LIMIT_PER_MINUTE=6000
+# REGISTER_FRONTEND_RATE_LIMIT_PER_MINUTE=6000
+# CREATE_USER_RATE_LIMIT_PER_MINUTE=20
+# SIMPLE_LOGIN_LIMIT_PER_MINUTE=10
+# PASSWORD_RESET_LIMIT_PER_MINUTE=1
+# SIGNAL_ENDPOINT_RATE_LIMIT_PER_SECOND=1
+
+# -----------------------------------------------------------------------------
+# Session
+# -----------------------------------------------------------------------------
+
+# SESSION_TTL_HOURS=48
+# SESSION_CLEAR_SITE_DATA_ON_LOGOUT=true
+# MAX_PARALLEL_SESSIONS=5
+
+# -----------------------------------------------------------------------------
+# Resource Limits
+# -----------------------------------------------------------------------------
+
+# UNLEASH_FEATURE_FLAGS_LIMIT=5000
+# UNLEASH_PROJECTS_LIMIT=500
+# UNLEASH_ENVIRONMENTS_LIMIT=50
+# UNLEASH_API_TOKENS_LIMIT=2000
+# UNLEASH_SEGMENTS_LIMIT=300
+# UNLEASH_SEGMENT_VALUES_LIMIT=250
+# UNLEASH_STRATEGY_SEGMENTS_LIMIT=30
+# UNLEASH_CONSTRAINTS_LIMIT=30
+# UNLEASH_CONSTRAINT_VALUES_LIMIT=250
+# UNLEASH_FEATURE_ENVIRONMENT_STRATEGIES_LIMIT=30
+# UNLEASH_SIGNAL_ENDPOINTS_LIMIT=5
+# UNLEASH_SIGNAL_TOKENS_PER_ENDPOINT_LIMIT=5
+# UNLEASH_ACTION_SETS_PER_PROJECT_LIMIT=5
+# UNLEASH_ACTION_SET_ACTIONS_LIMIT=10
+# UNLEASH_ACTION_SET_FILTERS_LIMIT=5
+# UNLEASH_ACTION_SET_FILTER_VALUES_LIMIT=25
+# UNLEASH_RELEASE_TEMPLATES_LIMIT=10
+
+# -----------------------------------------------------------------------------
+# Telemetry & Version Check
+# -----------------------------------------------------------------------------
+
+# Send anonymous usage data to Unleash (opt-out)
+SEND_TELEMETRY=true
+
+# Check for new Unleash versions
+CHECK_VERSION=true
+# UNLEASH_VERSION_URL=https://version.unleash.run
+
+# -----------------------------------------------------------------------------
+# Prometheus / Metrics
+# -----------------------------------------------------------------------------
+
+# Internal Prometheus scrape endpoint
+# PROMETHEUS_API=
+
+# Prometheus endpoint for impact metrics
+# PROMETHEUS_IMPACT_METRICS_API=
+
+# External Prometheus endpoint for impact metrics
+# EXTERNAL_PROMETHEUS_IMPACT_METRICS_API=
+
+# Daily metrics retention period in days (max 91)
+# DAILY_METRICS_STORAGE_DAYS=91
+
+# -----------------------------------------------------------------------------
+# Unleash Edge / Proxy
+# -----------------------------------------------------------------------------
+
+# URL of Unleash Edge instance (used to populate the edge URL in the UI)
+# EDGE_URL=
+
+# Shared secret between Unleash and Edge
+# EDGE_MASTER_KEY=
+
+# Client secret used when Unleash calls Edge
+# EDGE_CLIENT_SECRET=
+
+# -----------------------------------------------------------------------------
+# Security Headers & CSP
+# -----------------------------------------------------------------------------
+
+# Enable HTTP security headers (HSTS, X-Frame-Options, etc.)
+# SECURE_HEADERS=false
+
+# Access-Control-Max-Age in seconds
+# ACCESS_CONTROL_MAX_AGE=86400
+
+# Additional CSP allowed domains (comma-separated per directive)
+# CSP_ALLOWED_DEFAULT=
+# CSP_ALLOWED_FONT=
+# CSP_ALLOWED_STYLE=
+# CSP_ALLOWED_SCRIPT=
+# CSP_ALLOWED_IMG=
+# CSP_ALLOWED_CONNECT=
+# CSP_ALLOWED_MEDIA=
+# CSP_ALLOWED_OBJECT=
+# CSP_ALLOWED_FRAME=
+
+# -----------------------------------------------------------------------------
+# Import / Export
+# -----------------------------------------------------------------------------
+
+# Automatically import a feature toggle export file on startup
+# IMPORT_FILE=
+# IMPORT_PROJECT=default
+# IMPORT_ENVIRONMENT=development
+
+# -----------------------------------------------------------------------------
+# Misc / Advanced
+# -----------------------------------------------------------------------------
+
+# Comma-separated list of environments to enable on startup
+# ENABLED_ENVIRONMENTS=
+
+# OpenAPI (Swagger) UI
+# ENABLE_OAS=true
+
+# Enable per-request logging (verbose; useful for debugging)
+# REQUEST_LOGGER_ENABLE=false
+
+# Graceful shutdown
+# GRACEFUL_SHUTDOWN_ENABLE=true
+# GRACEFUL_SHUTDOWN_TIMEOUT=1000
+
+# Server keep-alive timeout in seconds
+# SERVER_KEEPALIVE_TIMEOUT=15
+
+# Disable gzip compression on responses
+# SERVER_DISABLE_COMPRESSION=false
+
+# Cache client features for performance
+# CLIENT_FEATURE_CACHING_ENABLED=true
+# CLIENT_FEATURE_CACHING_MAXAGE=3600000
+
+# OpenAI API key (used for AI-assisted features, if applicable)
+# OPENAI_API_KEY=
+
+# Days before a user is considered inactive
+# USER_INACTIVITY_THRESHOLD_IN_DAYS=180
+
+# Disable creation or editing of custom strategies
+# UNLEASH_DISABLE_CUSTOM_STRATEGY_CREATION=false
+# UNLEASH_DISABLE_CUSTOM_STRATEGY_EDITING=false
+
+# Encryption keys (used for sensitive data at rest)
+# UNLEASH_ENCRYPTION_KEY=
+# UNLEASH_ENCRYPTION_IV=
+
+# -----------------------------------------------------------------------------
+# Test environment
+# -----------------------------------------------------------------------------
+
+# TEST_DATABASE_URL=postgres://unleash_user:password@localhost:5432/unleash_test

--- a/contributing/CONTRIBUTING.md
+++ b/contributing/CONTRIBUTING.md
@@ -105,7 +105,13 @@ You'll need:
    docker start postgres
    ```
 
-4. **Start Unleash.** Run the below command and Unleash will start up and try to connect to the database. On a successful connection it will also configure the database.
+4. **Configure your environment.** Copy `.env.example` to `.env` and adjust any values for your setup:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+5. **Start Unleash.** Run the below command and Unleash will start up and try to connect to the database. On a successful connection it will also configure the database.
 
    ```bash
    pnpm dev


### PR DESCRIPTION
## About the changes
The project was missing a .env.example, so new contributors had to read through create-config.ts to figure out what to set.

This adds one. All variables are grouped by area, required ones are uncommented with working defaults, and optional ones are commented out with their defaults shown inline.

## Discussion points
I tried to cover everything, but if I missed anything, let me know and I’ll update it.