### PR TITLE
chore: preemptively fix more placeholder data

### DIFF
--- a/frontend/src/component/admin/groups/Group/Group.tsx
+++ b/frontend/src/component/admin/groups/Group/Group.tsx
@@ -44,10 +44,23 @@ import {
 import { useScimSettings } from 'hooks/api/getters/useScimSettings/useScimSettings';
 import { scimGroupTooltip } from '../group-constants.ts';
 
-export const groupUsersPlaceholder: IGroupUser[] = Array(15).fill({
-    name: 'Name of the user',
-    username: 'Username of the user',
-});
+export const groupUsersPlaceholder: IGroupUser[] = Array.from(
+    { length: 15 },
+    (_, index) => ({
+        id: -(index + 1),
+        name: 'Name of the user',
+        username: 'Username of the user',
+        email: '',
+        createdAt: '',
+        imageUrl: '',
+        loginAttempts: 0,
+        permissions: null,
+        inviteLink: '',
+        rootRole: 0,
+        seenAt: null,
+        isAPI: false,
+    }),
+);
 
 export type PageQueryType = Partial<
     Record<'sort' | 'order' | 'search', string>

--- a/frontend/src/component/user/Profile/PersonalAPITokensTab/PersonalAPITokensTab.tsx
+++ b/frontend/src/component/user/Profile/PersonalAPITokensTab/PersonalAPITokensTab.tsx
@@ -63,12 +63,16 @@ const StyledPlaceholderSubtitle = styled(Typography)(({ theme }) => ({
     marginBottom: theme.spacing(4.5),
 }));
 
-export const tokensPlaceholder: IPersonalAPIToken[] = Array(15).fill({
-    description: 'Short description of the feature',
-    type: '-',
-    createdAt: new Date(2022, 1, 1),
-    project: 'projectID',
-});
+export const tokensPlaceholder: IPersonalAPIToken[] = Array.from(
+    { length: 15 },
+    (_, index) => ({
+        id: `placeholder-${index}`,
+        description: 'Short description of the feature',
+        expiresAt: '',
+        createdAt: new Date(2022, 1, 1).toISOString(),
+        seenAt: '',
+    }),
+);
 
 export type PageQueryType = Partial<
     Record<'sort' | 'order' | 'search', string>


### PR DESCRIPTION
These apparently don't cause any issues today, but because they have no unique IDs, they may well do so in the future. So let's add ids and make sure the data we return actually matches the expected format (`array.fill` apparently returns `any[]`, so `any`thing goes).