### PR TITLE
fix: resolve console warning about wrong uri

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EditChange.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EditChange.test.tsx
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { render } from 'utils/testRenderer';
+import { Route, Routes } from 'react-router-dom';
+import { UPDATE_FEATURE_STRATEGY } from 'component/providers/AccessProvider/permissions';
+import { EditChange } from './EditChange.tsx';
+import { testServerRoute, testServerSetup } from 'utils/testServer';
+
+const server = testServerSetup();
+
+const featureName = 'my-feature';
+const project = 'default';
+const environment = 'development';
+
+const setupEndpoints = () => {
+    testServerRoute(server, '/api/admin/ui-config', {
+        versionInfo: { current: { enterprise: '5.7.0' } },
+        environment: 'enterprise',
+        flags: {},
+        unleashUrl: 'example.com',
+    });
+    testServerRoute(
+        server,
+        `/api/admin/projects/${project}/features/${featureName}`,
+        {
+            name: featureName,
+            project,
+            environments: [
+                {
+                    name: environment,
+                    type: 'development',
+                    strategies: [
+                        {
+                            id: 'strategy-1',
+                            name: 'flexibleRollout',
+                            constraints: [],
+                            parameters: {
+                                rollout: '50',
+                                groupId: featureName,
+                                stickiness: 'default',
+                            },
+                            variants: [],
+                        },
+                    ],
+                },
+            ],
+            variants: [],
+            dependencies: [],
+            children: [],
+        },
+    );
+    testServerRoute(server, '/api/admin/strategies/flexibleRollout', {
+        displayName: 'Gradual rollout',
+        name: 'flexibleRollout',
+        parameters: [
+            { name: 'rollout' },
+            { name: 'stickiness' },
+            { name: 'groupId' },
+        ],
+    });
+    testServerRoute(
+        server,
+        `/api/admin/projects/${project}/change-requests/config`,
+        [],
+    );
+    testServerRoute(server, '/api/admin/segments', { segments: [] });
+    testServerRoute(server, '/api/admin/context', []);
+};
+
+const setupComponent = () => {
+    const change = {
+        id: 1,
+        action: 'updateStrategy' as const,
+        payload: {
+            id: 'strategy-1',
+            name: 'flexibleRollout',
+            constraints: [],
+            parameters: {
+                rollout: '50',
+                groupId: featureName,
+                stickiness: 'default',
+            },
+            segments: [],
+            variants: [],
+        },
+    };
+
+    return render(
+        <Routes>
+            <Route
+                path='/projects/:projectId/features/:featureId'
+                element={
+                    <EditChange
+                        change={change}
+                        changeRequestId={1}
+                        featureId={featureName}
+                        environment={environment}
+                        open={true}
+                        onSubmit={vi.fn()}
+                        onClose={vi.fn()}
+                    />
+                }
+            />
+        </Routes>,
+        {
+            route: `/projects/${project}/features/${featureName}`,
+            permissions: [
+                { permission: UPDATE_FEATURE_STRATEGY, project, environment },
+            ],
+        },
+    );
+};
+
+beforeEach(() => {
+    setupEndpoints();
+});
+
+describe('EditChange', () => {
+    test('should not show stale data notification when feature loads', async () => {
+        setupComponent();
+
+        await screen.findByText('Save strategy');
+
+        expect(
+            screen.queryByText('Your data is stale'),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EditChange.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest/Changes/Change/EditChange.tsx
@@ -83,9 +83,13 @@ export const EditChange = ({
     const { unleashUrl } = uiConfig;
     const { isChangeRequestConfigured } = useChangeRequestsEnabled(projectId);
 
-    const { feature, refetchFeature } = useFeature(projectId, featureId);
+    const {
+        feature,
+        refetchFeature,
+        loading: featureLoading,
+    } = useFeature(projectId, featureId);
 
-    const ref = useRef<IFeatureToggle>(feature);
+    const cacheInitialized = useRef(false);
 
     const { data, staleDataNotification, forceRefreshCache } =
         useCollaborateData<IFeatureToggle>(
@@ -104,11 +108,11 @@ export const EditChange = ({
         );
 
     useEffect(() => {
-        if (ref.current.name === '' && feature.name) {
+        if (!featureLoading && !cacheInitialized.current) {
+            cacheInitialized.current = true;
             forceRefreshCache(feature);
-            ref.current = feature;
         }
-    }, [feature]);
+    }, [featureLoading]);
 
     const payload: IChangeSchema = {
         action: change.action,

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.test.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.test.tsx
@@ -285,4 +285,14 @@ describe('NewFeatureStrategyCreate', () => {
         expect(seconAddConstraintEl).toBeInTheDocument();
         expect(screen.queryByText('appName')).not.toBeInTheDocument();
     });
+
+    test('should not show stale data notification when feature loads', async () => {
+        setupComponent();
+
+        await screen.findByText('Save strategy');
+
+        expect(
+            screen.queryByText('Your data is stale'),
+        ).not.toBeInTheDocument();
+    });
 });

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate.tsx
@@ -74,13 +74,17 @@ export const FeatureStrategyCreate = () => {
     const { unleashUrl } = uiConfig;
     const navigate = useNavigate();
 
-    const { feature, refetchFeature } = useFeature(projectId, featureId);
+    const {
+        feature,
+        refetchFeature,
+        loading: featureLoading,
+    } = useFeature(projectId, featureId);
     const featureEnvironment = feature?.environments.find(
         (featureEnvironment) => featureEnvironment.name === environmentId,
     );
     const strategyCount = featureEnvironment?.strategies.length || 0;
     const { limit, limitReached } = useStrategyLimit(strategyCount);
-    const ref = useRef<IFeatureToggle>(feature);
+    const cacheInitialized = useRef(false);
     const { isChangeRequestConfigured } = useChangeRequestsEnabled(projectId);
     const { refetch: refetchChangeRequests } =
         usePendingChangeRequests(projectId);
@@ -103,11 +107,11 @@ export const FeatureStrategyCreate = () => {
         );
 
     useEffect(() => {
-        if (ref.current.name === '' && feature.name) {
+        if (!featureLoading && !cacheInitialized.current) {
+            cacheInitialized.current = true;
             forceRefreshCache(feature);
-            ref.current = feature;
         }
-    }, [feature.name]);
+    }, [featureLoading]);
 
     useEffect(() => {
         if (shouldUseDefaultStrategy) {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyEdit/FeatureStrategyEdit.tsx
@@ -127,9 +127,13 @@ export const FeatureStrategyEdit = () => {
     const featureName = useOptionalPathParam('featureId');
     const { setPreviousTitle } = useTitleTracking();
 
-    const { feature, refetchFeature } = useFeature(projectId, featureId);
+    const {
+        feature,
+        refetchFeature,
+        loading: featureLoading,
+    } = useFeature(projectId, featureId);
 
-    const ref = useRef<IFeatureToggle>(feature);
+    const cacheInitialized = useRef(false);
 
     const { data, staleDataNotification, forceRefreshCache } =
         useCollaborateData<IFeatureToggle>(
@@ -148,11 +152,11 @@ export const FeatureStrategyEdit = () => {
         );
 
     useEffect(() => {
-        if (ref.current.name === '' && feature.name) {
+        if (!featureLoading && !cacheInitialized.current) {
+            cacheInitialized.current = true;
             forceRefreshCache(feature);
-            ref.current = feature;
         }
-    }, [feature]);
+    }, [featureLoading]);
 
     const { trackEvent } = usePlausibleTracker();
     const { changeRequests: scheduledChangeRequestThatUseStrategy } =

--- a/frontend/src/hooks/api/getters/useFeature/useFeature.ts
+++ b/frontend/src/hooks/api/getters/useFeature/useFeature.ts
@@ -36,7 +36,11 @@ export const useFeature = (
     }, [mutate]);
 
     return {
-        feature: data?.body || emptyFeature,
+        feature: data?.body || {
+            ...emptyFeature,
+            project: projectId,
+            name: featureId,
+        },
         refetchFeature,
         loading: !error && !data,
         status: data?.status,


### PR DESCRIPTION
There is also different version of this PR: https://github.com/Unleash/unleash/pull/12101 

---

When you open console on the feature flag page you will get:

<img width="594" height="350" alt="Screenshot 2026-05-22 at 11 37 48" src="https://github.com/user-attachments/assets/e6ef9ffc-48bf-4c63-b51d-c9756894c0ac" />

Fixing it at the https://github.com/Unleash/unleash/blob/1b24563c8fcf305dc00c1bb6b94664011089d02b/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx#L170 

will probably force us to pass `projectId` and `featureId` from the parent component - note that's it's duplicating `feature`. 

Or invoking:
```
    const projectId = useRequiredPathParam('projectId');
    const featureId = useRequiredPathParam('featureId');
```
in yet another place. I don't think it makes sense. 

We're already using `projectId` and `featureId` alongside `feature` so why not initialize it while we're loading data with those values?  