### PR TITLE
chore: simple wrap your code examples

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/FlagUsageSnippet.story.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/FlagUsageSnippet.story.tsx
@@ -1,5 +1,5 @@
 import type { Story, StoryMeta } from 'component/stories/types';
-import { FlagUsageSnippet } from './FlagUsageSnippet';
+import { FlagUsageSnippet, FlagUsageSnippetError } from './FlagUsageSnippet';
 
 export const meta: StoryMeta = {
     title: 'Feature/ImplementFlagDialog/FlagUsageSnippet',
@@ -67,3 +67,5 @@ export const Android: Story = () => (
 export const Flutter: Story = () => (
     <FlagUsageSnippet sdkName='Flutter' feature={feature} />
 );
+
+export const MissingSnippet: Story = () => <FlagUsageSnippetError />;

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/FlagUsageSnippet.story.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/FlagUsageSnippet.story.tsx
@@ -1,5 +1,6 @@
 import type { Story, StoryMeta } from 'component/stories/types';
-import { FlagUsageSnippet, FlagUsageSnippetError } from './FlagUsageSnippet';
+import type { SdkName } from 'component/onboarding/dialog/sharedTypes';
+import { FlagUsageSnippet } from './FlagUsageSnippet';
 
 export const meta: StoryMeta = {
     title: 'Feature/ImplementFlagDialog/FlagUsageSnippet',
@@ -68,4 +69,10 @@ export const Flutter: Story = () => (
     <FlagUsageSnippet sdkName='Flutter' feature={feature} />
 );
 
-export const MissingSnippet: Story = () => <FlagUsageSnippetError />;
+export const MissingSnippet: Story = () => (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    <FlagUsageSnippet
+        sdkName={'Unknown' as SdkName}
+        feature='my-feature-flag'
+    />
+);

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/FlagUsageSnippet.story.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/FlagUsageSnippet.story.tsx
@@ -1,0 +1,69 @@
+import type { Story, StoryMeta } from 'component/stories/types';
+import { FlagUsageSnippet } from './FlagUsageSnippet';
+
+export const meta: StoryMeta = {
+    title: 'Feature/ImplementFlagDialog/FlagUsageSnippet',
+    background: 'paper',
+};
+
+const feature = 'my-feature-flag';
+
+export const NodeJs: Story = () => (
+    <FlagUsageSnippet sdkName='Node.js' feature={feature} />
+);
+
+export const Go: Story = () => (
+    <FlagUsageSnippet sdkName='Go' feature={feature} />
+);
+
+export const DotNet: Story = () => (
+    <FlagUsageSnippet sdkName='.NET' feature={feature} />
+);
+
+export const Ruby: Story = () => (
+    <FlagUsageSnippet sdkName='Ruby' feature={feature} />
+);
+
+export const Php: Story = () => (
+    <FlagUsageSnippet sdkName='PHP' feature={feature} />
+);
+
+export const Rust: Story = () => (
+    <FlagUsageSnippet sdkName='Rust' feature={feature} />
+);
+
+export const Java: Story = () => (
+    <FlagUsageSnippet sdkName='Java' feature={feature} />
+);
+
+export const Python: Story = () => (
+    <FlagUsageSnippet sdkName='Python' feature={feature} />
+);
+
+export const JavaScript: Story = () => (
+    <FlagUsageSnippet sdkName='JavaScript' feature={feature} />
+);
+
+export const React: Story = () => (
+    <FlagUsageSnippet sdkName='React' feature={feature} />
+);
+
+export const Vue: Story = () => (
+    <FlagUsageSnippet sdkName='Vue' feature={feature} />
+);
+
+export const Svelte: Story = () => (
+    <FlagUsageSnippet sdkName='Svelte' feature={feature} />
+);
+
+export const Swift: Story = () => (
+    <FlagUsageSnippet sdkName='Swift' feature={feature} />
+);
+
+export const Android: Story = () => (
+    <FlagUsageSnippet sdkName='Android' feature={feature} />
+);
+
+export const Flutter: Story = () => (
+    <FlagUsageSnippet sdkName='Flutter' feature={feature} />
+);

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/FlagUsageSnippet.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/FlagUsageSnippet.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import { render } from 'utils/testRenderer';
+import type { SdkName } from 'component/onboarding/dialog/sharedTypes';
+import { FlagUsageSnippet } from './FlagUsageSnippet';
+
+describe('FlagUsageSnippet', () => {
+    it('renders the feature name in the snippet', () => {
+        render(<FlagUsageSnippet sdkName='Node.js' feature='my-test-flag' />);
+        expect(screen.getByText(/my-test-flag/)).toBeInTheDocument();
+    });
+
+    it('renders an error when the SDK has no snippet', () => {
+        render(
+            <FlagUsageSnippet
+                sdkName={'Unknown' as SdkName}
+                feature='my-test-flag'
+            />,
+        );
+        expect(
+            screen.getByText(/missing a flag usage example/i),
+        ).toBeInTheDocument();
+    });
+});

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/FlagUsageSnippet.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/FlagUsageSnippet.tsx
@@ -1,3 +1,4 @@
+import { Alert } from '@mui/material';
 import { Markdown } from 'component/common/Markdown/Markdown';
 import {
     CodeRenderer,
@@ -11,11 +12,20 @@ interface FlagUsageSnippetProps {
     feature: string;
 }
 
+export const FlagUsageSnippetError = () => (
+    <Alert severity='error'>
+        This SDK is missing a flag usage example. Please let us know so we can
+        add one!
+    </Alert>
+);
+
 export const FlagUsageSnippet = ({
     sdkName,
     feature,
 }: FlagUsageSnippetProps) => {
     const snippet = buildFlagUsageSnippet(codeRenderSnippets[sdkName], feature);
+
+    if (snippet === null) return <FlagUsageSnippetError />;
 
     return <Markdown components={{ code: CodeRenderer }}>{snippet}</Markdown>;
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/FlagUsageSnippet.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/FlagUsageSnippet.tsx
@@ -12,7 +12,7 @@ interface FlagUsageSnippetProps {
     feature: string;
 }
 
-export const FlagUsageSnippetError = () => (
+const FlagUsageSnippetError = () => (
     <Alert severity='error'>
         This SDK is missing a flag usage example. Please let us know so we can
         add one!
@@ -23,7 +23,10 @@ export const FlagUsageSnippet = ({
     sdkName,
     feature,
 }: FlagUsageSnippetProps) => {
-    const snippet = buildFlagUsageSnippet(codeRenderSnippets[sdkName], feature);
+    const rawSnippet = codeRenderSnippets[sdkName];
+    const snippet = rawSnippet
+        ? buildFlagUsageSnippet(rawSnippet, feature)
+        : null;
 
     if (snippet === null) return <FlagUsageSnippetError />;
 

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/FlagUsageSnippet.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/FlagUsageSnippet.tsx
@@ -1,0 +1,21 @@
+import { Markdown } from 'component/common/Markdown/Markdown';
+import {
+    CodeRenderer,
+    codeRenderSnippets,
+} from 'component/onboarding/dialog/CodeRenderer';
+import type { SdkName } from 'component/onboarding/dialog/sharedTypes';
+import { buildFlagUsageSnippet } from './buildFlagUsageSnippet.ts';
+
+interface FlagUsageSnippetProps {
+    sdkName: SdkName;
+    feature: string;
+}
+
+export const FlagUsageSnippet = ({
+    sdkName,
+    feature,
+}: FlagUsageSnippetProps) => {
+    const snippet = buildFlagUsageSnippet(codeRenderSnippets[sdkName], feature);
+
+    return <Markdown components={{ code: CodeRenderer }}>{snippet}</Markdown>;
+};

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -11,17 +11,10 @@ import {
     useTheme,
 } from '@mui/material';
 import CheckIcon from '@mui/icons-material/Check';
-import { Markdown } from 'component/common/Markdown/Markdown';
-import {
-    CodeRenderer,
-    codeRenderSnippets,
-} from 'component/onboarding/dialog/CodeRenderer';
 import { allSdks, type SdkName } from 'component/onboarding/dialog/sharedTypes';
-import { buildSdkApiUrl } from 'component/onboarding/dialog/buildSdkApiUrl';
 import useFeatureMetrics from 'hooks/api/getters/useFeatureMetrics/useFeatureMetrics';
-import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { ImplementFlagInformation } from './ImplementFlagInformation.tsx';
-import { buildFlagUsageSnippet } from './buildFlagUsageSnippet.ts';
+import { FlagUsageSnippet } from './FlagUsageSnippet.tsx';
 
 const StyledDialog = styled(Dialog)(({ theme }) => ({
     '& .MuiDialog-paper': {
@@ -217,15 +210,6 @@ const DialogBody = ({ projectId, feature, onClose }: DialogBodyProps) => {
     });
     const evaluated = metrics.seenApplications.length > 0;
 
-    const { uiConfig } = useUiConfig();
-    const apiUrl = buildSdkApiUrl(uiConfig.unleashUrl, sdkName);
-
-    const wrappedSnippet = buildFlagUsageSnippet(
-        codeRenderSnippets[sdkName] || '',
-        feature,
-        apiUrl,
-    );
-
     return (
         <Container>
             <Content>
@@ -265,9 +249,7 @@ const DialogBody = ({ projectId, feature, onClose }: DialogBodyProps) => {
                         >
                             Code example
                         </Typography>
-                        <Markdown components={{ code: CodeRenderer }}>
-                            {wrappedSnippet}
-                        </Markdown>
+                        <FlagUsageSnippet sdkName={sdkName} feature={feature} />
                     </Box>
 
                     <Box>

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.test.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.test.ts
@@ -17,37 +17,21 @@ describe('buildFlagUsageSnippet', () => {
             '---',
             '```jsx',
             "if (useFlag('<YOUR_FLAG>')) {",
-            "    return 'enabled';",
+            "    return '<YOUR_FLAG> enabled';",
             '} else {',
-            "    return 'disabled';",
+            "    return '<YOUR_FLAG> disabled';",
             '}',
             '```',
         ].join('\n');
 
         expect(buildFlagUsageSnippet(raw, 'my-flag')).toBe(
-            "```jsx\nif (useFlag('my-flag')) {\n    return 'enabled';\n} else {\n    return 'disabled';\n}\n```",
+            "```jsx\nif (useFlag('my-flag')) {\n    return 'my-flag enabled';\n} else {\n    return 'my-flag disabled';\n}\n```",
         );
     });
 
-    it('replaces every occurrence of the flag placeholder', () => {
-        const raw = [
-            '---',
-            '---',
-            '---',
-            '```js',
-            "const a = isEnabled('<YOUR_FLAG>');",
-            "const b = isEnabled('<YOUR_FLAG>');",
-            '```',
-        ].join('\n');
-
-        expect(buildFlagUsageSnippet(raw, 'flag-x')).toBe(
-            "```js\nconst a = isEnabled('flag-x');\nconst b = isEnabled('flag-x');\n```",
-        );
-    });
-
-    it('returns an empty string when there are no code blocks', () => {
-        expect(buildFlagUsageSnippet('just prose, no fences', 'x')).toBe('');
-        expect(buildFlagUsageSnippet('', 'x')).toBe('');
+    it('returns null when there are no code blocks', () => {
+        expect(buildFlagUsageSnippet('just prose, no fences', 'x')).toBeNull();
+        expect(buildFlagUsageSnippet('', 'x')).toBeNull();
     });
 });
 
@@ -56,6 +40,7 @@ describe('every SDK snippet has a flag usage section', () => {
         Object.entries(codeRenderSnippets),
     )('%s has a non-empty flag usage snippet', (_sdkName, snippet) => {
         const result = buildFlagUsageSnippet(snippet, 'test-flag');
-        expect(result.trim()).not.toBe('');
+        expect(result).not.toBeNull();
+        expect(result!.trim()).not.toBe('');
     });
 });

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.test.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.test.ts
@@ -1,56 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { buildFlagUsageSnippet } from './buildFlagUsageSnippet.ts';
-
-const API_URL = 'https://example.com/api/';
+import { codeRenderSnippets } from 'component/onboarding/dialog/CodeRenderer';
 
 describe('buildFlagUsageSnippet', () => {
-    it('extracts the last code block from a 3-step snippet and substitutes the flag name', () => {
+    it('extracts the code block from the last section of the snippet', () => {
         const raw = [
-            '1\\. Install',
             '```sh',
             'npm install foo',
-            '```',
-            '',
-            '2\\. Initialize',
-            '```jsx',
-            'const client = init();',
-            '```',
-            '',
-            '3\\. Check flag',
-            '```jsx',
-            "const enabled = useFlag('<YOUR_FLAG>');",
-            '```',
-        ].join('\n');
-
-        expect(buildFlagUsageSnippet(raw, 'my-flag', API_URL)).toBe(
-            "```jsx\nconst enabled = useFlag('my-flag');\n```",
-        );
-    });
-
-    it('picks the init+check block for 2-step snippets and substitutes both the flag and the API URL', () => {
-        const raw = [
-            '1\\. Install',
-            '```sh',
-            'npm install unleash',
-            '```',
-            '',
-            '2\\. Run Unleash',
-            '```js',
-            "const u = initialize({ url: '<YOUR_API_URL>' });",
-            "setInterval(() => console.log(u.isEnabled('<YOUR_FLAG>')), 1000);",
-            '```',
-        ].join('\n');
-
-        expect(buildFlagUsageSnippet(raw, 'checkout', API_URL)).toBe(
-            "```js\nconst u = initialize({ url: 'https://example.com/api/' });\nsetInterval(() => console.log(u.isEnabled('checkout')), 1000);\n```",
-        );
-    });
-
-    it('ignores content after the first `---` separator (production variant and resource links)', () => {
-        const raw = [
-            '1\\. Use',
-            '```jsx',
-            "useFlag('<YOUR_FLAG>')",
             '```',
             '---',
             '```jsx',
@@ -58,31 +14,48 @@ describe('buildFlagUsageSnippet', () => {
             '```',
             '---',
             '- [docs](https://example.com)',
-        ].join('\n');
-
-        expect(buildFlagUsageSnippet(raw, 'x', API_URL)).toBe(
-            "```jsx\nuseFlag('x')\n```",
-        );
-    });
-
-    it('replaces every occurrence of the placeholders', () => {
-        const raw = [
-            '```js',
-            "const a = isEnabled('<YOUR_FLAG>');",
-            "const b = isEnabled('<YOUR_FLAG>');",
-            "fetch('<YOUR_API_URL>'); fetch('<YOUR_API_URL>');",
+            '---',
+            '```jsx',
+            "if (useFlag('<YOUR_FLAG>')) {",
+            "    return 'enabled';",
+            '} else {',
+            "    return 'disabled';",
+            '}',
             '```',
         ].join('\n');
 
-        expect(buildFlagUsageSnippet(raw, 'flag-x', API_URL)).toBe(
-            "```js\nconst a = isEnabled('flag-x');\nconst b = isEnabled('flag-x');\nfetch('https://example.com/api/'); fetch('https://example.com/api/');\n```",
+        expect(buildFlagUsageSnippet(raw, 'my-flag')).toBe(
+            "```jsx\nif (useFlag('my-flag')) {\n    return 'enabled';\n} else {\n    return 'disabled';\n}\n```",
+        );
+    });
+
+    it('replaces every occurrence of the flag placeholder', () => {
+        const raw = [
+            '---',
+            '---',
+            '---',
+            '```js',
+            "const a = isEnabled('<YOUR_FLAG>');",
+            "const b = isEnabled('<YOUR_FLAG>');",
+            '```',
+        ].join('\n');
+
+        expect(buildFlagUsageSnippet(raw, 'flag-x')).toBe(
+            "```js\nconst a = isEnabled('flag-x');\nconst b = isEnabled('flag-x');\n```",
         );
     });
 
     it('returns an empty string when there are no code blocks', () => {
-        expect(
-            buildFlagUsageSnippet('just prose, no fences', 'x', API_URL),
-        ).toBe('');
-        expect(buildFlagUsageSnippet('', 'x', API_URL)).toBe('');
+        expect(buildFlagUsageSnippet('just prose, no fences', 'x')).toBe('');
+        expect(buildFlagUsageSnippet('', 'x')).toBe('');
+    });
+});
+
+describe('every SDK snippet has a flag usage section', () => {
+    it.each(
+        Object.entries(codeRenderSnippets),
+    )('%s has a non-empty flag usage snippet', (_sdkName, snippet) => {
+        const result = buildFlagUsageSnippet(snippet, 'test-flag');
+        expect(result.trim()).not.toBe('');
     });
 });

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.test.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.test.ts
@@ -3,7 +3,7 @@ import { buildFlagUsageSnippet } from './buildFlagUsageSnippet.ts';
 import { codeRenderSnippets } from 'component/onboarding/dialog/CodeRenderer';
 
 describe('buildFlagUsageSnippet', () => {
-    it('extracts the code block from the last section of the snippet', () => {
+    it('extracts the code block from the third section of the snippet', () => {
         const raw = [
             '```sh',
             'npm install foo',
@@ -29,7 +29,7 @@ describe('buildFlagUsageSnippet', () => {
         );
     });
 
-    it('returns null when there are no code blocks', () => {
+    it('returns null when there is text in the snippet', () => {
         expect(buildFlagUsageSnippet('just prose, no fences', 'x')).toBeNull();
         expect(buildFlagUsageSnippet('', 'x')).toBeNull();
     });

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.ts
@@ -1,6 +1,6 @@
 /**
  * Given a raw onboarding markdown snippet (e.g. `react.md`), returns a
- * markdown string containing only the flag-usage code block with the
+ * markdown string containing the flag-usage code block with the
  * `<YOUR_FLAG>` placeholder replaced by the given feature name.
  *
  * Onboarding snippets have the shape:
@@ -9,37 +9,22 @@
  *     ```sh …```
  *     2. Initialize …
  *     ```js …```
- *     3. Check flag (optional third step)
- *     ```jsx …```
  *     ---
  *     ```… production variant …```
  *     ---
  *     - resource links
+ *     ---
+ *     ```… explicit flag usage example …```
  *
- * We want just the flag-usage block. We take the content before the first
- * `---` separator and pick the last fenced code block from it, which is the
- * check-the-flag example for 3-step SDKs, or the combined init-and-check
- * block for 2-step SDKs (Node, Python).
+ * We take the 3rd `---` section which is a dedicated flag-usage snippet.
  */
 export const buildFlagUsageSnippet = (
     rawSnippet: string,
     feature: string,
-    apiUrl: string,
 ): string => {
-    const [connectSection] = rawSnippet.split('---\n');
-    const lastBlock = extractLastCodeBlock(connectSection);
-    if (!lastBlock) return '';
-    const code = lastBlock.code
-        .replaceAll('<YOUR_FLAG>', feature)
-        .replaceAll('<YOUR_API_URL>', apiUrl);
-    return `\`\`\`${lastBlock.language}\n${code}\n\`\`\``;
-};
+    const sections = rawSnippet.split('---\n');
+    const lastSection = sections[3];
+    if (!lastSection) return '';
 
-const FENCED_CODE_BLOCK = /```(\w*)\n([\s\S]*?)```/g;
-
-const extractLastCodeBlock = (markdown: string) => {
-    const matches = [...markdown.matchAll(FENCED_CODE_BLOCK)];
-    if (matches.length === 0) return null;
-    const [, language, code] = matches[matches.length - 1];
-    return { language, code: code.trim() };
+    return lastSection.replaceAll('<YOUR_FLAG>', feature);
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/buildFlagUsageSnippet.ts
@@ -21,10 +21,10 @@
 export const buildFlagUsageSnippet = (
     rawSnippet: string,
     feature: string,
-): string => {
+): string | null => {
     const sections = rawSnippet.split('---\n');
     const lastSection = sections[3];
-    if (!lastSection) return '';
+    if (!lastSection) return null;
 
     return lastSection.replaceAll('<YOUR_FLAG>', feature);
 };

--- a/frontend/src/component/onboarding/dialog/snippets/android.md
+++ b/frontend/src/component/onboarding/dialog/snippets/android.md
@@ -64,3 +64,15 @@ class MainActivity : ComponentActivity() {
 ---
 - [SDK repository with documentation and example](https://github.com/Unleash/unleash-android)
 - [Android SDK basic example](hhttps://github.com/Unleash/unleash-sdk-examples/tree/main/Android)
+
+---
+
+```kotlin
+if (unleash.isEnabled("<YOUR_FLAG>")) {
+    println("<YOUR_FLAG> is enabled")
+} else {
+    println("<YOUR_FLAG> is disabled")
+}
+```
+
+ℹ️ **Info:** The Android SDK takes at least 60 seconds to post metrics to Unleash.

--- a/frontend/src/component/onboarding/dialog/snippets/dotnet.md
+++ b/frontend/src/component/onboarding/dialog/snippets/dotnet.md
@@ -51,3 +51,13 @@ var settings = new UnleashSettings()
 ---
 - [SDK repository with documentation](https://github.com/Unleash/unleash-client-dotnet)
 - [.NET/C# SDK example with CodeSandbox](https://github.com/Unleash/unleash-sdk-examples/tree/main/Csharp)
+
+---
+
+```csharp
+if (unleash.IsEnabled("<YOUR_FLAG>")) {
+    Console.WriteLine("<YOUR_FLAG> is enabled");
+} else {
+    Console.WriteLine("<YOUR_FLAG> is disabled");
+}
+```

--- a/frontend/src/component/onboarding/dialog/snippets/flutter.md
+++ b/frontend/src/component/onboarding/dialog/snippets/flutter.md
@@ -38,3 +38,13 @@ unleash.start();
 - [SDK repository with documentation](https://github.com/Unleash/unleash_proxy_client_flutter)
 - [Flutter example with CodeSandbox](https://github.com/Unleash/unleash-sdk-examples/tree/main/Flutter)
 - [A/B Testing in Flutter using Unleash and Mixpanel](https://docs.getunleash.io/guides/implement-ab-test-in-flutter)
+
+---
+
+```dart
+if (unleash.isEnabled("<YOUR_FLAG>")) {
+    print("<YOUR_FLAG> is enabled");
+} else {
+    print("<YOUR_FLAG> is disabled");
+}
+```

--- a/frontend/src/component/onboarding/dialog/snippets/go.md
+++ b/frontend/src/component/onboarding/dialog/snippets/go.md
@@ -47,3 +47,13 @@ func init() {
 ---
 - [SDK repository with documentation](https://github.com/Unleash/unleash-client-go)
 - [Go SDK example with CodeSandbox](https://github.com/Unleash/unleash-sdk-examples/tree/main/Go)
+
+---
+
+```go
+if unleash.IsEnabled("<YOUR_FLAG>") {
+    fmt.Println("<YOUR_FLAG> is enabled")
+} else {
+    fmt.Println("<YOUR_FLAG> is disabled")
+}
+```

--- a/frontend/src/component/onboarding/dialog/snippets/java.md
+++ b/frontend/src/component/onboarding/dialog/snippets/java.md
@@ -39,3 +39,13 @@ UnleashConfig config = UnleashConfig.builder()
 - [SDK repository with documentation](https://github.com/Unleash/unleash-client-java)
 - [Java SDK example with CodeSandbox](https://github.com/Unleash/unleash-sdk-examples/tree/main/Java)
 - [How to Implement Feature Flags in Java](https://docs.getunleash.io/feature-flag-tutorials/java)
+
+---
+
+```java
+if (unleash.isEnabled("<YOUR_FLAG>")) {
+    System.out.println("<YOUR_FLAG> is enabled");
+} else {
+    System.out.println("<YOUR_FLAG> is disabled");
+}
+```

--- a/frontend/src/component/onboarding/dialog/snippets/javascript.md
+++ b/frontend/src/component/onboarding/dialog/snippets/javascript.md
@@ -45,3 +45,13 @@ unleash.start();
 ---
 - [SDK repository with documentation](https://github.com/Unleash/unleash-proxy-client-js)
 - [JavaScript SDK example with CodeSandbox](https://github.com/Unleash/unleash-sdk-examples/tree/main/JavaScript)
+
+---
+
+```js
+if (unleash.isEnabled('<YOUR_FLAG>')) {
+    console.log('<YOUR_FLAG> is enabled');
+} else {
+    console.log('<YOUR_FLAG> is disabled');
+}
+```

--- a/frontend/src/component/onboarding/dialog/snippets/nodejs.md
+++ b/frontend/src/component/onboarding/dialog/snippets/nodejs.md
@@ -53,3 +53,13 @@ setInterval(() => {
 - [SDK repository with documentation](https://github.com/Unleash/unleash-client-node)
 - [Node.js SDK example with CodeSandbox](https://github.com/Unleash/unleash-sdk-examples/tree/main/Node.js)
 - [Node.js SDK tutorial](https://dev.to/reeshee/how-to-implement-feature-flags-in-nodejs-using-unleash-3907)
+
+---
+
+```js
+if (unleash.isEnabled('<YOUR_FLAG>')) {
+    console.log('<YOUR_FLAG> is enabled');
+} else {
+    console.log('<YOUR_FLAG> is disabled');
+}
+```

--- a/frontend/src/component/onboarding/dialog/snippets/php.md
+++ b/frontend/src/component/onboarding/dialog/snippets/php.md
@@ -36,3 +36,13 @@ $unleash = UnleashBuilder::create()
 ---
 - [SDK repository with documentation](https://github.com/Unleash/unleash-client-php)
 - [PHP SDK example with CodeSandbox](https://github.com/Unleash/unleash-sdk-examples/tree/main/PHP)
+
+---
+
+```php
+if ($unleash->isEnabled('<YOUR_FLAG>')) {
+    echo '<YOUR_FLAG> is enabled' . PHP_EOL;
+} else {
+    echo '<YOUR_FLAG> is disabled' . PHP_EOL;
+}
+```

--- a/frontend/src/component/onboarding/dialog/snippets/python.md
+++ b/frontend/src/component/onboarding/dialog/snippets/python.md
@@ -35,3 +35,12 @@ client = UnleashClient(
 - [SDK repository with documentation](https://github.com/Unleash/unleash-client-python)
 - [Python SDK example with CodeSandbox](https://github.com/Unleash/unleash-sdk-examples/tree/main/Python)
 - [How to Implement Feature Flags in Python](https://docs.getunleash.io/feature-flag-tutorials/python)
+
+---
+
+```python
+if client.is_enabled("<YOUR_FLAG>"):
+    print("<YOUR_FLAG> is enabled")
+else:
+    print("<YOUR_FLAG> is disabled")
+```

--- a/frontend/src/component/onboarding/dialog/snippets/react.md
+++ b/frontend/src/component/onboarding/dialog/snippets/react.md
@@ -49,3 +49,17 @@ const config = {
 - [React SDK example with CodeSandbox](https://github.com/Unleash/unleash-sdk-examples/tree/main/React)
 - [https://docs.getunleash.io/feature-flag-tutorials/react](https://docs.getunleash.io/feature-flag-tutorials/react)
 
+---
+
+```jsx
+const TestComponent = () => {
+  const enabled = useFlag('<YOUR_FLAG>');
+
+  if (enabled) {
+    return (<div>{'<YOUR_FLAG> is enabled'}</div>);
+  } else {
+    return (<div>{'<YOUR_FLAG> is disabled'}</div>);
+  }
+};
+```
+

--- a/frontend/src/component/onboarding/dialog/snippets/ruby.md
+++ b/frontend/src/component/onboarding/dialog/snippets/ruby.md
@@ -38,3 +38,13 @@ end
 - [SDK repository with documentation](https://github.com/Unleash/unleash-client-ruby)
 - [Ruby example with CodeSandbox](https://github.com/Unleash/unleash-sdk-examples/tree/main/Ruby)
 - [How to Implement Feature Flags in Ruby](https://docs.getunleash.io/feature-flag-tutorials/ruby)
+
+---
+
+```rb
+if @unleash.is_enabled?("<YOUR_FLAG>")
+    puts "<YOUR_FLAG> is enabled"
+else
+    puts "<YOUR_FLAG> is disabled"
+end
+```

--- a/frontend/src/component/onboarding/dialog/snippets/rust.md
+++ b/frontend/src/component/onboarding/dialog/snippets/rust.md
@@ -67,3 +67,18 @@ client.register().await?;
 - [SDK repository with documentation](https://github.com/Unleash/unleash-client-rust)
 - [Rust example with CodeSandbox](https://github.com/Unleash/unleash-sdk-examples/tree/main/Rust)
 - [How to Implement Feature Flags in Rust](https://docs.getunleash.io/feature-flag-tutorials/rust)
+
+---
+
+```rust
+enum Flags {
+    #[serde(rename = "<YOUR_FLAG>")]
+    TestFlag,
+}
+
+if client.is_enabled(Flags::TestFlag, None, true) {
+    println!("<YOUR_FLAG> is enabled");
+} else {
+    println!("<YOUR_FLAG> is disabled");
+}
+```

--- a/frontend/src/component/onboarding/dialog/snippets/svelte.md
+++ b/frontend/src/component/onboarding/dialog/snippets/svelte.md
@@ -50,3 +50,20 @@ const config = {
 - [SDK repository with documentation](https://github.com/Unleash/proxy-client-svelte)
 - [Svelte example with CodeSandbox](https://github.com/Unleash/unleash-sdk-examples/tree/main/Svelte)
 - [How to Implement Feature Flags in SvelteKit](https://docs.getunleash.io/feature-flag-tutorials/sveltekit)
+
+---
+
+```svelte
+<script lang="ts">
+	import { useFlag } from '@unleash/proxy-client-svelte';
+	const enabled = useFlag('<YOUR_FLAG>');
+</script>
+
+<section>
+	{#if $enabled}
+		<p><YOUR_FLAG> is enabled!</p>
+	{:else}
+		<p><YOUR_FLAG> is disabled!</p>
+	{/if}
+</section>
+```

--- a/frontend/src/component/onboarding/dialog/snippets/swift.md
+++ b/frontend/src/component/onboarding/dialog/snippets/swift.md
@@ -22,3 +22,16 @@ Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
 }
 ```
 ℹ️ **Info:** The Swift SDK takes at least 60 seconds to post metrics to Unleash.
+---
+---
+---
+
+```swift
+if unleash.isEnabled(name: "<YOUR_FLAG>") {
+    print("<YOUR_FLAG> is enabled")
+} else {
+    print("<YOUR_FLAG> is disabled")
+}
+```
+
+ℹ️ **Info:** The Swift SDK takes at least 60 seconds to post metrics to Unleash.

--- a/frontend/src/component/onboarding/dialog/snippets/vue.md
+++ b/frontend/src/component/onboarding/dialog/snippets/vue.md
@@ -47,3 +47,22 @@ const config = {
 ---
 - [SDK repository with documentation](https://github.com/Unleash/proxy-client-vue)
 - [Vue example with CodeSandbox](https://github.com/Unleash/unleash-sdk-examples/tree/main/Vue)
+
+---
+
+```vue
+<script setup lang="ts">
+import { useFlag, useFlagsStatus } from '@unleash/proxy-client-vue'
+
+const enabled = useFlag('<YOUR_FLAG>')
+const { flagsReady } = useFlagsStatus()
+</script>
+
+<template>
+  <div>
+    <div v-if="!flagsReady">Loading...</div>
+    <div v-else-if="enabled"><YOUR_FLAG> is enabled</div>
+    <div v-else><YOUR_FLAG> is disabled</div>
+  </div>
+</template>
+```


### PR DESCRIPTION
1. Add a simpler code example dedicated to "Wrap your code" dialog
2. Simplify the code rendering - it can just render the 3rd section without complex logic. 
3. How it will look like: 


<img width="1125" height="721" alt="Screenshot 2026-05-26 at 12 45 24" src="https://github.com/user-attachments/assets/5736f6c6-9ec9-4156-be85-c3cf2bb96f7f" />
<img width="1240" height="966" alt="Screenshot 2026-05-26 at 12 30 32" src="https://github.com/user-attachments/assets/11365b29-ed48-41ac-a158-2b0f27f2ae09" />
<img width="1261" height="818" alt="Screenshot 2026-05-26 at 12 30 11" src="https://github.com/user-attachments/assets/706ae338-c06d-45d5-ad30-c0ed289a9c6a" />
