### PR TITLE
fix: Avoid placeholders rendering over actual rows

### DIFF
--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.tsx
@@ -34,26 +34,29 @@ import { createFeatureOverviewCell } from 'component/common/Table/cells/FeatureO
 import { AvatarCell } from 'component/project/Project/PaginatedProjectFeatureToggles/AvatarCell';
 import { StatusCell } from './StatusCell/StatusCell.tsx';
 
-export const featuresPlaceholder = Array(15).fill({
-    name: 'Name of the feature',
-    description: 'Short description of the feature',
-    type: '-',
-    createdAt: new Date(2022, 1, 1).toISOString(),
-    project: 'projectID',
-    createdBy: {
-        id: 0,
-        name: 'admin',
-        imageUrl: '',
-    },
-    archivedAt: null,
-    favorite: false,
-    stale: false,
-    dependencyType: null,
-    tags: [],
-    environments: [],
-    impressionData: false,
-    segments: [],
-} as FeatureSearchResponseSchema);
+export const featuresPlaceholder: FeatureSearchResponseSchema[] = Array.from(
+    { length: 15 },
+    (_, index) => ({
+        name: `Name of feature #${index + 1}`,
+        description: 'Short description of the feature',
+        type: '-',
+        createdAt: new Date(2022, 1, 1).toISOString(),
+        project: 'projectID',
+        createdBy: {
+            id: 0,
+            name: 'admin',
+            imageUrl: '',
+        },
+        archivedAt: null,
+        favorite: false,
+        stale: false,
+        dependencyType: null,
+        tags: [],
+        environments: [],
+        impressionData: false,
+        segments: [],
+    }),
+);
 
 const columnHelper = createColumnHelper<FeatureSearchResponseSchema>();
 


### PR DESCRIPTION
This changes the placeholder result returned for feature searches to have unique names per flag. Even though it's just a placeholder and the flag name is obviously not real (it contains spaces), we still need to make sure they're unique because we use them as keys in tables etc.

This fixes the visual bug for the archived flags table.

The only thing that's changed is that we're using array.from instead of fill (to be able to map) and the name of the flags. (disable whitespace diff for a cleaner view)

Before:
<img width="1628" height="1173" alt="image" src="https://github.com/user-attachments/assets/cfb34d07-df49-46ef-a02d-17a9bed5b13e" />

After:
<img width="1538" height="1160" alt="image" src="https://github.com/user-attachments/assets/bbf9ad3b-f757-4054-966a-62d14679b87e" />
