### PR TITLE
chore: simple logging of network requests

### DIFF
--- a/frontend/src/component/providers/LogRocketProvider/LogRocketRunner.tsx
+++ b/frontend/src/component/providers/LogRocketProvider/LogRocketRunner.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import LogRocket from 'logrocket';
+import { scrubUrl } from './scrubUrl';
 
 type Props = {
     appId: string;
@@ -17,7 +18,20 @@ const LogRocketRunner = ({ appId, clientId, userId }: Props) => {
                 },
                 shouldCaptureIP: false,
                 network: {
-                    requestSanitizer: () => null,
+                    requestSanitizer: ({ reqId, method, url }) => ({
+                        reqId,
+                        method,
+                        url: scrubUrl(url),
+                        headers: {},
+                        body: undefined,
+                    }),
+                    responseSanitizer: ({ reqId, method, status }) => ({
+                        reqId,
+                        method,
+                        status,
+                        headers: {},
+                        body: undefined,
+                    }),
                 },
             });
             LogRocket.identify(`${clientId}:${userId}`, {

--- a/frontend/src/component/providers/LogRocketProvider/scrubUrl.test.ts
+++ b/frontend/src/component/providers/LogRocketProvider/scrubUrl.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { scrubUrl } from './scrubUrl';
+
+describe('scrubUrl', () => {
+    it('masks segments after the first 3 character-by-character', () => {
+        expect(
+            scrubUrl('/api/admin/projects/my-project/features/my-flag'),
+        ).toBe('/api/admin/projects/**********/********/*******');
+    });
+
+    it('masks query param values, preserving keys', () => {
+        expect(scrubUrl('/api/admin/features?project=foo&tag=bar')).toBe(
+            '/api/admin/features?project=***&tag=***',
+        );
+    });
+
+    it('handles absolute URLs by discarding the host', () => {
+        expect(
+            scrubUrl('https://app.getunleash.io/api/admin/projects/secret'),
+        ).toBe('/api/admin/projects/******');
+    });
+
+    it('returns what is available when path has fewer than 3 segments', () => {
+        expect(scrubUrl('/api/admin')).toBe('/api/admin');
+        expect(scrubUrl('/api')).toBe('/api');
+    });
+
+    it('returns / for root path', () => {
+        expect(scrubUrl('/')).toBe('/');
+    });
+
+    it('returns exactly 3 segments unchanged when path has exactly 3', () => {
+        expect(scrubUrl('/api/admin/features')).toBe('/api/admin/features');
+    });
+});

--- a/frontend/src/component/providers/LogRocketProvider/scrubUrl.ts
+++ b/frontend/src/component/providers/LogRocketProvider/scrubUrl.ts
@@ -1,0 +1,33 @@
+const mask = (s: string) => '*'.repeat(s.length);
+
+const MAX_CACHE = 300;
+const cache = new Map<string, string>();
+
+const setCached = (url: string, result: string): string => {
+    if (cache.size >= MAX_CACHE) {
+        cache.delete(cache.keys().next().value!);
+    }
+    cache.set(url, result);
+    return result;
+};
+
+export const scrubUrl = (url: string): string => {
+    const cached = cache.get(url);
+    if (cached !== undefined) return cached;
+
+    const { pathname, search } = new URL(url, 'http://x');
+
+    const segments = pathname.split('/').filter(Boolean);
+    const scrubbedPath = segments.map((segment, i) =>
+        i < 3 ? segment : mask(segment),
+    );
+    const path = scrubbedPath.length > 0 ? `/${scrubbedPath.join('/')}` : '/';
+
+    if (!search) return setCached(url, path);
+
+    const params = new URLSearchParams(search);
+    const scrubbed = new URLSearchParams(
+        [...params].map(([k, v]) => [k, mask(v)]),
+    );
+    return setCached(url, `${path}?${scrubbed.toString()}`);
+};


### PR DESCRIPTION
I think we can log some basic network data to give us at least an idea if user encountered a 500 error anywhere. 

I've tried to be really defensive. 
* log request method
* log response status code
* Log url but mask anything that could contain any sensitive data. 
