### PR TITLE
fix: avoid invalid html nesting and a  rather obnoxious console error

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
@@ -117,6 +117,8 @@ export const FeatureOverviewEnvironment = ({
                         strategyCount: environment.strategies?.length ?? 0,
                         releasePlanCount: environment.releasePlans?.length ?? 0,
                     }}
+                    component={hasActivations ? undefined : 'div'}
+                    role={hasActivations ? undefined : 'none'}
                     environmentId={environment.name}
                     projectId={projectId}
                     featureId={featureId}


### PR DESCRIPTION
Removes invalid button in button nesting. This is because we render an "add strategy" button if there are no strategies. However, MUI still renders the accordion header as a button (even though it's not targetable or particularly clickable). This change makes sure we override both the role and the component if there are no strategies.

Fixes this error:
<img width="1421" height="1207" alt="image" src="https://github.com/user-attachments/assets/100b650f-c1e5-41cf-b21e-fb7d7eb99e9e" />
