### PR TITLE
fix: Remove placeholder segment rows.

### DIFF
--- a/frontend/src/component/segments/SegmentTable/SegmentTable.tsx
+++ b/frontend/src/component/segments/SegmentTable/SegmentTable.tsx
@@ -49,13 +49,15 @@ export const SegmentTable = () => {
 
     const data = useMemo<ISegment[]>(() => {
         if (!segments) {
-            return Array(5).fill({
+            return Array.from({ length: 5 }, (_, index) => ({
+                id: -(index + 1),
                 name: 'Segment name',
-                description: 'Segment descripton',
+                description: 'Segment description',
                 createdAt: new Date().toISOString(),
                 createdBy: 'user',
-                projectId: 'Project',
-            });
+                project: 'Project',
+                constraints: [],
+            }));
         }
 
         if (projectId) {


### PR DESCRIPTION
Much like we had placeholder flag rows, there were also placeholder segment rows being rendered. Similarly to how the flags all shared a name, these segments have no id, so there's no way to distinguish them from ... well, anything. This introduces a negative, unique id (and fixes some type issues and typos).

Before:
<img width="1271" height="612" alt="image" src="https://github.com/user-attachments/assets/dccfe4ed-f974-46f9-8c78-16d7cdb80a04" />


After:
<img width="1225" height="354" alt="image" src="https://github.com/user-attachments/assets/f9d2fea3-b433-421e-9930-73144513d94d" />
