### PR TITLE
chore: update react router step 1: relativeSplatPath

### DIFF
--- a/frontend/src/component/project/Project/ProjectSettings/ProjectSettings.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectSettings.tsx
@@ -22,6 +22,7 @@ import { Box, styled } from '@mui/material';
 import { ProjectActions } from './ProjectActions/ProjectActions.tsx';
 import { useUiFlag } from 'hooks/useUiFlag';
 import { ProjectContextFields } from './ProjectContextFields.tsx';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam.ts';
 
 const StyledBadgeContainer = styled(Box)({
     marginLeft: 'auto',
@@ -33,6 +34,7 @@ export const ProjectSettings = () => {
     const location = useLocation();
     const { isPro, isEnterprise } = useUiConfig();
     const navigate = useNavigate();
+    const projectId = useRequiredPathParam('projectId');
 
     const actionsEnabled = useUiFlag('automatedActions');
 
@@ -93,13 +95,7 @@ export const ProjectSettings = () => {
         });
     }
 
-    const settings = '/settings';
-    const settingsIndex = location.pathname.lastIndexOf(settings);
-    const basePath =
-        settingsIndex >= 0
-            ? location.pathname.slice(0, settingsIndex)
-            : location.pathname;
-    const toTabPath = (id: string) => `${basePath}${settings}/${id}`;
+    const toTabPath = (id: string) => `/projects/${projectId}/settings/${id}`;
     const onChange = (tab: ITab) => {
         navigate(toTabPath(tab.id));
     };
@@ -110,7 +106,7 @@ export const ProjectSettings = () => {
             value={
                 tabs.find(
                     ({ id }) =>
-                        id && location.pathname?.includes(`${settings}/${id}`),
+                        id && location.pathname?.includes(`/settings/${id}`),
                 )?.id || tabs[0].id
             }
             onChange={onChange}

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectSettings.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectSettings.tsx
@@ -94,7 +94,11 @@ export const ProjectSettings = () => {
     }
 
     const settings = '/settings';
-    const [basePath] = location.pathname.split(settings);
+    const settingsIndex = location.pathname.lastIndexOf(settings);
+    const basePath =
+        settingsIndex >= 0
+            ? location.pathname.slice(0, settingsIndex)
+            : location.pathname;
     const toTabPath = (id: string) => `${basePath}${settings}/${id}`;
     const onChange = (tab: ITab) => {
         navigate(toTabPath(tab.id));

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectSettings.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectSettings.tsx
@@ -93,8 +93,11 @@ export const ProjectSettings = () => {
         });
     }
 
+    const settings = '/settings';
+    const [basePath] = location.pathname.split(settings);
+    const toTabPath = (id: string) => `${basePath}${settings}/${id}`;
     const onChange = (tab: ITab) => {
-        navigate(tab.id);
+        navigate(toTabPath(tab.id));
     };
 
     return (
@@ -103,7 +106,7 @@ export const ProjectSettings = () => {
             value={
                 tabs.find(
                     ({ id }) =>
-                        id && location.pathname?.includes(`/settings/${id}`),
+                        id && location.pathname?.includes(`${settings}/${id}`),
                 )?.id || tabs[0].id
             }
             onChange={onChange}
@@ -129,7 +132,7 @@ export const ProjectSettings = () => {
                 <Route path='actions/*' element={<ProjectActions />} />
                 <Route
                     path='*'
-                    element={<Navigate replace to={tabs[0].id} />}
+                    element={<Navigate replace to={toTabPath(tabs[0].id)} />}
                 />
             </Routes>
         </VerticalTabs>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -49,7 +49,12 @@ const ApplicationRoot = () => {
     return (
         <UIProviderContainer>
             <AccessProvider>
-                <BrowserRouter basename={basePath}>
+                <BrowserRouter
+                    future={{
+                        v7_relativeSplatPath: true,
+                    }}
+                    basename={basePath}
+                >
                     <QueryParamProvider adapter={ReactRouter6Adapter}>
                         <ThemeProvider>
                             <AnnouncerProvider>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -26,11 +26,13 @@ import { useRecordUIErrorApi } from 'hooks/api/actions/useRecordUIErrorApi/useRe
 import { HighlightProvider } from 'component/common/Highlight/HighlightProvider';
 import { UnleashFlagProvider } from 'component/providers/UnleashFlagProvider/UnleashFlagProvider';
 import { WelcomeDialogProvider } from 'component/personalDashboard/WelcomeDialogProvider.tsx';
+import { useUiFlag } from 'hooks/useUiFlag.ts';
 
 window.global ||= window;
 
 const ApplicationRoot = () => {
     const { recordUiError } = useRecordUIErrorApi();
+    const useRelativeSplatPath = useUiFlag('reactRouter_v7_relativeSplatPath');
 
     const sendErrorToApi = async (
         error: Error,
@@ -50,9 +52,7 @@ const ApplicationRoot = () => {
         <UIProviderContainer>
             <AccessProvider>
                 <BrowserRouter
-                    future={{
-                        v7_relativeSplatPath: true,
-                    }}
+                    future={{ v7_relativeSplatPath: useRelativeSplatPath }}
                     basename={basePath}
                 >
                     <QueryParamProvider adapter={ReactRouter6Adapter}>

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -96,6 +96,7 @@ export type UiFlags = {
     onboardingConnectSDKNewDialog?: boolean;
     logRocketEnabled?: boolean;
     newProjectList?: boolean;
+    reactRouter_v7_relativeSplatPath?: boolean;
 };
 
 export interface IVersionInfo {

--- a/frontend/src/utils/testRenderer.tsx
+++ b/frontend/src/utils/testRenderer.tsx
@@ -48,7 +48,11 @@ export const render = (
             <UIProviderContainer>
                 <FeedbackProvider>
                     <AccessProviderMock permissions={permissions}>
-                        <BrowserRouter>
+                        <BrowserRouter
+                            future={{
+                                v7_relativeSplatPath: true,
+                            }}
+                        >
                             <QueryParamProvider adapter={ReactRouter6Adapter}>
                                 <ThemeProvider>
                                     <AnnouncerProvider>

--- a/frontend/src/utils/testRenderer.tsx
+++ b/frontend/src/utils/testRenderer.tsx
@@ -48,11 +48,7 @@ export const render = (
             <UIProviderContainer>
                 <FeedbackProvider>
                     <AccessProviderMock permissions={permissions}>
-                        <BrowserRouter
-                            future={{
-                                v7_relativeSplatPath: true,
-                            }}
-                        >
+                        <BrowserRouter future={{ v7_relativeSplatPath: true }}>
                             <QueryParamProvider adapter={ReactRouter6Adapter}>
                                 <ThemeProvider>
                                     <AnnouncerProvider>

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -78,6 +78,7 @@ export type IFlagKey =
     | 'accessOverviewRework'
     | 'onboardingConnectSDKNewDialog'
     | 'logRocketEnabled'
+    | 'reactRouter_v7_relativeSplatPath'
     | 'newProjectList';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
@@ -355,6 +356,10 @@ const flags: IFlags = {
     ),
     newProjectList: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_NEW_PROJECT_LIST,
+        false,
+    ),
+    reactRouter_v7_relativeSplatPath: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_REACT_ROUTER_V7_RELATIVE_SPLAT_PATH,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -61,6 +61,7 @@ process.nextTick(async () => {
                         onlyFeatureTokensWithFeatureAPIs: false,
                         accessOverviewRework: true,
                         onboardingConnectSDKNewDialog: true,
+                        reactRouter_v7_relativeSplatPath: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Part of the gradual migration to React Router v7. Opts the app into v7's `relativeSplatPath` behavior behind an internal flag (`reactRouter_v7_relativeSplatPath`) so we can roll it out controllably and fall back if something regresses in production.

## What this does

- Adds a new internal feature flag `reactRouter_v7_relativeSplatPath` (defaults off in OSS, on in dev).
- Wires the flag to `<BrowserRouter future={{ v7_relativeSplatPath }}>` in `frontend/src/index.tsx`.
- Pins the flag to `true` in `testRenderer.tsx` so tests run under the new behavior.
- Fixes one site that broke under the new resolution semantics: the project-settings vertical tabs in `ProjectSettings.tsx`. Both the `onChange` handler and the catch-all `<Navigate>` were passing relative tab IDs (`'access'`, `''`, etc.) into `navigate`/`<Navigate>`. Under v7 these append to the current URL instead of resolving against the route mount; switched them to absolute paths derived from `location.pathname`.

## Why

Under v7, `navigate('access')` from `/projects/X/settings/segments` resolves to `/projects/X/settings/segments/access` (appending) rather than `/projects/X/settings/access` (replacing). This is the v7-correct behavior — splat captures are no longer silently stripped during relative-path resolution — but it surfaced a latent bug in the settings tab navigation that was relying on the old (buggy) v6 behavior.

## Migration reference

- React Router v6 → v7 upgrade guide for this flag: https://reactrouter.com/upgrading/v6#v7_relativesplatpath
- `useResolvedPath` docs explaining the resolution change: https://reactrouter.com/6.30.3/hooks/use-resolved-path#splat-paths