### PR TITLE
feat: add flag-gated `membersPreview` to /api/admin/projects

### DIFF
--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -50,6 +50,7 @@ import { InactiveUsersStore } from '../users/inactive/inactive-users-store.js';
 import { TrafficDataUsageStore } from '../features/traffic-data-usage/traffic-data-usage-store.js';
 import { SegmentReadModel } from '../features/segment/segment-read-model.js';
 import { ProjectOwnersReadModel } from '../features/project/project-owners-read-model.js';
+import { ProjectMembersReadModel } from '../features/project/project-members-read-model.js';
 import { FeatureLifecycleStore } from '../features/feature-lifecycle/feature-lifecycle-store.js';
 import { ProjectFlagCreatorsReadModel } from '../features/project/project-flag-creators-read-model.js';
 import { FeatureStrategiesReadModel } from '../features/feature-toggle/feature-strategies-read-model.js';
@@ -182,6 +183,7 @@ export const createStores = (
         trafficDataUsageStore: new TrafficDataUsageStore(db, getLogger),
         segmentReadModel: new SegmentReadModel(db),
         projectOwnersReadModel: new ProjectOwnersReadModel(db),
+        projectMembersReadModel: new ProjectMembersReadModel(db),
         projectFlagCreatorsReadModel: new ProjectFlagCreatorsReadModel(db),
         featureLifecycleStore: new FeatureLifecycleStore(db, eventBus),
         featureStrategiesReadModel: new FeatureStrategiesReadModel(db),

--- a/src/lib/features/project/createProjectService.ts
+++ b/src/lib/features/project/createProjectService.ts
@@ -41,6 +41,8 @@ import {
 } from '../private-project/createPrivateProjectChecker.js';
 import { ProjectOwnersReadModel } from './project-owners-read-model.js';
 import { FakeProjectOwnersReadModel } from './fake-project-owners-read-model.js';
+import { ProjectMembersReadModel } from './project-members-read-model.js';
+import { FakeProjectMembersReadModel } from './fake-project-members-read-model.js';
 import { FakeProjectFlagCreatorsReadModel } from './fake-project-flag-creators-read-model.js';
 import { ProjectFlagCreatorsReadModel } from './project-flag-creators-read-model.js';
 import FakeApiTokenStore from '../../../test/fixtures/fake-api-token-store.js';
@@ -70,6 +72,7 @@ export const createProjectService = (
     const eventStore = new EventStore(db, getLogger);
     const projectStore = new ProjectStore(db, eventBus, config);
     const projectOwnersReadModel = new ProjectOwnersReadModel(db);
+    const projectMembersReadModel = new ProjectMembersReadModel(db);
     const projectFlagCreatorsReadModel = new ProjectFlagCreatorsReadModel(db);
     const groupStore = new GroupStore(db);
     const edgeTokenStore = new EdgeTokenStore(db, eventBus, config);
@@ -152,6 +155,7 @@ export const createProjectService = (
             accountStore,
             projectStatsStore,
             projectOwnersReadModel,
+            projectMembersReadModel,
             projectFlagCreatorsReadModel,
             projectReadModel,
             onboardingReadModel,
@@ -174,6 +178,7 @@ export const createFakeProjectService = (config: IUnleashConfig) => {
     const { getLogger } = config;
     const eventStore = new FakeEventStore();
     const projectOwnersReadModel = new FakeProjectOwnersReadModel();
+    const projectMembersReadModel = new FakeProjectMembersReadModel();
     const projectFlagCreatorsReadModel = new FakeProjectFlagCreatorsReadModel();
     const projectStore = new FakeProjectStore();
     const groupStore = new FakeGroupStore();
@@ -223,6 +228,7 @@ export const createFakeProjectService = (config: IUnleashConfig) => {
         {
             projectStore,
             projectOwnersReadModel,
+            projectMembersReadModel,
             projectFlagCreatorsReadModel,
             eventStore,
             featureToggleStore,

--- a/src/lib/features/project/fake-project-members-read-model.ts
+++ b/src/lib/features/project/fake-project-members-read-model.ts
@@ -1,0 +1,12 @@
+import type {
+    IProjectMembersReadModel,
+    ProjectMember,
+} from './project-members-read-model.type.js';
+
+export class FakeProjectMembersReadModel implements IProjectMembersReadModel {
+    async getMembersPreviewByProject(): Promise<
+        Record<string, ProjectMember[]>
+    > {
+        return {};
+    }
+}

--- a/src/lib/features/project/project-members-read-model.test.ts
+++ b/src/lib/features/project/project-members-read-model.test.ts
@@ -1,0 +1,140 @@
+import dbInit, {
+    type ITestDb,
+} from '../../../test/e2e/helpers/database-init.js';
+import getLogger from '../../../test/fixtures/no-logger.js';
+import { type IUser, RoleName, type IGroup } from '../../types/index.js';
+import { randomId } from '../../util/index.js';
+import { ProjectMembersReadModel } from './project-members-read-model.js';
+
+let db: ITestDb;
+let readModel: ProjectMembersReadModel;
+
+let memberRoleId: number;
+let userA: IUser;
+let userB: IUser;
+let userC: IUser;
+let userD: IUser;
+let userE: IUser;
+let group: IGroup;
+
+beforeAll(async () => {
+    db = await dbInit('project_members_read_model_serial', getLogger);
+    readModel = new ProjectMembersReadModel(db.rawDatabase);
+    memberRoleId = (await db.stores.roleStore.getRoleByName(RoleName.MEMBER))
+        .id;
+
+    userA = await db.stores.userStore.insert({
+        name: 'User A',
+        username: 'user-a',
+        email: 'a@example.com',
+    });
+    userB = await db.stores.userStore.insert({
+        name: 'User B',
+        username: 'user-b',
+        email: 'b@example.com',
+    });
+    userC = await db.stores.userStore.insert({
+        name: 'User C',
+        username: 'user-c',
+        email: 'c@example.com',
+    });
+    userD = await db.stores.userStore.insert({
+        name: 'User D',
+        username: 'user-d',
+        email: 'd@example.com',
+    });
+    userE = await db.stores.userStore.insert({
+        name: 'User E',
+        username: 'user-e',
+        email: 'e@example.com',
+    });
+
+    group = await db.stores.groupStore.create({ name: 'Team' });
+    await db.stores.groupStore.addUserToGroups(userD.id, [group.id]);
+});
+
+afterAll(async () => {
+    if (db) {
+        await db.destroy();
+    }
+});
+
+test('returns empty object when no projects exist', async () => {
+    const members = await readModel.getMembersPreviewByProject();
+    expect(members).toStrictEqual({});
+});
+
+test('includes users with a direct project role', async () => {
+    const projectId = randomId();
+    await db.stores.projectStore.create({ id: projectId, name: projectId });
+    await db.stores.accessStore.addUserToRole(
+        userA.id,
+        memberRoleId,
+        projectId,
+    );
+
+    const members = await readModel.getMembersPreviewByProject();
+
+    expect(members[projectId]).toMatchObject([
+        {
+            name: 'User A',
+            email: 'a@example.com',
+            imageUrl: expect.stringContaining('https://gravatar.com/avatar'),
+        },
+    ]);
+});
+
+test('includes users via a group with a project role', async () => {
+    const projectId = randomId();
+    await db.stores.projectStore.create({ id: projectId, name: projectId });
+    await db.stores.accessStore.addGroupToRole(
+        group.id,
+        memberRoleId,
+        '',
+        projectId,
+    );
+
+    const members = await readModel.getMembersPreviewByProject();
+
+    expect(members[projectId]).toMatchObject([{ name: 'User D' }]);
+});
+
+test('caps at 4 members per project', async () => {
+    const projectId = randomId();
+    await db.stores.projectStore.create({ id: projectId, name: projectId });
+
+    for (const user of [userA, userB, userC, userD, userE]) {
+        await db.stores.accessStore.addUserToRole(
+            user.id,
+            memberRoleId,
+            projectId,
+        );
+    }
+
+    const members = await readModel.getMembersPreviewByProject();
+
+    expect(members[projectId]).toHaveLength(4);
+});
+
+test('deduplicates users present via both a direct role and a group', async () => {
+    const projectId = randomId();
+    await db.stores.projectStore.create({ id: projectId, name: projectId });
+
+    // userD is both a direct member AND a member of the group with a project role
+    await db.stores.accessStore.addUserToRole(
+        userD.id,
+        memberRoleId,
+        projectId,
+    );
+    await db.stores.accessStore.addGroupToRole(
+        group.id,
+        memberRoleId,
+        '',
+        projectId,
+    );
+
+    const members = await readModel.getMembersPreviewByProject();
+
+    expect(members[projectId]).toHaveLength(1);
+    expect(members[projectId][0]).toMatchObject({ name: 'User D' });
+});

--- a/src/lib/features/project/project-members-read-model.ts
+++ b/src/lib/features/project/project-members-read-model.ts
@@ -14,7 +14,7 @@ export class ProjectMembersReadModel implements IProjectMembersReadModel {
         this.db = db;
     }
 
-    static membersUnion(db: Db) {
+    static usersWithProjectRoles(db: Db) {
         return db
             .select('user_id', 'project')
             .from('role_user')
@@ -35,7 +35,9 @@ export class ProjectMembersReadModel implements IProjectMembersReadModel {
     async getMembersPreviewByProject(): Promise<
         Record<string, ProjectMember[]>
     > {
-        const membersUnion = ProjectMembersReadModel.membersUnion(this.db);
+        const membersUnion = ProjectMembersReadModel.usersWithProjectRoles(
+            this.db,
+        );
 
         // Take the first N members of each project, ordered by user id.
         const selectedMembers = this.db

--- a/src/lib/features/project/project-members-read-model.ts
+++ b/src/lib/features/project/project-members-read-model.ts
@@ -1,0 +1,76 @@
+import type { Db } from '../../db/db.js';
+import { generateImageUrl } from '../../util/index.js';
+import type {
+    IProjectMembersReadModel,
+    ProjectMember,
+} from './project-members-read-model.type.js';
+
+const MEMBERS_PREVIEW_SIZE = 4;
+
+export class ProjectMembersReadModel implements IProjectMembersReadModel {
+    private db: Db;
+
+    constructor(db: Db) {
+        this.db = db;
+    }
+
+    static membersUnion(db: Db) {
+        return db
+            .select('user_id', 'project')
+            .from('role_user')
+            .leftJoin('roles', 'role_user.role_id', 'roles.id')
+            .where((b) => b.whereNot('type', 'root'))
+            .union((qb) => {
+                qb.select('user_id', 'project')
+                    .from('group_role')
+                    .leftJoin(
+                        'group_user',
+                        'group_user.group_id',
+                        'group_role.group_id',
+                    );
+            })
+            .as('query');
+    }
+
+    async getMembersPreviewByProject(): Promise<
+        Record<string, ProjectMember[]>
+    > {
+        const membersUnion = ProjectMembersReadModel.membersUnion(this.db);
+
+        // Take the first N members of each project, ordered by user id.
+        const selectedMembers = this.db
+            .select(
+                'query.project',
+                'users.name',
+                'users.username',
+                'users.email',
+                'users.image_url',
+            )
+            .rowNumber('rn', 'users.id', 'query.project')
+            .from(membersUnion)
+            .leftJoin('users', 'users.id', 'query.user_id')
+            .whereNotNull('users.id')
+            .as('selected_members');
+
+        const rows = await this.db
+            .select('*')
+            .from(selectedMembers)
+            .where('rn', '<=', MEMBERS_PREVIEW_SIZE);
+
+        const membersByProject: Record<string, ProjectMember[]> = {};
+        for (const row of rows) {
+            const project = row.project as string;
+            if (!project) continue;
+            if (!membersByProject[project]) {
+                membersByProject[project] = [];
+            }
+            membersByProject[project].push({
+                name: row.name || row.username || row.email,
+                email: row.email,
+                imageUrl: generateImageUrl(row),
+            });
+        }
+
+        return membersByProject;
+    }
+}

--- a/src/lib/features/project/project-members-read-model.type.ts
+++ b/src/lib/features/project/project-members-read-model.type.ts
@@ -1,8 +1,6 @@
-export type ProjectMember = {
-    name: string;
-    email?: string;
-    imageUrl?: string;
-};
+import type { UserProjectOwner } from './project-owners-read-model.type.js';
+
+export type ProjectMember = Omit<UserProjectOwner, 'ownerType'>;
 
 export interface IProjectMembersReadModel {
     getMembersPreviewByProject(): Promise<Record<string, ProjectMember[]>>;

--- a/src/lib/features/project/project-members-read-model.type.ts
+++ b/src/lib/features/project/project-members-read-model.type.ts
@@ -1,0 +1,9 @@
+export type ProjectMember = {
+    name: string;
+    email?: string;
+    imageUrl?: string;
+};
+
+export interface IProjectMembersReadModel {
+    getMembersPreviewByProject(): Promise<Record<string, ProjectMember[]>>;
+}

--- a/src/lib/features/project/project-read-model-type.ts
+++ b/src/lib/features/project/project-read-model-type.ts
@@ -1,5 +1,6 @@
 import type { ProjectMode } from '../../types/index.js';
 import type { OnboardingStatus } from '../onboarding/onboarding-read-model-type.js';
+import type { ProjectMember } from './project-members-read-model.type.js';
 import type { IProjectQuery, IProjectsQuery } from './project-store-type.js';
 
 export type ProjectForUi = {
@@ -18,6 +19,7 @@ export type ProjectForUi = {
     lastUpdatedAt: Date | null;
     onboardingStatus?: OnboardingStatus;
     cleanupCount?: number;
+    membersPreview?: ProjectMember[];
 };
 
 export type ProjectForInsights = {

--- a/src/lib/features/project/project-read-model.ts
+++ b/src/lib/features/project/project-read-model.ts
@@ -235,7 +235,9 @@ export class ProjectReadModel implements IProjectReadModel {
 
     private async getMembersCount(): Promise<IProjectMembersCount[]> {
         const memberTimer = this.timer('getMembersCount');
-        const membersQuery = ProjectMembersReadModel.membersUnion(this.db);
+        const membersQuery = ProjectMembersReadModel.usersWithProjectRoles(
+            this.db,
+        );
 
         const members = await this.db
             .select('project')

--- a/src/lib/features/project/project-read-model.ts
+++ b/src/lib/features/project/project-read-model.ts
@@ -10,6 +10,7 @@ import type { IProjectQuery, IProjectsQuery } from './project-store-type.js';
 import metricsHelper from '../../util/metrics-helper.js';
 import type EventEmitter from 'events';
 import type { IProjectMembersCount } from './project-store.js';
+import { ProjectMembersReadModel } from './project-members-read-model.js';
 type Raw<T = any> = Knex.Raw<T>;
 
 const TABLE = 'projects';
@@ -234,22 +235,7 @@ export class ProjectReadModel implements IProjectReadModel {
 
     private async getMembersCount(): Promise<IProjectMembersCount[]> {
         const memberTimer = this.timer('getMembersCount');
-        const membersQuery = this.db
-            .select('user_id', 'project')
-            .from('role_user')
-            .leftJoin('roles', 'role_user.role_id', 'roles.id')
-            .where((builder) => builder.whereNot('type', 'root'))
-            .union((queryBuilder) => {
-                queryBuilder
-                    .select('user_id', 'project')
-                    .from('group_role')
-                    .leftJoin(
-                        'group_user',
-                        'group_user.group_id',
-                        'group_role.group_id',
-                    );
-            })
-            .as('query');
+        const membersQuery = ProjectMembersReadModel.membersUnion(this.db);
 
         const members = await this.db
             .select('project')

--- a/src/lib/features/project/project-service.e2e.test.ts
+++ b/src/lib/features/project/project-service.e2e.test.ts
@@ -214,6 +214,55 @@ describe('should list all projects', () => {
             expect(projectCleanupCount).toBe(1);
         });
     });
+
+    test("includes membersPreview with 'newProjectList' flag enabled", async () => {
+        const flagEnabledConfig = createTestConfig({
+            getLogger,
+            experimental: { flags: { newProjectList: true } },
+        });
+        const projectServiceWithFlag = createProjectService(
+            db.rawDatabase,
+            flagEnabledConfig,
+        );
+
+        const project = {
+            id: 'members-preview',
+            name: 'Members preview project',
+            description: 'Blah',
+            mode: 'open' as const,
+            defaultStickiness: 'default',
+        };
+
+        await projectServiceWithFlag.createProject(project, user, auditUser);
+
+        const memberUser = await stores.userStore.insert({
+            name: 'Member User',
+            username: 'preview-member',
+            email: 'preview-member@example.com',
+        });
+        const memberRoleId = (
+            await stores.roleStore.getRoleByName(RoleName.MEMBER)
+        ).id;
+        await stores.accessStore.addUserToRole(
+            memberUser.id,
+            memberRoleId,
+            project.id,
+        );
+
+        const projects = await projectServiceWithFlag.getProjects();
+        const projectMembersPreview = projects.find(
+            (p) => p.id === project.id,
+        )?.membersPreview;
+
+        expect(projectMembersPreview).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    name: 'Member User',
+                    email: 'preview-member@example.com',
+                }),
+            ]),
+        );
+    });
 });
 
 test('should create new project', async () => {

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -91,7 +91,7 @@ import metricsHelper from '../../util/metrics-helper.js';
 import { FUNCTION_TIME } from '../../metric-events.js';
 import type { ResourceLimitsService } from '../resource-limits/resource-limits-service.js';
 import type { OnboardingStatus } from '../onboarding/onboarding-read-model-type.js';
-import { ProjectMember } from './project-members-read-model.type.js';
+import type { ProjectMember } from './project-members-read-model.type.js';
 
 type Days = number;
 type Count = number;
@@ -269,7 +269,11 @@ export default class ProjectService {
         if (this.flagResolver.isEnabled('newProjectList')) {
             //TODO: update project-schema when removing this flag
             const projectIds = projects.map((p) => p.id);
-            const [onboardingStatuses, cleanupByProject, membersPreviewByProject] = await Promise.all([
+            const [
+                onboardingStatuses,
+                cleanupByProject,
+                membersPreviewByProject,
+            ] = await Promise.all([
                 this.onboardingReadModel
                     .getOnboardingStatusesForProjects(projectIds)
                     .catch(() => new Map<string, OnboardingStatus>()),
@@ -285,8 +289,9 @@ export default class ProjectService {
                         return map;
                     })
                     .catch(() => new Map<string, number>()),
-                 this.projectMembersReadModel.getMembersPreviewByProject()
-                 .catch(() => ({} as Record<string, ProjectMember[]>)),
+                this.projectMembersReadModel
+                    .getMembersPreviewByProject()
+                    .catch(() => ({}) as Record<string, ProjectMember[]>),
             ]);
 
             for (const project of projects) {

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -30,6 +30,7 @@ import {
     type IProjectHealth,
     type IProjectOverview,
     type IProjectOwnersReadModel,
+    type IProjectMembersReadModel,
     type IProjectRoleUsage,
     type IProjectStore,
     type IProjectUpdate,
@@ -90,6 +91,7 @@ import metricsHelper from '../../util/metrics-helper.js';
 import { FUNCTION_TIME } from '../../metric-events.js';
 import type { ResourceLimitsService } from '../resource-limits/resource-limits-service.js';
 import type { OnboardingStatus } from '../onboarding/onboarding-read-model-type.js';
+import { ProjectMember } from './project-members-read-model.type.js';
 
 type Days = number;
 type Count = number;
@@ -114,6 +116,8 @@ export default class ProjectService {
     private projectStore: IProjectStore;
 
     private projectOwnersReadModel: IProjectOwnersReadModel;
+
+    private projectMembersReadModel: IProjectMembersReadModel;
 
     private projectFlagCreatorsReadModel: IProjectFlagCreatorsReadModel;
 
@@ -167,6 +171,7 @@ export default class ProjectService {
         {
             projectStore,
             projectOwnersReadModel,
+            projectMembersReadModel,
             projectFlagCreatorsReadModel,
             eventStore,
             featureToggleStore,
@@ -182,6 +187,7 @@ export default class ProjectService {
             IUnleashStores,
             | 'projectStore'
             | 'projectOwnersReadModel'
+            | 'projectMembersReadModel'
             | 'projectFlagCreatorsReadModel'
             | 'eventStore'
             | 'featureToggleStore'
@@ -206,6 +212,7 @@ export default class ProjectService {
     ) {
         this.projectStore = projectStore;
         this.projectOwnersReadModel = projectOwnersReadModel;
+        this.projectMembersReadModel = projectMembersReadModel;
         this.projectFlagCreatorsReadModel = projectFlagCreatorsReadModel;
         this.environmentStore = environmentStore;
         this.featureEnvironmentStore = featureEnvironmentStore;
@@ -262,7 +269,7 @@ export default class ProjectService {
         if (this.flagResolver.isEnabled('newProjectList')) {
             //TODO: update project-schema when removing this flag
             const projectIds = projects.map((p) => p.id);
-            const [onboardingStatuses, cleanupByProject] = await Promise.all([
+            const [onboardingStatuses, cleanupByProject, membersPreviewByProject] = await Promise.all([
                 this.onboardingReadModel
                     .getOnboardingStatusesForProjects(projectIds)
                     .catch(() => new Map<string, OnboardingStatus>()),
@@ -278,11 +285,15 @@ export default class ProjectService {
                         return map;
                     })
                     .catch(() => new Map<string, number>()),
+                 this.projectMembersReadModel.getMembersPreviewByProject()
+                 .catch(() => ({} as Record<string, ProjectMember[]>)),
             ]);
 
             for (const project of projects) {
                 project.onboardingStatus = onboardingStatuses.get(project.id);
                 project.cleanupCount = cleanupByProject.get(project.id);
+                project.membersPreview =
+                    membersPreviewByProject[project.id] ?? [];
             }
         }
 

--- a/src/lib/types/stores.ts
+++ b/src/lib/types/stores.ts
@@ -41,6 +41,7 @@ import type { IInactiveUsersStore } from '../users/inactive/types/inactive-users
 import type { ITrafficDataUsageStore } from '../features/traffic-data-usage/traffic-data-usage-store-type.js';
 import type { ISegmentReadModel } from '../features/segment/segment-read-model-type.js';
 import type { IProjectOwnersReadModel } from '../features/project/project-owners-read-model.type.js';
+import type { IProjectMembersReadModel } from '../features/project/project-members-read-model.type.js';
 import type { IFeatureLifecycleStore } from '../features/feature-lifecycle/feature-lifecycle-store-type.js';
 import type { IProjectFlagCreatorsReadModel } from '../features/project/project-flag-creators-read-model.type.js';
 import type { IFeatureStrategiesReadModel } from '../features/feature-toggle/types/feature-strategies-read-model-type.js';
@@ -113,6 +114,7 @@ export interface IUnleashStores {
     trafficDataUsageStore: ITrafficDataUsageStore;
     segmentReadModel: ISegmentReadModel;
     projectOwnersReadModel: IProjectOwnersReadModel;
+    projectMembersReadModel: IProjectMembersReadModel;
     projectFlagCreatorsReadModel: IProjectFlagCreatorsReadModel;
     featureLifecycleStore: IFeatureLifecycleStore;
     featureStrategiesReadModel: IFeatureStrategiesReadModel;
@@ -179,6 +181,7 @@ export {
     type ITrafficDataUsageStore,
     type ISegmentReadModel,
     type IProjectOwnersReadModel,
+    type IProjectMembersReadModel,
     type IFeatureLifecycleStore,
     type IProjectFlagCreatorsReadModel,
     type IFeatureStrategiesReadModel,

--- a/src/test/fixtures/store.ts
+++ b/src/test/fixtures/store.ts
@@ -48,6 +48,7 @@ import { FakeInactiveUsersStore } from '../../lib/users/inactive/fakes/fake-inac
 import { FakeTrafficDataUsageStore } from '../../lib/features/traffic-data-usage/fake-traffic-data-usage-store.js';
 import { FakeSegmentReadModel } from '../../lib/features/segment/fake-segment-read-model.js';
 import { FakeProjectOwnersReadModel } from '../../lib/features/project/fake-project-owners-read-model.js';
+import { FakeProjectMembersReadModel } from '../../lib/features/project/fake-project-members-read-model.js';
 import { FakeFeatureLifecycleStore } from '../../lib/features/feature-lifecycle/fake-feature-lifecycle-store.js';
 import { FakeProjectFlagCreatorsReadModel } from '../../lib/features/project/fake-project-flag-creators-read-model.js';
 import { FakeFeatureStrategiesReadModel } from '../../lib/features/feature-toggle/fake-feature-strategies-read-model.js';
@@ -124,6 +125,7 @@ const createStores: () => IUnleashStores = () => {
         trafficDataUsageStore: new FakeTrafficDataUsageStore(),
         segmentReadModel: new FakeSegmentReadModel(),
         projectOwnersReadModel: new FakeProjectOwnersReadModel(),
+        projectMembersReadModel: new FakeProjectMembersReadModel(),
         projectFlagCreatorsReadModel: new FakeProjectFlagCreatorsReadModel(),
         featureLifecycleStore: new FakeFeatureLifecycleStore(),
         featureStrategiesReadModel: new FakeFeatureStrategiesReadModel(),


### PR DESCRIPTION
As part of the project card redesign, we want to render avatars for 4 project members (see [MUI component](https://mui.com/material-ui/react-avatar/#total-avatars)). 
This adds a flag-gated `membersPreview` field to each project on /api/admin/projects, which represents the "last" 4 members of a project (sorted by ID). 

- Adds `ProjectMembersReadModel` with `getMembersPreviewByProject()` and a static `membersUnion()` for the "who counts as a project member" subquery.
- `getProjects` in the project service merges `membersPreview` onto each project (gated by `newProjectList`)
- `getMembersCount` in the new project members read model reuses `membersUnion` instead of duplicating the UNION inline.