### PR TITLE
feat: add flag-gated `cleanupCount` on /api/admin/projects

### DIFF
--- a/src/lib/features/project/createProjectService.ts
+++ b/src/lib/features/project/createProjectService.ts
@@ -57,6 +57,8 @@ import {
     createFakeOnboardingReadModel,
     createOnboardingReadModel,
 } from '../onboarding/createOnboardingReadModel.js';
+import { FeatureLifecycleReadModel } from '../feature-lifecycle/feature-lifecycle-read-model.js';
+import { FakeFeatureLifecycleReadModel } from '../feature-lifecycle/fake-feature-lifecycle-read-model.js';
 import { FakeEdgeTokenStore } from '../edgetokens/fake-edge-token-store.js';
 import { EdgeTokenStore } from '../edgetokens/edge-token-store.js';
 
@@ -138,6 +140,8 @@ export const createProjectService = (
 
     const onboardingReadModel = createOnboardingReadModel(db, flagResolver);
 
+    const featureLifecycleReadModel = new FeatureLifecycleReadModel(db);
+
     return new ProjectService(
         {
             projectStore,
@@ -151,6 +155,7 @@ export const createProjectService = (
             projectFlagCreatorsReadModel,
             projectReadModel,
             onboardingReadModel,
+            featureLifecycleReadModel,
             edgeTokenStore,
         },
         config,
@@ -212,6 +217,8 @@ export const createFakeProjectService = (config: IUnleashConfig) => {
 
     const onboardingReadModel = createFakeOnboardingReadModel();
 
+    const featureLifecycleReadModel = new FakeFeatureLifecycleReadModel();
+
     const projectService = new ProjectService(
         {
             projectStore,
@@ -225,6 +232,7 @@ export const createFakeProjectService = (config: IUnleashConfig) => {
             projectStatsStore,
             projectReadModel,
             onboardingReadModel,
+            featureLifecycleReadModel,
             edgeTokenStore,
         },
         config,

--- a/src/lib/features/project/project-read-model-type.ts
+++ b/src/lib/features/project/project-read-model-type.ts
@@ -17,6 +17,7 @@ export type ProjectForUi = {
     lastReportedFlagUsage: Date | null;
     lastUpdatedAt: Date | null;
     onboardingStatus?: OnboardingStatus;
+    cleanupCount?: number;
 };
 
 export type ProjectForInsights = {

--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -12,7 +12,10 @@ import { randomId } from '../../util/index.js';
 import EnvironmentService from '../project-environments/environment-service.js';
 import IncompatibleProjectError from '../../error/incompatible-project-error.js';
 import type { ApiTokenService, EventService } from '../../services/index.js';
-import { FeatureEnvironmentEvent } from '../../types/index.js';
+import {
+    FeatureEnvironmentEvent,
+    type IUnleashConfig,
+} from '../../types/index.js';
 import { addDays, subDays } from 'date-fns';
 import {
     createAccessService,
@@ -139,32 +142,76 @@ describe('should list all projects', () => {
         );
     });
 
-    test("includes onboarding status with 'newProjectList' flag enabled", async () => {
-        const flagEnabledConfig = createTestConfig({
-            getLogger,
-            experimental: { flags: { newProjectList: true } },
+    describe("with 'newProjectList' flag enabled", () => {
+        let flagEnabledConfig: IUnleashConfig;
+        let projectServiceWithFlag: ProjectService;
+        beforeAll(() => {
+            flagEnabledConfig = createTestConfig({
+                getLogger,
+                experimental: { flags: { newProjectList: true } },
+            });
+
+            projectServiceWithFlag = createProjectService(
+                db.rawDatabase,
+                flagEnabledConfig,
+            );
         });
-        const projectServiceWithFlag = createProjectService(
-            db.rawDatabase,
-            flagEnabledConfig,
-        );
 
-        const project = {
-            id: 'onboarding-status',
-            name: 'Onboarding status project',
-            description: 'Blah',
-            mode: 'open' as const,
-            defaultStickiness: 'default',
-        };
+        test('includes onboarding status', async () => {
+            const project = {
+                id: 'onboarding-status',
+                name: 'Onboarding status project',
+                description: 'Blah',
+                mode: 'open' as const,
+                defaultStickiness: 'default',
+            };
 
-        await projectServiceWithFlag.createProject(project, user, auditUser);
-        const projects = await projectServiceWithFlag.getProjects();
-        const projectOnboardingStatus = projects.find(
-            (p) => p.id === project.id,
-        )?.onboardingStatus;
+            await projectServiceWithFlag.createProject(
+                project,
+                user,
+                auditUser,
+            );
+            const projects = await projectServiceWithFlag.getProjects();
+            const projectOnboardingStatus = projects.find(
+                (p) => p.id === project.id,
+            )?.onboardingStatus;
 
-        expect(projectOnboardingStatus).toMatchObject({
-            status: 'onboarding-started',
+            expect(projectOnboardingStatus).toMatchObject({
+                status: 'onboarding-started',
+            });
+        });
+
+        test('includes cleanupCount', async () => {
+            const project = {
+                id: 'cleanup-count',
+                name: 'Cleanup count project',
+                description: 'Blah',
+                mode: 'open' as const,
+                defaultStickiness: 'default',
+            };
+
+            await projectServiceWithFlag.createProject(
+                project,
+                user,
+                auditUser,
+            );
+
+            await stores.featureToggleStore.create(project.id, {
+                name: 'cleanup-feature',
+                createdByUserId: user.id,
+            });
+
+            await stores.featureLifecycleStore.insert([
+                { feature: 'cleanup-feature', stage: 'initial' },
+                { feature: 'cleanup-feature', stage: 'completed' },
+            ]);
+
+            const projects = await projectServiceWithFlag.getProjects();
+            const projectCleanupCount = projects.find(
+                (p) => p.id === project.id,
+            )?.cleanupCount;
+
+            expect(projectCleanupCount).toBe(1);
         });
     });
 });

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -53,6 +53,7 @@ import {
     SYSTEM_USER_ID,
     type IProjectReadModel,
     type IOnboardingReadModel,
+    type IFeatureLifecycleReadModel,
     type IEdgeTokenStore,
 } from '../../types/index.js';
 import type {
@@ -88,6 +89,7 @@ import { batchExecute } from '../../util/index.js';
 import metricsHelper from '../../util/metrics-helper.js';
 import { FUNCTION_TIME } from '../../metric-events.js';
 import type { ResourceLimitsService } from '../resource-limits/resource-limits-service.js';
+import type { OnboardingStatus } from '../onboarding/onboarding-read-model-type.js';
 
 type Days = number;
 type Count = number;
@@ -155,6 +157,8 @@ export default class ProjectService {
 
     private onboardingReadModel: IOnboardingReadModel;
 
+    private featureLifecycleReadModel: IFeatureLifecycleReadModel;
+
     private edgeTokenStore: IEdgeTokenStore;
 
     private timer: Function;
@@ -172,6 +176,7 @@ export default class ProjectService {
             projectStatsStore,
             projectReadModel,
             onboardingReadModel,
+            featureLifecycleReadModel,
             edgeTokenStore,
         }: Pick<
             IUnleashStores,
@@ -186,6 +191,7 @@ export default class ProjectService {
             | 'projectStatsStore'
             | 'projectReadModel'
             | 'onboardingReadModel'
+            | 'featureLifecycleReadModel'
             | 'edgeTokenStore'
         >,
         config: IUnleashConfig,
@@ -221,6 +227,7 @@ export default class ProjectService {
         this.eventBus = config.eventBus;
         this.projectReadModel = projectReadModel;
         this.onboardingReadModel = onboardingReadModel;
+        this.featureLifecycleReadModel = featureLifecycleReadModel;
         this.edgeTokenStore = edgeTokenStore;
         this.timer = (functionName: string) =>
             metricsHelper.wrapTimer(config.eventBus, FUNCTION_TIME, {
@@ -255,12 +262,27 @@ export default class ProjectService {
         if (this.flagResolver.isEnabled('newProjectList')) {
             //TODO: update project-schema when removing this flag
             const projectIds = projects.map((p) => p.id);
-            const onboardingStatuses =
-                await this.onboardingReadModel.getOnboardingStatusesForProjects(
-                    projectIds,
-                );
+            const [onboardingStatuses, cleanupByProject] = await Promise.all([
+                this.onboardingReadModel
+                    .getOnboardingStatusesForProjects(projectIds)
+                    .catch(() => new Map<string, OnboardingStatus>()),
+                this.featureLifecycleReadModel
+                    .getStageCountByProject()
+                    .then((rows) => {
+                        const map = new Map<string, number>();
+                        for (const row of rows) {
+                            if (row.stage === 'completed') {
+                                map.set(row.project, row.count);
+                            }
+                        }
+                        return map;
+                    })
+                    .catch(() => new Map<string, number>()),
+            ]);
+
             for (const project of projects) {
                 project.onboardingStatus = onboardingStatuses.get(project.id);
+                project.cleanupCount = cleanupByProject.get(project.id);
             }
         }
 


### PR DESCRIPTION
As part of the project cards redesign, we want to include a mention of the number of flags in clean up, so this:

- Adds `cleanupCount` to the `/api/admin/projects` response if the `newProjectList` feature flag is enabled (`cleanupCount` represents the number of features currently in `completed` lifecycle stage for the project).
  - [src/lib/features/project/project-service.ts](https://github.com/Unleash/unleash/pull/12103/changes#diff-6ca938c85e8ebbb46d117d9437a791ed063066c23245e8796001e79972100743R265) fetches `featureLifecycleReadModel.getStageCountByProject()` alongside the existing onboarding-status call via `Promise.all`. Each fetch has its own `.catch` returning an empty `Map`, so a failure in one doesn't take down the other. 

## Performance considerations 

This PR adds a new caller of `getStageCountByProject()` to a somewhat critical admin endpoint.
 If this causes performance issues once we enable the flag, we could consider either of the following follow up tasks to mitigate:
 - **Index migration on `feature_lifecycles`**: add `(feature, created_at DESC)`. The query relies on `DISTINCT ON (feature) ORDER BY feature, created_at DESC`, and no matching index exists today (only the PK on `(feature, stage)`), so Postgres falls back to a sort. The index would let it scan in order instead.
 - **Move lifecycle counts per stage to a separate endpoint and lazy-load on the frontend**. We could also consider only loading a project lifecycle count if the card is visible on viewport.
 
For now, since we already fetch all feature flag lifecycles for all projects in `/insights` (Analytics page), I'd merge as-is and only remediate if it becomes an issue.
Shoutout to @melindafekete and @gergokekesi for discussing this with me 💖 