### PR TITLE
chore: include patches directory in docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,4 @@ frontend/node_modules
 node_modules
 !docker/index.js
 !.pnpm
+!patches


### PR DESCRIPTION
To allow package patches to be included in the docker build.