### PR TITLE
chore: sanitization tweaks for browser project

### DIFF
--- a/frontend/src/component/providers/LogRocketProvider/LogRocketRunner.tsx
+++ b/frontend/src/component/providers/LogRocketProvider/LogRocketRunner.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import LogRocket from 'logrocket';
-import { scrubUrl } from './scrubUrl';
+import { scrubUrl, scrubBrowserUrl, isStaticAsset } from './scrubUrl';
 
 type Props = {
     appId: string;
@@ -18,13 +18,13 @@ const LogRocketRunner = ({ appId, clientId, userId }: Props) => {
                 },
                 shouldCaptureIP: false,
                 browser: {
-                    urlSanitizer: (url) => scrubUrl(url),
+                    urlSanitizer: (url) => scrubBrowserUrl(url),
                 },
                 network: {
                     requestSanitizer: ({ reqId, method, url }) => ({
                         reqId,
                         method,
-                        url: scrubUrl(url),
+                        url: isStaticAsset(url) ? url : scrubUrl(url),
                         headers: {},
                         body: undefined,
                     }),

--- a/frontend/src/component/providers/LogRocketProvider/scrubUrl.test.ts
+++ b/frontend/src/component/providers/LogRocketProvider/scrubUrl.test.ts
@@ -33,12 +33,6 @@ describe('scrubUrl', () => {
         expect(scrubUrl('/api/admin/features')).toBe('/api/admin/features');
     });
 
-    it('normalizes embedded double slashes without emitting a browser warning', () => {
-        expect(scrubUrl('/projects//features//copy')).toBe(
-            '/projects/features/copy',
-        );
-    });
-
     it('respects custom depth parameter', () => {
         // depth=2: keep 'api' and 'admin', mask everything after
         expect(

--- a/frontend/src/component/providers/LogRocketProvider/scrubUrl.test.ts
+++ b/frontend/src/component/providers/LogRocketProvider/scrubUrl.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { scrubUrl } from './scrubUrl';
+import { scrubUrl, scrubBrowserUrl, isStaticAsset } from './scrubUrl';
 
 describe('scrubUrl', () => {
     it('masks segments after the first 3 character-by-character', () => {
@@ -20,16 +20,6 @@ describe('scrubUrl', () => {
         ).toBe('https://app.getunleash.io/api/admin/projects/******');
     });
 
-    it('masks feature and flag name in page navigation URLs', () => {
-        expect(
-            scrubUrl(
-                'https://us.app.getunleash.io/someInstance12/projects/default/features/Some_Flag',
-            ),
-        ).toBe(
-            'https://us.app.getunleash.io/someInstance12/projects/default/********/*********',
-        );
-    });
-
     it('returns what is available when path has fewer than 3 segments', () => {
         expect(scrubUrl('/api/admin')).toBe('/api/admin');
         expect(scrubUrl('/api')).toBe('/api');
@@ -47,5 +37,83 @@ describe('scrubUrl', () => {
         expect(scrubUrl('/projects//features//copy')).toBe(
             '/projects/features/copy',
         );
+    });
+
+    it('respects custom depth parameter', () => {
+        // depth=2: keep 'api' and 'admin', mask everything after
+        expect(
+            scrubUrl('/api/admin/projects/my-project/features/my-flag', 2),
+        ).toBe('/api/admin/********/**********/********/*******');
+    });
+});
+
+describe('scrubBrowserUrl', () => {
+    it('scrubs navigation URLs with depth 2', () => {
+        expect(
+            scrubBrowserUrl(
+                'https://us.app.getunleash.io/someInstance12/projects/default/features/Some_Flag',
+            ),
+        ).toBe(
+            'https://us.app.getunleash.io/someInstance12/projects/*******/********/*********',
+        );
+    });
+});
+
+describe('isStaticAsset', () => {
+    it('detects static file extensions', () => {
+        expect(
+            isStaticAsset(
+                'https://cdn.getunleash.io/unleash/v7.6.5/static/style-ABC.css',
+            ),
+        ).toBe(true);
+        expect(
+            isStaticAsset(
+                'https://cdn.getunleash.io/unleash/v7.6.5/static/FlagMetricsChart-123456.js',
+            ),
+        ).toBe(true);
+        expect(
+            isStaticAsset(
+                'https://sandbox.getunleash.io/enterprise/static/logo-BbvuC13D.gif',
+            ),
+        ).toBe(true);
+        expect(
+            isStaticAsset(
+                'https://sandbox.getunleash.io/enterprise/static/texture.png',
+            ),
+        ).toBe(true);
+        expect(
+            isStaticAsset(
+                'https://fonts.gstatic.com/s/sen/v12/some_file.woff2',
+            ),
+        ).toBe(true);
+    });
+
+    it('detects /static/ path segment without file extension', () => {
+        expect(
+            isStaticAsset(
+                'https://cdn.getunleash.io/unleash/v7.6.5/static/somechunk',
+            ),
+        ).toBe(true);
+    });
+
+    it('detects font service domains', () => {
+        expect(
+            isStaticAsset(
+                'https://fonts.googleapis.com/css2?family=Sen:wght@400;500;700;800&display=swap',
+            ),
+        ).toBe(true);
+    });
+
+    it('returns false for API and navigation URLs', () => {
+        expect(
+            isStaticAsset(
+                'https://eu.app.getunleash.io/api/admin/projects/default/features/my-flag',
+            ),
+        ).toBe(false);
+        expect(
+            isStaticAsset(
+                'https://eu.app.getunleash.io/eull0626/projects/default/features/Some_Flag',
+            ),
+        ).toBe(false);
     });
 });

--- a/frontend/src/component/providers/LogRocketProvider/scrubUrl.ts
+++ b/frontend/src/component/providers/LogRocketProvider/scrubUrl.ts
@@ -1,38 +1,62 @@
 const mask = (s: string) => '*'.repeat(s.length);
 
+const DOUBLE_SLASH_RE = /(?<!:)\/\//g;
+
 const MAX_CACHE = 300;
 const cache = new Map<string, string>();
 
-const setCached = (url: string, result: string): string => {
+const setCached = (key: string, result: string): string => {
     if (cache.size >= MAX_CACHE) {
         cache.delete(cache.keys().next().value!);
     }
-    cache.set(url, result);
+    cache.set(key, result);
     return result;
 };
 
-export const scrubUrl = (url: string): string => {
-    const cached = cache.get(url);
+export const scrubUrl = (url: string, depth = 3): string => {
+    const cacheKey = `${depth}:${url}`;
+    const cached = cache.get(cacheKey);
     if (cached !== undefined) return cached;
 
     // Collapse double slashes in path (e.g. /projects//features//copy) to avoid
     // a browser URL constructor warning. Use a lookbehind to preserve :// in absolute URLs.
-    const parsed = new URL(url.replace(/(?<!:)\/\//g, '/'), 'http://x');
+    const parsed = new URL(url.replace(DOUBLE_SLASH_RE, '/'), 'http://x');
 
     const isAbsolute = /^https?:\/\//i.test(url);
     const origin = isAbsolute ? `${parsed.protocol}//${parsed.host}` : '';
 
     const segments = parsed.pathname.split('/').filter(Boolean);
     const scrubbedPath = segments.map((segment, i) =>
-        i < 3 ? segment : mask(segment),
+        i < depth ? segment : mask(segment),
     );
     const path = scrubbedPath.length > 0 ? `/${scrubbedPath.join('/')}` : '/';
 
-    if (!parsed.search) return setCached(url, `${origin}${path}`);
+    if (!parsed.search) return setCached(cacheKey, `${origin}${path}`);
 
     const params = new URLSearchParams(parsed.search);
     const scrubbed = new URLSearchParams(
         [...params].map(([k, v]) => [k, mask(v)]),
     );
-    return setCached(url, `${origin}${path}?${scrubbed.toString()}`);
+    return setCached(cacheKey, `${origin}${path}?${scrubbed.toString()}`);
 };
+
+const STATIC_ASSET_EXT_RE =
+    /\.(?:css|js|mjs|png|jpe?g|gif|svg|ico|webp|woff2?|ttf|eot|avif|mp4|webm)(?:[?#]|$)/i;
+
+const STATIC_PATH_RE = /(?:^|\/)static\//i;
+
+const FONT_SERVICE_DOMAINS = new Set([
+    'fonts.googleapis.com',
+    'fonts.gstatic.com',
+]);
+
+export const isStaticAsset = (url: string): boolean => {
+    if (STATIC_ASSET_EXT_RE.test(url)) return true;
+    const parsed = new URL(url.replace(DOUBLE_SLASH_RE, '/'), 'http://x');
+    return (
+        FONT_SERVICE_DOMAINS.has(parsed.hostname) ||
+        STATIC_PATH_RE.test(parsed.pathname)
+    );
+};
+
+export const scrubBrowserUrl = (url: string): string => scrubUrl(url, 2);

--- a/frontend/src/component/providers/LogRocketProvider/scrubUrl.ts
+++ b/frontend/src/component/providers/LogRocketProvider/scrubUrl.ts
@@ -1,7 +1,5 @@
 const mask = (s: string) => '*'.repeat(s.length);
 
-const DOUBLE_SLASH_RE = /(?<!:)\/\//g;
-
 const MAX_CACHE = 300;
 const cache = new Map<string, string>();
 
@@ -13,16 +11,16 @@ const setCached = (key: string, result: string): string => {
     return result;
 };
 
+const ABSOLUTE_URL_RE = /^https?:\/\//i;
+
 export const scrubUrl = (url: string, depth = 3): string => {
     const cacheKey = `${depth}:${url}`;
     const cached = cache.get(cacheKey);
     if (cached !== undefined) return cached;
 
-    // Collapse double slashes in path (e.g. /projects//features//copy) to avoid
-    // a browser URL constructor warning. Use a lookbehind to preserve :// in absolute URLs.
-    const parsed = new URL(url.replace(DOUBLE_SLASH_RE, '/'), 'http://x');
+    const parsed = new URL(url, 'http://x');
 
-    const isAbsolute = /^https?:\/\//i.test(url);
+    const isAbsolute = ABSOLUTE_URL_RE.test(url);
     const origin = isAbsolute ? `${parsed.protocol}//${parsed.host}` : '';
 
     const segments = parsed.pathname.split('/').filter(Boolean);
@@ -34,10 +32,10 @@ export const scrubUrl = (url: string, depth = 3): string => {
     if (!parsed.search) return setCached(cacheKey, `${origin}${path}`);
 
     const params = new URLSearchParams(parsed.search);
-    const scrubbed = new URLSearchParams(
+    const scrubbedParams = new URLSearchParams(
         [...params].map(([k, v]) => [k, mask(v)]),
     );
-    return setCached(cacheKey, `${origin}${path}?${scrubbed.toString()}`);
+    return setCached(cacheKey, `${origin}${path}?${scrubbedParams.toString()}`);
 };
 
 const STATIC_ASSET_EXT_RE =
@@ -52,7 +50,7 @@ const FONT_SERVICE_DOMAINS = new Set([
 
 export const isStaticAsset = (url: string): boolean => {
     if (STATIC_ASSET_EXT_RE.test(url)) return true;
-    const parsed = new URL(url.replace(DOUBLE_SLASH_RE, '/'), 'http://x');
+    const parsed = new URL(url, 'http://x');
     return (
         FONT_SERVICE_DOMAINS.has(parsed.hostname) ||
         STATIC_PATH_RE.test(parsed.pathname)


### PR DESCRIPTION
* remove double slashes handling - it wasn't related to sanitization
* browser url should sanitize one path earlier
* no need to sanitize names of the static files 