### PR TITLE
chore: update react router step 2: startTransition

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -26,11 +26,13 @@ import { useRecordUIErrorApi } from 'hooks/api/actions/useRecordUIErrorApi/useRe
 import { HighlightProvider } from 'component/common/Highlight/HighlightProvider';
 import { UnleashFlagProvider } from 'component/providers/UnleashFlagProvider/UnleashFlagProvider';
 import { WelcomeDialogProvider } from 'component/personalDashboard/WelcomeDialogProvider.tsx';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 window.global ||= window;
 
 const ApplicationRoot = () => {
     const { recordUiError } = useRecordUIErrorApi();
+    const useStartTransition = useUiFlag('reactRouter_v7_startTransition');
 
     const sendErrorToApi = async (
         error: Error,
@@ -49,7 +51,10 @@ const ApplicationRoot = () => {
     return (
         <UIProviderContainer>
             <AccessProvider>
-                <BrowserRouter basename={basePath}>
+                <BrowserRouter
+                    basename={basePath}
+                    future={{ v7_startTransition: useStartTransition }}
+                >
                     <QueryParamProvider adapter={ReactRouter6Adapter}>
                         <ThemeProvider>
                             <AnnouncerProvider>

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -96,6 +96,7 @@ export type UiFlags = {
     onboardingConnectSDKNewDialog?: boolean;
     logRocketEnabled?: boolean;
     newProjectList?: boolean;
+    reactRouter_v7_startTransition?: boolean;
 };
 
 export interface IVersionInfo {

--- a/frontend/src/utils/testRenderer.tsx
+++ b/frontend/src/utils/testRenderer.tsx
@@ -48,7 +48,7 @@ export const render = (
             <UIProviderContainer>
                 <FeedbackProvider>
                     <AccessProviderMock permissions={permissions}>
-                        <BrowserRouter>
+                        <BrowserRouter future={{ v7_startTransition: true }}>
                             <QueryParamProvider adapter={ReactRouter6Adapter}>
                                 <ThemeProvider>
                                     <AnnouncerProvider>

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -78,8 +78,8 @@ export type IFlagKey =
     | 'accessOverviewRework'
     | 'onboardingConnectSDKNewDialog'
     | 'logRocketEnabled'
-    | 'reactRouter_v7_relativeSplatPath'
     | 'newProjectList'
+    | 'reactRouter_v7_relativeSplatPath'
     | 'reactRouter_v7_startTransition';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -78,7 +78,8 @@ export type IFlagKey =
     | 'accessOverviewRework'
     | 'onboardingConnectSDKNewDialog'
     | 'logRocketEnabled'
-    | 'newProjectList';
+    | 'newProjectList'
+    | 'reactRouter_v7_startTransition';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -355,6 +356,10 @@ const flags: IFlags = {
     ),
     newProjectList: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_NEW_PROJECT_LIST,
+        false,
+    ),
+    reactRouter_v7_startTransition: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_REACT_ROUTER_V7_START_TRANSITION,
         false,
     ),
 };


### PR DESCRIPTION
## Summary
- Part of the React Router v6 → v7 migration. Enables the `v7_startTransition` future flag, which wraps router state updates in `React.startTransition` so navigation can yield to more urgent work and integrate with Suspense.
- Adds a new `reactRouter_v7_startTransition` UI flag 
- The test renderer enables the flag unconditionally so the suite always exercises the v7 path.

## Why it should be safe
- Every `React.lazy(...)` call in the frontend is declared at module scope (not recreated per render), which is the failure mode the migration guide specifically calls out for `startTransition`.
- All lazy route components render below the top-level `<Suspense fallback={<Loader type='fullscreen' />}>` in `App.tsx`, so any suspension during a transition has a fallback to settle to.
- No `flushSync` or synchronous-state-after-navigate patterns in the codebase.
