### PR TITLE
feat: check frontend API cache readiness before accepting traffic

### DIFF
--- a/src/lib/features/frontend-api/frontend-api-service.ts
+++ b/src/lib/features/frontend-api/frontend-api-service.ts
@@ -78,6 +78,10 @@ export class FrontendApiService {
         this.globalFrontendApiCache = globalFrontendApiCache;
     }
 
+    isCacheReady(): boolean {
+        return this.globalFrontendApiCache.isReady();
+    }
+
     async getFrontendApiFeatures(
         token: IApiUser,
         context: Context,

--- a/src/lib/features/frontend-api/frontend-api-service.ts
+++ b/src/lib/features/frontend-api/frontend-api-service.ts
@@ -82,6 +82,10 @@ export class FrontendApiService {
         return this.globalFrontendApiCache.isReady();
     }
 
+    async waitForCacheReady(): Promise<void> {
+        return this.globalFrontendApiCache.readyPromise;
+    }
+
     async getFrontendApiFeatures(
         token: IApiUser,
         context: Context,

--- a/src/lib/features/frontend-api/global-frontend-api-cache.ts
+++ b/src/lib/features/frontend-api/global-frontend-api-cache.ts
@@ -37,6 +37,8 @@ export class GlobalFrontendApiCache extends EventEmitter {
 
     private status: GlobalFrontendApiCacheState = 'starting';
 
+    public readyPromise: Promise<void>;
+
     constructor(
         config: Config,
         segmentReadModel: ISegmentReadModel,
@@ -49,7 +51,7 @@ export class GlobalFrontendApiCache extends EventEmitter {
         this.configurationRevisionService = configurationRevisionService;
         this.segmentReadModel = segmentReadModel;
         this.onUpdateRevisionEvent = this.onUpdateRevisionEvent.bind(this);
-        this.refreshData();
+        this.readyPromise = this.refreshData();
         this.configurationRevisionService.on(
             UPDATE_REVISION,
             this.onUpdateRevisionEvent,

--- a/src/lib/features/frontend-api/global-frontend-api-cache.ts
+++ b/src/lib/features/frontend-api/global-frontend-api-cache.ts
@@ -56,6 +56,10 @@ export class GlobalFrontendApiCache extends EventEmitter {
         );
     }
 
+    isReady(): boolean {
+        return this.status === 'ready' || this.status === 'updated';
+    }
+
     getSegment(id: number): Segment | undefined {
         return this.segments.find((segment) => segment.id === id);
     }

--- a/src/lib/routes/ready-check.ts
+++ b/src/lib/routes/ready-check.ts
@@ -10,20 +10,27 @@ import { NONE } from '../types/permissions.js';
 import { createResponseSchema } from '../openapi/util/create-response-schema.js';
 import type { ReadyCheckSchema } from '../openapi/spec/ready-check-schema.js';
 import { emptyResponse, parseEnvVarNumber } from '../server-impl.js';
+import type { FrontendApiService } from '../features/frontend-api/frontend-api-service.js';
 
 export class ReadyCheckController extends Controller {
     private logger: Logger;
 
     private db?: Db;
 
+    private frontendApiService: FrontendApiService;
+
     constructor(
         config: IUnleashConfig,
-        { openApiService }: Pick<IUnleashServices, 'openApiService'>,
+        {
+            openApiService,
+            frontendApiService,
+        }: Pick<IUnleashServices, 'openApiService' | 'frontendApiService'>,
         db?: Db,
     ) {
         super(config);
         this.logger = config.getLogger('ready-check.js');
         this.db = db;
+        this.frontendApiService = frontendApiService;
 
         this.route({
             method: 'get',
@@ -47,6 +54,11 @@ export class ReadyCheckController extends Controller {
     }
 
     async getReady(_: Request, res: Response<ReadyCheckSchema>): Promise<void> {
+        if (!this.frontendApiService.isCacheReady()) {
+            res.status(503).end();
+            return;
+        }
+
         if (this.config.checkDbOnReady && this.db) {
             try {
                 const timeoutMs = parseEnvVarNumber(

--- a/src/test/e2e/ready.e2e.test.ts
+++ b/src/test/e2e/ready.e2e.test.ts
@@ -9,11 +9,12 @@ describe('DB is up', () => {
     });
 
     test('when checkDb is disabled, returns ready', async () => {
-        const { request } = await setupAppWithCustomConfig(
+        const { request, services } = await setupAppWithCustomConfig(
             db.stores,
             undefined,
             db.rawDatabase,
         );
+        await services.frontendApiService.waitForCacheReady();
         await request
             .get('/ready')
             .expect('Content-Type', /json/)
@@ -22,20 +23,22 @@ describe('DB is up', () => {
     });
 
     test('when checkDb is enabled, returns ready', async () => {
-        const { request } = await setupAppWithCustomConfig(
+        const { request, services } = await setupAppWithCustomConfig(
             db.stores,
             { checkDbOnReady: true },
             db.rawDatabase,
         );
+        await services.frontendApiService.waitForCacheReady();
         await request.get('/ready').expect(200).expect('{"health":"GOOD"}');
     });
 
     test('fails fast when readiness query hangs', async () => {
-        const { request } = await setupAppWithCustomConfig(
+        const { request, services } = await setupAppWithCustomConfig(
             db.stores,
             { checkDbOnReady: true },
             db.rawDatabase,
         );
+        await services.frontendApiService.waitForCacheReady();
 
         const pool = db.rawDatabase.client.pool;
         const originalAcquire = pool.acquire.bind(pool);
@@ -77,11 +80,12 @@ describe('DB is down', () => {
     });
 
     test('when checkDb is disabled, returns readiness good', async () => {
-        const { request } = await setupAppWithCustomConfig(
+        const { request, services } = await setupAppWithCustomConfig(
             db.stores,
             undefined,
             db.rawDatabase,
         );
+        await services.frontendApiService.waitForCacheReady();
         await db.destroy();
         await request
             .get('/ready')
@@ -91,11 +95,12 @@ describe('DB is down', () => {
     });
 
     test('when checkDb is enabled, fails readiness check', async () => {
-        const { request } = await setupAppWithCustomConfig(
+        const { request, services } = await setupAppWithCustomConfig(
             db.stores,
             { checkDbOnReady: true },
             db.rawDatabase,
         );
+        await services.frontendApiService.waitForCacheReady();
         await db.destroy();
         await request.get('/ready').expect(503);
     });


### PR DESCRIPTION
- Adds a cache readiness check to the `/api/health/ready` endpoint that returns 503 until the `GlobalFrontendApiCache` has finished its initial load

- The check is a pure in-memory field read, so it adds no DB or network overhead — and short-circuits before the DB connectivity check, reducing pool pressure during startup