### PR TITLE
chore: improving some points made by UX on quirks in UI

### DIFF
--- a/frontend/src/component/admin/users/AccessOverview/AccessOverviewAccordion/NewAccessOverviewList.tsx
+++ b/frontend/src/component/admin/users/AccessOverview/AccessOverviewAccordion/NewAccessOverviewList.tsx
@@ -12,7 +12,6 @@ import type {
 } from 'interfaces/permissions';
 import type { IRole } from 'interfaces/role';
 import type { IGroup } from 'interfaces/group';
-import { useGroup } from 'hooks/api/getters/useGroup/useGroup';
 
 export type IAccessOverviewPermissionCategory = Omit<
     IPermissionCategory,
@@ -20,20 +19,6 @@ export type IAccessOverviewPermissionCategory = Omit<
 > & {
     permissions: IAccessOverviewPermission[];
 };
-
-const StyledDescription = styled('div', {
-    shouldForwardProp: (prop) => prop !== 'tooltip',
-})<{ tooltip?: boolean }>(({ theme, tooltip }) => ({
-    width: '100%',
-    maxWidth: theme.spacing(50),
-    padding: tooltip ? theme.spacing(1) : theme.spacing(3),
-    backgroundColor: tooltip
-        ? theme.palette.background.paper
-        : theme.palette.neutral.light,
-    color: theme.palette.text.secondary,
-    fontSize: theme.fontSizes.smallBody,
-    borderRadius: tooltip ? 0 : theme.shape.borderRadiusMedium,
-}));
 
 const StyledSupervisedUserCircle = styled(SupervisedUserCircle)(
     ({ theme }) => ({
@@ -48,12 +33,26 @@ const StyledRoleHeader = styled('p')(({ theme }) => ({
     color: theme.palette.text.primary,
     fontSize: theme.fontSizes.bodySize,
     fontWeight: theme.fontWeight.bold,
+    margin: 0,
+}));
+
+const StyledRoleSource = styled('span')(({ theme }) => ({
+    fontSize: theme.fontSizes.smallBody,
+    color: theme.palette.text.secondary,
+    paddingLeft: theme.spacing(3),
+}));
+
+const StyledRoleItem = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.25),
+    padding: theme.spacing(0.5, 0),
 }));
 
 const StyledRoleDescriptions = styled('div')(({ theme }) => ({
     display: 'flex',
     flexDirection: 'column',
-    gap: theme.spacing(0.5),
+    gap: theme.spacing(1),
     '& > *:not(:last-child)': {
         borderBottom: `1px solid ${theme.palette.divider}`,
         paddingBottom: theme.spacing(1),
@@ -154,14 +153,13 @@ export const NewAccessOverviewList = ({
 const RoleDescription = ({
     roleId,
     permission,
-    groupId,
+    sourceLabel,
 }: {
     roleId: number;
     permission: string;
-    groupId?: number;
+    sourceLabel: string;
 }) => {
     const { role } = useRole(roleId.toString());
-    const { group } = groupId ? useGroup(groupId) : { group: undefined };
     if (!role) return null;
     const { name, permissions } = role;
     if (
@@ -172,13 +170,13 @@ const RoleDescription = ({
         return null;
 
     return (
-        <StyledDescription>
+        <StyledRoleItem>
             <StyledRoleHeader>
                 <StyledSupervisedUserCircle color='disabled' />
                 {name}
-                {group && `-${group.name}`}
             </StyledRoleHeader>
-        </StyledDescription>
+            <StyledRoleSource>{sourceLabel}</StyledRoleSource>
+        </StyledRoleItem>
     );
 };
 
@@ -206,6 +204,7 @@ const PermissionStatus = ({
                                 key={rootRole?.id}
                                 permission={permission}
                                 roleId={rootRole?.id}
+                                sourceLabel='Via instance role'
                             />
                         )}
                         {roles?.map((roleId) => (
@@ -213,6 +212,7 @@ const PermissionStatus = ({
                                 key={roleId}
                                 permission={permission}
                                 roleId={roleId}
+                                sourceLabel='Directly assigned to user on the project'
                             />
                         ))}
                         {groups
@@ -222,7 +222,7 @@ const PermissionStatus = ({
                                     key={group.id}
                                     permission={permission}
                                     roleId={group.rootRole!}
-                                    groupId={group.id}
+                                    sourceLabel={`As a member of group "${group.name}"`}
                                 />
                             ))}
                     </StyledRoleDescriptions>

--- a/frontend/src/component/admin/users/AccessOverview/NewAccessOverview.tsx
+++ b/frontend/src/component/admin/users/AccessOverview/NewAccessOverview.tsx
@@ -38,6 +38,10 @@ const StyledAccessOverviewContainer = styled('div')(({ theme }) => ({
     gap: theme.spacing(2),
 }));
 
+const StyledProjectAccessWrapper = styled('div')(({ theme }) => ({
+    marginTop: theme.spacing(4),
+}));
+
 export const NewAccessOverview = () => {
     const id = useRequiredPathParam('id');
     const { projects } = useProjects();
@@ -98,12 +102,14 @@ export const NewAccessOverview = () => {
                         categories={rootCategories}
                     />
                     <RootRoleGroupAccess groups={rootRoleGroups ?? []} />
-                    <ProjectAccessSection
-                        id={id}
-                        projects={projects}
-                        environments={environments}
-                        searchValue={searchValue}
-                    />
+                    <StyledProjectAccessWrapper>
+                        <ProjectAccessSection
+                            id={id}
+                            projects={projects}
+                            environments={environments}
+                            searchValue={searchValue}
+                        />
+                    </StyledProjectAccessWrapper>
                 </SearchHighlightProvider>
             </StyledAccessOverviewContainer>
         </PageContent>

--- a/frontend/src/component/admin/users/AccessOverview/ProjectAccess/EnvironmentAccessTable.tsx
+++ b/frontend/src/component/admin/users/AccessOverview/ProjectAccess/EnvironmentAccessTable.tsx
@@ -10,6 +10,7 @@ const StyledEnvAccessHeader = styled('div')(({ theme }) => ({
     padding: theme.spacing(2),
     fontWeight: 'bold',
     fontSize: theme.typography.body2.fontSize,
+    backgroundColor: theme.palette.background.elevation1,
     borderTop: `1px solid ${theme.palette.divider}`,
     borderBottom: `1px solid ${theme.palette.divider}`,
 }));
@@ -31,6 +32,9 @@ const StyledEnvTable = styled('table')(({ theme }) => ({
     '& th:not(:first-of-type)': {
         textAlign: 'center',
         minWidth: theme.spacing(12),
+    },
+    '& td:first-of-type': {
+        paddingLeft: theme.spacing(4),
     },
     '& td:not(:first-of-type)': {
         textAlign: 'center',

--- a/frontend/src/component/admin/users/AccessOverview/ProjectAccess/ProjectAccess.tsx
+++ b/frontend/src/component/admin/users/AccessOverview/ProjectAccess/ProjectAccess.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@mui/material';
+import { Badge } from 'component/common/Badge/Badge';
 import { NewAccessOverviewAccordion } from '../AccessOverviewAccordion/NewAccessOverviewAccordion.tsx';
 import FolderOutlined from '@mui/icons-material/FolderOutlined';
 import { useMemo } from 'react';
@@ -73,11 +73,21 @@ export const ProjectAccess = ({
                         sx={{ flexShrink: 0, color: 'text.secondary' }}
                     />
                     <span>{projectName}</span>
-                    {projectRoles?.map((role) => (
-                        <Badge key={role.id} color='secondary'>
-                            {role.name}
-                        </Badge>
-                    ))}
+                    {projectRoles?.map((role) => {
+                        const isCustom = ![
+                            'Reader',
+                            'Member',
+                            'Owner',
+                        ].includes(role.name);
+                        return (
+                            <Badge
+                                key={role.id}
+                                color={isCustom ? 'success' : 'secondary'}
+                            >
+                                {role.name}
+                            </Badge>
+                        );
+                    })}
                 </>
             }
             rootRole={rootRole}

--- a/frontend/src/component/admin/users/AccessOverview/ProjectAccess/ProjectAccessSection.tsx
+++ b/frontend/src/component/admin/users/AccessOverview/ProjectAccess/ProjectAccessSection.tsx
@@ -125,8 +125,11 @@ export const ProjectAccessSection = ({
                         }
                         renderValue={() => projectSelectorLabel}
                         size='small'
-                        sx={{ minWidth: 150, flexShrink: 0 }}
+                        sx={{ minWidth: 150, maxWidth: 200, flexShrink: 0 }}
                         displayEmpty
+                        MenuProps={{
+                            sx: { '& .MuiPaper-root': { maxWidth: 200 } },
+                        }}
                     >
                         {sortedProjects.map((project) => (
                             <ProjectMenuItem
@@ -155,25 +158,48 @@ export const ProjectAccessSection = ({
                     <Select
                         multiple
                         value={selectedEnvironments}
-                        onChange={(e) =>
-                            setSelectedEnvironments(e.target.value as string[])
-                        }
+                        onChange={(e) => {
+                            const value = e.target.value as string[];
+                            if (value.length <= 3) {
+                                setSelectedEnvironments(value);
+                            }
+                        }}
                         renderValue={() => environmentSelectorLabel}
                         size='small'
-                        sx={{ minWidth: 150, flexShrink: 0 }}
+                        sx={{ minWidth: 150, maxWidth: 200, flexShrink: 0 }}
                         displayEmpty
+                        MenuProps={{
+                            sx: { '& .MuiPaper-root': { maxWidth: 200 } },
+                        }}
                     >
-                        {environments.map((env) => (
-                            <MenuItem key={env.name} value={env.name}>
-                                <Checkbox
-                                    checked={selectedEnvironments.includes(
-                                        env.name,
-                                    )}
-                                    size='small'
-                                />
-                                <ListItemText primary={env.name} />
-                            </MenuItem>
-                        ))}
+                        {environments.map((env) => {
+                            const isSelected = selectedEnvironments.includes(
+                                env.name,
+                            );
+                            const atLimit = selectedEnvironments.length >= 3;
+                            return (
+                                <MenuItem
+                                    key={env.name}
+                                    value={env.name}
+                                    disabled={atLimit && !isSelected}
+                                >
+                                    <Checkbox
+                                        checked={isSelected}
+                                        size='small'
+                                    />
+                                    <ListItemText
+                                        primary={env.name}
+                                        sx={{
+                                            '& .MuiListItemText-primary': {
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        }}
+                                    />
+                                </MenuItem>
+                            );
+                        })}
                     </Select>
                 </StyledSelectorCard>
             </StyledSelectorCardsContainer>

--- a/frontend/src/component/admin/users/AccessOverview/ProjectAccess/ProjectMenuItem.tsx
+++ b/frontend/src/component/admin/users/AccessOverview/ProjectAccess/ProjectMenuItem.tsx
@@ -28,7 +28,16 @@ export const ProjectMenuItem = ({
     return (
         <MenuItem {...props} value={project.id}>
             <Checkbox checked={selected} size='small' />
-            <ListItemText primary={project.name} />
+            <ListItemText
+                primary={project.name}
+                sx={{
+                    '& .MuiListItemText-primary': {
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                    },
+                }}
+            />
         </MenuItem>
     );
 };


### PR DESCRIPTION
Improves a few quirks in the permissions overview UI:
- Select up to 3 environments
- use badges for project roles on project accordion header
- Improve the permission has access tooltip on why user has access
- spacing
- header highlighting for environment access section

<img width="367" height="386" alt="Skjermbilde 2026-05-21 kl  16 08 01" src="https://github.com/user-attachments/assets/34721872-05d9-4082-9aa3-6b76460b204a" />
<img width="453" height="185" alt="Skjermbilde 2026-05-21 kl  16 07 55" src="https://github.com/user-attachments/assets/6c78d313-616e-41f3-84d9-bb749af9f8a0" />