### PR TITLE
feat: startup probe

### DIFF
--- a/src/lib/features/frontend-api/frontend-api-service.ts
+++ b/src/lib/features/frontend-api/frontend-api-service.ts
@@ -78,6 +78,10 @@ export class FrontendApiService {
         this.globalFrontendApiCache = globalFrontendApiCache;
     }
 
+    isCacheReady(): boolean {
+        return this.globalFrontendApiCache.getStatus() !== 'starting';
+    }
+
     async getFrontendApiFeatures(
         token: IApiUser,
         context: Context,

--- a/src/lib/features/frontend-api/global-frontend-api-cache.ts
+++ b/src/lib/features/frontend-api/global-frontend-api-cache.ts
@@ -37,6 +37,10 @@ export class GlobalFrontendApiCache extends EventEmitter {
 
     private status: GlobalFrontendApiCacheState = 'starting';
 
+    getStatus(): GlobalFrontendApiCacheState {
+        return this.status;
+    }
+
     constructor(
         config: Config,
         segmentReadModel: ISegmentReadModel,

--- a/src/lib/openapi/spec/index.ts
+++ b/src/lib/openapi/spec/index.ts
@@ -201,6 +201,7 @@ export * from './signup-data-schema.js';
 export * from './sort-order-schema.js';
 export * from './splash-request-schema.js';
 export * from './splash-response-schema.js';
+export * from './started-check-schema.js';
 export * from './strategies-schema.js';
 export * from './strategy-schema.js';
 export * from './strategy-variant-schema.js';

--- a/src/lib/openapi/spec/started-check-schema.ts
+++ b/src/lib/openapi/spec/started-check-schema.ts
@@ -1,0 +1,22 @@
+import type { FromSchema } from 'json-schema-to-ts';
+
+export const startedCheckSchema = {
+    $id: '#/components/schemas/startedCheckSchema',
+    type: 'object',
+    description:
+        'Used by service orchestrators to decide whether this Unleash instance has completed startup and is ready to serve traffic.',
+    additionalProperties: false,
+    required: ['health'],
+    properties: {
+        health: {
+            description:
+                'The startup state of this Unleash instance. GOOD if the server has completed initial cache warming and is ready to serve traffic. If the server is still starting you will get an unsuccessful http response.',
+            type: 'string',
+            enum: ['GOOD'],
+            example: 'GOOD',
+        },
+    },
+    components: {},
+} as const;
+
+export type StartedCheckSchema = FromSchema<typeof startedCheckSchema>;

--- a/src/lib/routes/index.ts
+++ b/src/lib/routes/index.ts
@@ -10,6 +10,7 @@ import ClientApi from './client-api/index.js';
 
 import { ReadyCheckController } from './ready-check.js';
 import { HealthCheckController } from './health-check.js';
+import { StartedCheckController } from './started-check.js';
 import FrontendAPIController from '../features/frontend-api/frontend-api-controller.js';
 import EdgeController from './edge-api/index.js';
 import { PublicInviteController } from './public-invite.js';
@@ -31,6 +32,10 @@ class IndexRouter extends Controller {
             new ReadyCheckController(config, services, db).router,
         );
         this.use('/health', new HealthCheckController(config, services).router);
+        this.use(
+            '/started',
+            new StartedCheckController(config, services).router,
+        );
         this.use(
             '/invite',
             new PublicInviteController(config, services).router,

--- a/src/lib/routes/started-check.ts
+++ b/src/lib/routes/started-check.ts
@@ -1,0 +1,56 @@
+import type { Request, Response } from 'express';
+import type { IUnleashConfig } from '../types/option.js';
+import type { IUnleashServices } from '../services/index.js';
+
+import Controller from './controller.js';
+import { NONE } from '../types/permissions.js';
+import { createResponseSchema } from '../openapi/util/create-response-schema.js';
+import type { StartedCheckSchema } from '../openapi/spec/started-check-schema.js';
+import { emptyResponse } from '../server-impl.js';
+import type { FrontendApiService } from '../features/frontend-api/frontend-api-service.js';
+
+export class StartedCheckController extends Controller {
+    private frontendApiService: FrontendApiService;
+
+    constructor(
+        config: IUnleashConfig,
+        {
+            openApiService,
+            frontendApiService,
+        }: Pick<IUnleashServices, 'openApiService' | 'frontendApiService'>,
+    ) {
+        super(config);
+        this.frontendApiService = frontendApiService;
+
+        this.route({
+            method: 'get',
+            path: '',
+            handler: this.getStarted,
+            permission: NONE,
+            middleware: [
+                openApiService.validPath({
+                    tags: ['Operational'],
+                    operationId: 'getStarted',
+                    summary: 'Get instance startup status',
+                    description:
+                        'This operation returns information about whether this Unleash instance has completed startup (initial cache warming) and is ready to serve traffic. Typically used as a Kubernetes startup probe.',
+                    responses: {
+                        200: createResponseSchema('startedCheckSchema'),
+                        503: emptyResponse,
+                    },
+                }),
+            ],
+        });
+    }
+
+    async getStarted(
+        _: Request,
+        res: Response<StartedCheckSchema>,
+    ): Promise<void> {
+        if (this.frontendApiService.isCacheReady()) {
+            res.status(200).json({ health: 'GOOD' });
+        } else {
+            res.status(503).end();
+        }
+    }
+}


### PR DESCRIPTION
## About the changes

Adds a `/started` endpoint intended for use as a Kubernetes startup probe. 

The endpoint checks whether the global frontend API cache has completed its initial warm-up:
- Returns `200 {"health":"GOOD"}` once the cache is ready
- Returns `503` while still warming up

The frontend API cache is the slowest one-time initialization in the startup path, making it the right signal for
"instance is done booting." DB connectivity and ongoing health are already covered by `/ready` and `/health`
respectively.

### K8s probe mapping

| Probe | Endpoint | Purpose |
|-------|----------|---------|
| Startup | `/started` | Gates other probes until one-time init completes |
| Liveness | `/health` | Process is alive and not hung |
| Readiness | `/ready` | Can serve traffic (DB reachable) |

### Important files

- `src/lib/routes/started-check.ts` — new controller
- `src/lib/openapi/spec/started-check-schema.ts` — OpenAPI schema
- `src/lib/features/frontend-api/frontend-api-service.ts` — `isCacheReady()` method
- `src/lib/features/frontend-api/global-frontend-api-cache.ts` — `getStatus()` accessor
