### PR TITLE
feat: include flag-gated `onboardingStatus` on /api/admin/projects

### DIFF
--- a/src/lib/features/onboarding/onboarding-read-model-type.ts
+++ b/src/lib/features/onboarding/onboarding-read-model-type.ts
@@ -1,6 +1,6 @@
-import type { ProjectOverviewSchema } from '../../openapi/index.js';
+import type { OnboardingStatusSchema } from '../../openapi/index.js';
 
-export type OnboardingStatus = ProjectOverviewSchema['onboardingStatus'];
+export type OnboardingStatus = OnboardingStatusSchema;
 
 /**
  * All the values are in seconds

--- a/src/lib/features/project/project-read-model-type.ts
+++ b/src/lib/features/project/project-read-model-type.ts
@@ -1,4 +1,5 @@
 import type { ProjectMode } from '../../types/index.js';
+import type { OnboardingStatus } from '../onboarding/onboarding-read-model-type.js';
 import type { IProjectQuery, IProjectsQuery } from './project-store-type.js';
 
 export type ProjectForUi = {
@@ -15,6 +16,7 @@ export type ProjectForUi = {
     featureCount: number;
     lastReportedFlagUsage: Date | null;
     lastUpdatedAt: Date | null;
+    onboardingStatus?: OnboardingStatus;
 };
 
 export type ProjectForInsights = {

--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -122,7 +122,7 @@ test('should have default project', async () => {
 });
 
 describe('should list all projects', () => {
-    test('returns all projects with member counts', async () => {
+    test('includes member count in the project payload', async () => {
         const project = {
             id: 'test-list',
             name: 'New project',

--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -121,19 +121,49 @@ test('should have default project', async () => {
     expect(project.id).toBe('default');
 });
 
-test('should list all projects', async () => {
-    const project = {
-        id: 'test-list',
-        name: 'New project',
-        description: 'Blah',
-        mode: 'open' as const,
-        defaultStickiness: 'default',
-    };
+describe('should list all projects', () => {
+    test('returns all projects with member counts', async () => {
+        const project = {
+            id: 'test-list',
+            name: 'New project',
+            description: 'Blah',
+            mode: 'open' as const,
+            defaultStickiness: 'default',
+        };
 
-    await projectService.createProject(project, user, auditUser);
-    const projects = await projectService.getProjects();
-    expect(projects).toHaveLength(2);
-    expect(projects.find((p) => p.name === project.name)?.memberCount).toBe(1);
+        await projectService.createProject(project, user, auditUser);
+        const projects = await projectService.getProjects();
+        expect(projects).toHaveLength(2);
+        expect(projects.find((p) => p.name === project.name)?.memberCount).toBe(
+            1,
+        );
+    });
+
+    test('includes onboarding status when flag is enabled', async () => {
+        const flagEnabledConfig = createTestConfig({
+            getLogger,
+            experimental: { flags: { newProjectList: true } },
+        });
+        const flagEnabledProjectService = createProjectService(
+            db.rawDatabase,
+            flagEnabledConfig,
+        );
+
+        const project = {
+            id: 'onboarding-status',
+            name: 'Onboarding status project',
+            description: 'Blah',
+            mode: 'open' as const,
+            defaultStickiness: 'default',
+        };
+
+        await flagEnabledProjectService.createProject(project, user, auditUser);
+        const projects = await flagEnabledProjectService.getProjects();
+
+        expect(projects.find((p) => p.id === project.id)).toMatchObject({
+            onboardingStatus: { status: 'onboarding-started' },
+        });
+    });
 });
 
 test('should create new project', async () => {

--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -139,12 +139,12 @@ describe('should list all projects', () => {
         );
     });
 
-    test('includes onboarding status when flag is enabled', async () => {
+    test("includes onboarding status with 'newProjectList' flag enabled", async () => {
         const flagEnabledConfig = createTestConfig({
             getLogger,
             experimental: { flags: { newProjectList: true } },
         });
-        const flagEnabledProjectService = createProjectService(
+        const projectServiceWithFlag = createProjectService(
             db.rawDatabase,
             flagEnabledConfig,
         );
@@ -157,11 +157,14 @@ describe('should list all projects', () => {
             defaultStickiness: 'default',
         };
 
-        await flagEnabledProjectService.createProject(project, user, auditUser);
-        const projects = await flagEnabledProjectService.getProjects();
+        await projectServiceWithFlag.createProject(project, user, auditUser);
+        const projects = await projectServiceWithFlag.getProjects();
+        const projectOnboardingStatus = projects.find(
+            (p) => p.id === project.id,
+        )?.onboardingStatus;
 
-        expect(projects.find((p) => p.id === project.id)).toMatchObject({
-            onboardingStatus: { status: 'onboarding-started' },
+        expect(projectOnboardingStatus).toMatchObject({
+            status: 'onboarding-started',
         });
     });
 });

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -233,10 +233,24 @@ export default class ProjectService {
         query?: IProjectQuery & IProjectsQuery,
         userId?: number,
     ): Promise<ProjectForUi[]> {
-        const projects = await this.projectReadModel.getProjectsForAdminUi(
+        const allProjects = await this.projectReadModel.getProjectsForAdminUi(
             query,
             userId,
         );
+
+        let projects = allProjects;
+        if (userId) {
+            const projectAccess =
+                await this.privateProjectChecker.getUserAccessibleProjects(
+                    userId,
+                );
+
+            if (projectAccess.mode !== 'all') {
+                projects = allProjects.filter((project) =>
+                    projectAccess.projects.includes(project.id),
+                );
+            }
+        }
 
         if (this.flagResolver.isEnabled('newProjectList')) {
             const projectIds = projects.map((p) => p.id);
@@ -249,20 +263,6 @@ export default class ProjectService {
             }
         }
 
-        if (userId) {
-            const projectAccess =
-                await this.privateProjectChecker.getUserAccessibleProjects(
-                    userId,
-                );
-
-            if (projectAccess.mode === 'all') {
-                return projects;
-            } else {
-                return projects.filter((project) =>
-                    projectAccess.projects.includes(project.id),
-                );
-            }
-        }
         return projects;
     }
 

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -238,6 +238,17 @@ export default class ProjectService {
             userId,
         );
 
+        if (this.flagResolver.isEnabled('newProjectList')) {
+            const projectIds = projects.map((p) => p.id);
+            const onboardingStatuses =
+                await this.onboardingReadModel.getOnboardingStatusesForProjects(
+                    projectIds,
+                );
+            for (const project of projects) {
+                project.onboardingStatus = onboardingStatuses.get(project.id);
+            }
+        }
+
         if (userId) {
             const projectAccess =
                 await this.privateProjectChecker.getUserAccessibleProjects(

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -253,6 +253,7 @@ export default class ProjectService {
         }
 
         if (this.flagResolver.isEnabled('newProjectList')) {
+            //TODO: update project-schema when removing this flag
             const projectIds = projects.map((p) => p.id);
             const onboardingStatuses =
                 await this.onboardingReadModel.getOnboardingStatusesForProjects(

--- a/src/lib/openapi/spec/index.ts
+++ b/src/lib/openapi/spec/index.ts
@@ -130,6 +130,7 @@ export * from './maintenance-schema.js';
 export * from './me-schema.js';
 export * from './metric-query-schema.js';
 export * from './name-schema.js';
+export * from './onboarding-status-schema.js';
 export * from './outdated-sdks-schema.js';
 export * from './override-schema.js';
 export * from './parameters-schema.js';

--- a/src/lib/openapi/spec/onboarding-status-schema.ts
+++ b/src/lib/openapi/spec/onboarding-status-schema.ts
@@ -1,0 +1,42 @@
+import type { FromSchema } from 'json-schema-to-ts';
+
+export const onboardingStatusSchema = {
+    $id: '#/components/schemas/onboardingStatusSchema',
+    type: 'object',
+    description: 'The current onboarding status of a project.',
+    example: { status: 'first-flag-created', feature: 'my-feature-flag' },
+    oneOf: [
+        {
+            type: 'object',
+            properties: {
+                status: {
+                    type: 'string',
+                    enum: ['onboarding-started', 'sdk-connected', 'onboarded'],
+                    example: 'onboarding-started',
+                },
+            },
+            required: ['status'],
+            additionalProperties: false,
+        },
+        {
+            type: 'object',
+            properties: {
+                status: {
+                    type: 'string',
+                    enum: ['first-flag-created'],
+                    example: 'first-flag-created',
+                },
+                feature: {
+                    type: 'string',
+                    description: 'The name of the feature flag',
+                    example: 'my-feature-flag',
+                },
+            },
+            required: ['status', 'feature'],
+            additionalProperties: false,
+        },
+    ],
+    components: {},
+} as const;
+
+export type OnboardingStatusSchema = FromSchema<typeof onboardingStatusSchema>;

--- a/src/lib/openapi/spec/personal-dashboard-project-details-schema.ts
+++ b/src/lib/openapi/spec/personal-dashboard-project-details-schema.ts
@@ -1,6 +1,6 @@
 import type { FromSchema } from 'json-schema-to-ts';
 import { projectSchema } from './project-schema.js';
-import { projectOverviewSchema } from './project-overview-schema.js';
+import { onboardingStatusSchema } from './onboarding-status-schema.js';
 
 export const personalDashboardProjectDetailsSchema = {
     $id: '#/components/schemas/personalDashboardProjectDetailsSchema',
@@ -91,7 +91,9 @@ export const personalDashboardProjectDetailsSchema = {
                 },
             },
         },
-        onboardingStatus: projectOverviewSchema.properties.onboardingStatus,
+        onboardingStatus: {
+            $ref: '#/components/schemas/onboardingStatusSchema',
+        },
         latestEvents: {
             type: 'array',
             description: 'The latest events for the project.',
@@ -168,7 +170,9 @@ export const personalDashboardProjectDetailsSchema = {
         },
     },
     components: {
-        schemas: {},
+        schemas: {
+            onboardingStatusSchema,
+        },
     },
 } as const;
 

--- a/src/lib/openapi/spec/project-overview-schema.ts
+++ b/src/lib/openapi/spec/project-overview-schema.ts
@@ -163,7 +163,6 @@ export const projectOverviewSchema = {
         },
         onboardingStatus: {
             $ref: '#/components/schemas/onboardingStatusSchema',
-            description: 'The current onboarding status of the project.',
         },
     },
     components: {

--- a/src/lib/openapi/spec/project-overview-schema.ts
+++ b/src/lib/openapi/spec/project-overview-schema.ts
@@ -23,6 +23,7 @@ import { releasePlanSafeguardSchema } from './release-plan-safeguard-schema.js';
 import { featureEnvironmentSafeguardSchema } from './feature-environment-safeguard-schema.js';
 import { metricQuerySchema } from './metric-query-schema.js';
 import { safeguardTriggerConditionSchema } from './safeguard-trigger-condition-schema.js';
+import { onboardingStatusSchema } from './onboarding-status-schema.js';
 
 export const projectOverviewSchema = {
     $id: '#/components/schemas/projectOverviewSchema',
@@ -161,42 +162,7 @@ export const projectOverviewSchema = {
                 '`true` if the project was favorited, otherwise `false`.',
         },
         onboardingStatus: {
-            type: 'object',
-            oneOf: [
-                {
-                    type: 'object',
-                    properties: {
-                        status: {
-                            type: 'string',
-                            enum: [
-                                'onboarding-started',
-                                'sdk-connected',
-                                'onboarded',
-                            ],
-                            example: 'onboarding-started',
-                        },
-                    },
-                    required: ['status'],
-                    additionalProperties: false,
-                },
-                {
-                    type: 'object',
-                    properties: {
-                        status: {
-                            type: 'string',
-                            enum: ['first-flag-created'],
-                            example: 'first-flag-created',
-                        },
-                        feature: {
-                            type: 'string',
-                            description: 'The name of the feature flag',
-                            example: 'my-feature-flag',
-                        },
-                    },
-                    required: ['status', 'feature'],
-                    additionalProperties: false,
-                },
-            ],
+            $ref: '#/components/schemas/onboardingStatusSchema',
             description: 'The current onboarding status of the project.',
         },
     },
@@ -226,6 +192,7 @@ export const projectOverviewSchema = {
             createFeatureNamingPatternSchema,
             featureTypeCountSchema,
             projectLinkTemplateSchema,
+            onboardingStatusSchema,
         },
     },
 } as const;

--- a/src/lib/openapi/spec/project-schema.ts
+++ b/src/lib/openapi/spec/project-schema.ts
@@ -1,4 +1,5 @@
 import type { FromSchema } from 'json-schema-to-ts';
+import { onboardingStatusSchema } from './onboarding-status-schema.js';
 
 export const projectSchema = {
     $id: '#/components/schemas/projectSchema',
@@ -193,8 +194,17 @@ export const projectSchema = {
                 },
             ],
         },
+        onboardingStatus: {
+            $ref: '#/components/schemas/onboardingStatusSchema',
+            description:
+                'Experimental. The current onboarding status of the project.',
+        },
     },
-    components: {},
+    components: {
+        schemas: {
+            onboardingStatusSchema,
+        },
+    },
 } as const;
 
 export type ProjectSchema = FromSchema<typeof projectSchema>;

--- a/src/lib/openapi/spec/project-schema.ts
+++ b/src/lib/openapi/spec/project-schema.ts
@@ -1,10 +1,12 @@
 import type { FromSchema } from 'json-schema-to-ts';
-import { onboardingStatusSchema } from './onboarding-status-schema.js';
 
+// TODO: when `newProjectList` is removed and `onboardingStatus` is stable here,
+// declare it as a property ($ref to onboardingStatusSchema) and flip
+// `additionalProperties` back to `false`.
 export const projectSchema = {
     $id: '#/components/schemas/projectSchema',
     type: 'object',
-    additionalProperties: false,
+    additionalProperties: true,
     required: ['id', 'name'],
     description:
         'A definition of the project used for projects listing purposes',
@@ -194,17 +196,8 @@ export const projectSchema = {
                 },
             ],
         },
-        onboardingStatus: {
-            $ref: '#/components/schemas/onboardingStatusSchema',
-            description:
-                'Experimental. The current onboarding status of the project.',
-        },
     },
-    components: {
-        schemas: {
-            onboardingStatusSchema,
-        },
-    },
+    components: {},
 } as const;
 
 export type ProjectSchema = FromSchema<typeof projectSchema>;


### PR DESCRIPTION
- Adds `onboardingStatus` to the `/api/admin/projects` response if the `newProjectList` feature flag is enabled (if it's not enabled, it's omitted). 
- Breaks out the onboarding status schema into its own file so it can be reused consistently (currently by `projectOverviewSchema` and `personalDashboardProjectDetailsSchema`)
- Sets `additionalProperties` to true in project-schema (used by `/api/admin/projects`) until `onboardingStatus` is stable

A left a few questions as comments to this PR, please take a look, I'd love input 🙏 