### PR TITLE
feat: add new prometheus integration metrics [auth/addons]

### DIFF
--- a/src/lib/features/instance-stats/instance-stats-service.ts
+++ b/src/lib/features/instance-stats/instance-stats-service.ts
@@ -34,6 +34,7 @@ import type { IFeatureUsageInfo } from '../../services/version-service.js';
 import type { ReleasePlanTemplateStore } from '../release-plans/release-plan-template-store.js';
 import type { ReleasePlanStore } from '../release-plans/release-plan-store.js';
 import type { GetEdgeInstances } from './getEdgeInstances.js';
+import { AUTH_PROVIDERS_CATALOG } from '../../types/settings/auth-settings.js';
 
 export type TimeRange = 'allTime' | '30d' | '7d';
 
@@ -276,7 +277,7 @@ export class InstanceStatsService {
     async hasOIDC(): Promise<boolean> {
         return this.memorize('hasOIDC', async () => {
             const settings = await this.settingStore.get<{ enabled: boolean }>(
-                'unleash.enterprise.auth.oidc',
+                AUTH_PROVIDERS_CATALOG['oidc'].configId,
             );
 
             return settings?.enabled || false;
@@ -286,7 +287,7 @@ export class InstanceStatsService {
     async hasSAML(): Promise<boolean> {
         return this.memorize('hasSAML', async () => {
             const settings = await this.settingStore.get<{ enabled: boolean }>(
-                'unleash.enterprise.auth.saml',
+                AUTH_PROVIDERS_CATALOG['saml'].configId,
             );
 
             return settings?.enabled || false;

--- a/src/lib/features/instance-stats/instance-stats-service.ts
+++ b/src/lib/features/instance-stats/instance-stats-service.ts
@@ -34,7 +34,7 @@ import type { IFeatureUsageInfo } from '../../services/version-service.js';
 import type { ReleasePlanTemplateStore } from '../release-plans/release-plan-template-store.js';
 import type { ReleasePlanStore } from '../release-plans/release-plan-store.js';
 import type { GetEdgeInstances } from './getEdgeInstances.js';
-import { AUTH_PROVIDERS_CATALOG } from '../../types/settings/auth-settings.js';
+import { getAuthConfigId } from '../../types/settings/auth-settings.js';
 
 export type TimeRange = 'allTime' | '30d' | '7d';
 
@@ -277,7 +277,7 @@ export class InstanceStatsService {
     async hasOIDC(): Promise<boolean> {
         return this.memorize('hasOIDC', async () => {
             const settings = await this.settingStore.get<{ enabled: boolean }>(
-                AUTH_PROVIDERS_CATALOG['oidc'].configId,
+                getAuthConfigId('oidc'),
             );
 
             return settings?.enabled || false;
@@ -287,7 +287,7 @@ export class InstanceStatsService {
     async hasSAML(): Promise<boolean> {
         return this.memorize('hasSAML', async () => {
             const settings = await this.settingStore.get<{ enabled: boolean }>(
-                AUTH_PROVIDERS_CATALOG['saml'].configId,
+                getAuthConfigId('saml'),
             );
 
             return settings?.enabled || false;
@@ -297,7 +297,7 @@ export class InstanceStatsService {
     async hasPasswordAuth(): Promise<boolean> {
         return this.memorize('hasPasswordAuth', async () => {
             const settings = await this.settingStore.get<{ disabled: boolean }>(
-                'unleash.auth.simple',
+                getAuthConfigId('simple'),
             );
 
             return (

--- a/src/lib/features/instance-stats/instance-stats-service.ts
+++ b/src/lib/features/instance-stats/instance-stats-service.ts
@@ -1,3 +1,4 @@
+import { AUTH_PROVIDERS_CATALOG } from '../../types/settings/auth-settings.js';
 import { sha256 } from 'js-sha256';
 import type { IUnleashConfig } from '../../types/option.js';
 import type {
@@ -34,7 +35,6 @@ import type { IFeatureUsageInfo } from '../../services/version-service.js';
 import type { ReleasePlanTemplateStore } from '../release-plans/release-plan-template-store.js';
 import type { ReleasePlanStore } from '../release-plans/release-plan-store.js';
 import type { GetEdgeInstances } from './getEdgeInstances.js';
-import { getAuthConfigId } from '../../types/settings/auth-settings.js';
 
 export type TimeRange = 'allTime' | '30d' | '7d';
 
@@ -277,7 +277,7 @@ export class InstanceStatsService {
     async hasOIDC(): Promise<boolean> {
         return this.memorize('hasOIDC', async () => {
             const settings = await this.settingStore.get<{ enabled: boolean }>(
-                getAuthConfigId('oidc'),
+                AUTH_PROVIDERS_CATALOG.OIDC.configId,
             );
 
             return settings?.enabled || false;
@@ -287,7 +287,7 @@ export class InstanceStatsService {
     async hasSAML(): Promise<boolean> {
         return this.memorize('hasSAML', async () => {
             const settings = await this.settingStore.get<{ enabled: boolean }>(
-                getAuthConfigId('saml'),
+                AUTH_PROVIDERS_CATALOG.SAML.configId,
             );
 
             return settings?.enabled || false;
@@ -297,7 +297,7 @@ export class InstanceStatsService {
     async hasPasswordAuth(): Promise<boolean> {
         return this.memorize('hasPasswordAuth', async () => {
             const settings = await this.settingStore.get<{ disabled: boolean }>(
-                getAuthConfigId('simple'),
+                AUTH_PROVIDERS_CATALOG.Simple.configId,
             );
 
             return (

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -8,6 +8,7 @@ import {
     registerIntegrationMetrics,
 } from './integration-metrics.js';
 import { AUTH_PROVIDERS_CATALOG } from '../../../types/settings/auth-settings.js';
+import { DbMetricsMonitor } from '../../../metrics-gauge.js';
 
 beforeEach(() => {
     register.clear();
@@ -25,13 +26,18 @@ const setupMetrics = (overrides: {
 }) => {
     const eventBus = new EventEmitter();
 
+    // tests call dbMetrics.refreshMetrics()
+    // before scraping to populate the gauge from the stub stores.
+    const dbMetrics = new DbMetricsMonitor(testConfig);
+
     registerIntegrationMetrics({
         config: testConfig,
         eventBus,
+        dbMetrics,
         addonProviders: overrides.addonProviders ?? {},
         stores: overrides.stores,
     });
-    return { eventBus };
+    return { eventBus, dbMetrics };
 };
 
 const makeAddonProvider = (
@@ -80,10 +86,12 @@ describe('Integration Metrics', () => {
                 ),
             };
 
-            setupMetrics({
+            const { dbMetrics } = setupMetrics({
                 addonProviders,
                 stores: stores([], {}),
             });
+            // the gauge only carries values after a refresh.
+            await dbMetrics.refreshMetrics();
 
             const output = await register.metrics();
 
@@ -121,10 +129,12 @@ describe('Integration Metrics', () => {
                 'old-addon': makeAddonProvider('old-addon', 'v7.0.0'),
             };
 
-            setupMetrics({
+            const { dbMetrics } = setupMetrics({
                 addonProviders,
                 stores: stores([], {}),
             });
+            // the gauge only carries values after a refresh.
+            await dbMetrics.refreshMetrics();
 
             const output = await register.metrics();
 
@@ -144,10 +154,12 @@ describe('Integration Metrics', () => {
                 webhook: makeAddonProvider('webhook'),
             };
 
-            setupMetrics({
+            const { dbMetrics } = setupMetrics({
                 addonProviders,
                 stores: stores([], {}),
             });
+            // the gauge only carries values after a refresh.
+            await dbMetrics.refreshMetrics();
 
             const output = await register.metrics();
 
@@ -176,19 +188,21 @@ describe('Integration Metrics', () => {
                 { provider: 'datadog', enabled: false },
             ];
 
-            setupMetrics({
+            const { dbMetrics } = setupMetrics({
                 addonProviders: {},
                 stores: stores(addonRows, {}),
             });
+            // Push-based: the gauge only carries values after a refresh.
+            await dbMetrics.refreshMetrics();
 
             const output = await register.metrics();
 
             expect(output).toMatch(
-                /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 1/,
+                /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 2/,
             );
-            // expect(output).toMatch(
-            //     /integration_configured\{[^}]*name="webhook"[^}]*state="disabled"[^}]*\} 1/,
-            // );
+            expect(output).toMatch(
+                /integration_configured\{[^}]*name="webhook"[^}]*state="disabled"[^}]*\} 1/,
+            );
             expect(output).toMatch(
                 /integration_configured\{[^}]*name="datadog"[^}]*state="disabled"[^}]*\} 1/,
             );
@@ -200,7 +214,7 @@ describe('Integration Metrics', () => {
         });
 
         test('reports auth providers as not_configured / enabled / disabled based on settings', async () => {
-            setupMetrics({
+            const { dbMetrics } = setupMetrics({
                 addonProviders: {},
                 stores: stores([], {
                     'unleash.enterprise.auth.oidc': { enabled: true },
@@ -209,6 +223,7 @@ describe('Integration Metrics', () => {
                     // simple is missing entirely
                 }),
             });
+            await dbMetrics.refreshMetrics();
 
             const output = await register.metrics();
 
@@ -233,7 +248,7 @@ describe('Integration Metrics', () => {
             );
         });
 
-        test('caches the DB read across calls within the TTL window', async () => {
+        test('scrapes between refreshes are zero-cost: the DB is not re-read', async () => {
             let calls = 0;
             const countingStores = {
                 addonStore: {
@@ -247,21 +262,24 @@ describe('Integration Metrics', () => {
                 },
             } as any;
 
-            setupMetrics({
+            const { dbMetrics } = setupMetrics({
                 addonProviders: {},
                 stores: countingStores,
             });
 
+            // one refresh -> populates the gauge.
+            await dbMetrics.refreshMetrics();
+
             await register.metrics();
+
+            // next scrapes read from memory - not hit the store until the next refresh.
             await register.metrics();
             await register.metrics();
 
-            // Each scrape only reads on the 1st call (cache miss).
-            // Two consecutive calls within 60s must not double-query.
             expect(calls).toBe(1);
         });
 
-        test('serves stale samples and never throws when the store fails', async () => {
+        test('serves stale values when a refresh fails (DbMetricsMonitor hides the error)', async () => {
             let attempt = 0;
             const flakyStores = {
                 addonStore: {
@@ -276,22 +294,21 @@ describe('Integration Metrics', () => {
                 settingStore: { get: async () => undefined },
             } as any;
 
-            setupMetrics({
+            const { dbMetrics } = setupMetrics({
                 addonProviders: {},
                 stores: flakyStores,
             });
 
-            // 1st call
+            // 1st refresh  gauge populate
+            await dbMetrics.refreshMetrics();
             const first = await register.metrics();
 
             expect(first).toMatch(
                 /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 1/,
             );
 
-            // 2nd call: store throws — must not throw, must serve stale
-            await expect(register.metrics()).resolves.toEqual(
-                expect.any(String),
-            );
+            // 2nd refresh: store throws. the previous gauge values stay in place.
+            await expect(dbMetrics.refreshMetrics()).resolves.not.toThrow();
             const second = await register.metrics();
 
             expect(second).toMatch(

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -1,3 +1,4 @@
+import EventEmitter from 'events';
 import { register } from 'prom-client';
 import noLogger from '../../../../test/fixtures/no-logger.js';
 import type { IAddonProviders } from '../../../addons/index.js';
@@ -11,6 +12,29 @@ import { AUTH_PROVIDERS_CATALOG } from '../../../types/settings/auth-settings.js
 beforeEach(() => {
     register.clear();
 });
+
+const testConfig = {
+    getLogger: noLogger,
+    server: { unleashUrl: 'http://localhost:4242' },
+    flagResolver: { isEnabled: () => false } as any,
+} as any;
+
+const setupMetrics = (overrides: {
+    addonProviders?: IAddonProviders;
+    stores: any;
+    options?: { cacheTtlMs?: number };
+}) => {
+    const eventBus = new EventEmitter();
+
+    registerIntegrationMetrics({
+        config: testConfig,
+        eventBus,
+        addonProviders: overrides.addonProviders ?? {},
+        stores: overrides.stores,
+        options: overrides.options,
+    });
+    return { eventBus };
+};
 
 const makeAddonProvider = (
     name: string,
@@ -58,10 +82,9 @@ describe('Integration Metrics', () => {
                 ),
             };
 
-            registerIntegrationMetrics({
+            setupMetrics({
                 addonProviders,
                 stores: stores([], {}),
-                getLogger: noLogger,
             });
 
             const output = await register.metrics();
@@ -100,10 +123,9 @@ describe('Integration Metrics', () => {
                 'old-addon': makeAddonProvider('old-addon', 'v7.0.0'),
             };
 
-            registerIntegrationMetrics({
+            setupMetrics({
                 addonProviders,
                 stores: stores([], {}),
-                getLogger: noLogger,
             });
 
             const output = await register.metrics();
@@ -124,10 +146,9 @@ describe('Integration Metrics', () => {
                 webhook: makeAddonProvider('webhook'),
             };
 
-            registerIntegrationMetrics({
+            setupMetrics({
                 addonProviders,
                 stores: stores([], {}),
-                getLogger: noLogger,
             });
 
             const output = await register.metrics();
@@ -157,10 +178,9 @@ describe('Integration Metrics', () => {
                 { provider: 'datadog', enabled: false },
             ];
 
-            registerIntegrationMetrics({
+            setupMetrics({
                 addonProviders: {},
                 stores: stores(addonRows, {}),
-                getLogger: noLogger,
             });
 
             const output = await register.metrics();
@@ -182,7 +202,7 @@ describe('Integration Metrics', () => {
         });
 
         test('reports auth providers as not_configured / enabled / disabled based on settings', async () => {
-            registerIntegrationMetrics({
+            setupMetrics({
                 addonProviders: {},
                 stores: stores([], {
                     'unleash.enterprise.auth.oidc': { enabled: true },
@@ -190,7 +210,6 @@ describe('Integration Metrics', () => {
                     'unleash.enterprise.auth.google': {}, // google has a row but enabled is undefined-ish
                     // simple is missing entirely
                 }),
-                getLogger: noLogger,
             });
 
             const output = await register.metrics();
@@ -230,10 +249,9 @@ describe('Integration Metrics', () => {
                 },
             } as any;
 
-            registerIntegrationMetrics({
+            setupMetrics({
                 addonProviders: {},
                 stores: countingStores,
-                getLogger: noLogger,
                 options: { cacheTtlMs: 60_000 },
             });
 
@@ -261,10 +279,9 @@ describe('Integration Metrics', () => {
                 settingStore: { get: async () => undefined },
             } as any;
 
-            registerIntegrationMetrics({
+            setupMetrics({
                 addonProviders: {},
                 stores: flakyStores,
-                getLogger: noLogger,
                 options: { cacheTtlMs: 0 }, // force a refetch on every collect
             });
 
@@ -306,23 +323,23 @@ describe('Integration Metrics', () => {
     });
 
     describe('auth_login_total', () => {
-        test('auth_login_total increments when the eventBus fires AUTH_LOGIN_COMPLETED', async () => {
-            const { authLoginTotal } = registerIntegrationMetrics({
+        test('increments when AUTH_LOGIN_COMPLETED is emitted on the eventBus', async () => {
+            const { eventBus } = setupMetrics({
                 addonProviders: {},
                 stores: stores([], {}),
-                getLogger: noLogger,
             });
-            authLoginTotal.increment({
+
+            eventBus.emit('auth-login-completed', {
                 provider: 'google',
                 outcome: 'success',
             });
-            authLoginTotal.increment({
+            eventBus.emit('auth-login-completed', {
+                provider: 'google',
+                outcome: 'success',
+            });
+            eventBus.emit('auth-login-completed', {
                 provider: 'google',
                 outcome: 'failure',
-            });
-            authLoginTotal.increment({
-                provider: 'google',
-                outcome: 'success',
             });
 
             const output = await register.metrics();

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -306,27 +306,33 @@ describe('Integration Metrics', () => {
     });
 
     describe('auth_login_total', () => {
-        test('auth_login_total increments when the eventBus fires AUTH_LOGIN_COMPLETED', () => {
+        test('auth_login_total increments when the eventBus fires AUTH_LOGIN_COMPLETED', async () => {
             const { authLoginTotal } = registerIntegrationMetrics({
                 addonProviders: {},
                 stores: stores([], {}),
                 getLogger: noLogger,
             });
-            authLoginTotal.inc({ provider: 'google', outcome: 'success' });
-            authLoginTotal.inc({ provider: 'google', outcome: 'failure' });
-            authLoginTotal.inc({ provider: 'google', outcome: 'success' });
+            authLoginTotal.increment({
+                provider: 'google',
+                outcome: 'success',
+            });
+            authLoginTotal.increment({
+                provider: 'google',
+                outcome: 'failure',
+            });
+            authLoginTotal.increment({
+                provider: 'google',
+                outcome: 'success',
+            });
 
-            const series = authLoginTotal as any;
-            const sample =
-                series.hashMap[
-                    Object.keys(series.hashMap).find(
-                        (k) =>
-                            k.includes('provider:google') &&
-                            k.includes('outcome:success'),
-                    )!
-                ];
+            const output = await register.metrics();
 
-            expect(sample.value).toBe(2);
+            expect(output).toMatch(
+                /auth_login_total\{[^}]*provider="google"[^}]*outcome="success"[^}]*\} 2/,
+            );
+            expect(output).toMatch(
+                /auth_login_total\{[^}]*provider="google"[^}]*outcome="failure"[^}]*\} 1/,
+            );
         });
     });
 });

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -1,0 +1,283 @@
+import { register } from 'prom-client';
+import noLogger from '../../../../test/fixtures/no-logger.js';
+import type { IAddonProviders } from '../../../addons/index.js';
+import type { IAddon } from '../../../types/stores/addon-store.js';
+import {
+    AUTH_PROVIDERS_CATALOG,
+    collectConfiguredSamples,
+    registerIntegrationMetrics,
+} from './integration-metrics.js';
+
+/**
+ * The prom-client default registry is a process-wide singleton. Each test
+ * must call `register.clear()` to avoid "Metric already registered" errors
+ * leaking between tests.
+ */
+beforeEach(() => {
+    register.clear();
+});
+
+const makeAddonProvider = (
+    name: string,
+    deprecated?: string,
+): IAddonProviders[string] =>
+    ({
+        name,
+        definition: {
+            name,
+            displayName: name,
+            description: '',
+            documentationUrl: '',
+            ...(deprecated ? { deprecated } : {}),
+        },
+    }) as unknown as IAddonProviders[string];
+
+const fakeAddonStore = (rows: Partial<IAddon>[]) => ({
+    getAll: async () => rows as IAddon[],
+});
+
+const fakeSettingStore = (
+    map: Record<string, { enabled?: boolean } | undefined>,
+) => ({
+    get: async <T>(name: string) => map[name] as T | undefined,
+});
+
+const stores = (
+    addons: Partial<IAddon>[],
+    settings: Record<string, { enabled?: boolean } | undefined>,
+) =>
+    ({
+        addonStore: fakeAddonStore(addons),
+        settingStore: fakeSettingStore(settings),
+    }) as any;
+
+describe('integration_available', () => {
+    test('emits one sample per registered addon and per known auth provider', async () => {
+        const addonProviders: IAddonProviders = {
+            webhook: makeAddonProvider('webhook'),
+            'slack-app': makeAddonProvider('slack-app'),
+            slack: makeAddonProvider(
+                'slack',
+                'Use slack-app instead. Removed in v8.',
+            ),
+        };
+
+        registerIntegrationMetrics({
+            addonProviders,
+            stores: stores([], {}),
+            getLogger: noLogger,
+        });
+
+        const output = await register.metrics();
+        // One series per addon
+        expect(output).toMatch(
+            /integration_available\{[^}]*name="webhook"[^}]*kind="addon"[^}]*deprecated="false"[^}]*\} 1/,
+        );
+        expect(output).toMatch(
+            /integration_available\{[^}]*name="slack-app"[^}]*kind="addon"[^}]*deprecated="false"[^}]*\} 1/,
+        );
+        // The deprecated addon is still "available" (still selectable); the
+        // deprecated flag is the discriminator, not the absence of a series.
+        expect(output).toMatch(
+            /integration_available\{[^}]*name="slack"[^}]*kind="addon"[^}]*deprecated="true"[^}]*\} 1/,
+        );
+        // All known auth providers are present too.
+        for (const provider of AUTH_PROVIDERS_CATALOG) {
+            const expectedDeprecated = provider.deprecatedRemovalTarget
+                ? 'true'
+                : 'false';
+            expect(output).toMatch(
+                new RegExp(
+                    `integration_available\\{[^}]*name="${provider.name}"[^}]*kind="auth"[^}]*deprecated="${expectedDeprecated}"[^}]*\\} 1`,
+                ),
+            );
+        }
+    });
+});
+
+describe('integration_deprecated_info', () => {
+    test('emits a series only for deprecated integrations', async () => {
+        const addonProviders: IAddonProviders = {
+            webhook: makeAddonProvider('webhook'),
+            'legacy-foo': makeAddonProvider(
+                'legacy-foo',
+                'will be removed in v9',
+            ),
+        };
+
+        registerIntegrationMetrics({
+            addonProviders,
+            stores: stores([], {}),
+            getLogger: noLogger,
+        });
+
+        const output = await register.metrics();
+
+        // Non-deprecated addon: must NOT appear in the deprecated gauge.
+        expect(output).not.toMatch(
+            /integration_deprecated_info\{[^}]*name="webhook"/,
+        );
+        // Deprecated addon: must appear with the deprecation string.
+        expect(output).toMatch(
+            /integration_deprecated_info\{[^}]*name="legacy-foo"[^}]*kind="addon"[^}]*removal_target="will be removed in v9"[^}]*\} 1/,
+        );
+        // Deprecated auth providers from the catalog appear too.
+        const deprecatedAuth = AUTH_PROVIDERS_CATALOG.filter(
+            (p) => p.deprecatedRemovalTarget,
+        );
+        for (const provider of deprecatedAuth) {
+            expect(output).toMatch(
+                new RegExp(
+                    `integration_deprecated_info\\{[^}]*name="${provider.name}"[^}]*kind="auth"[^}]*removal_target="${provider.deprecatedRemovalTarget}"[^}]*\\} 1`,
+                ),
+            );
+        }
+    });
+});
+
+describe('integration_configured', () => {
+    test('aggregates addons by provider × state', async () => {
+        const addonRows: Partial<IAddon>[] = [
+            { provider: 'webhook', enabled: true },
+            { provider: 'webhook', enabled: true },
+            { provider: 'webhook', enabled: false },
+            { provider: 'datadog', enabled: false },
+        ];
+
+        registerIntegrationMetrics({
+            addonProviders: {},
+            stores: stores(addonRows, {}),
+            getLogger: noLogger,
+        });
+
+        const output = await register.metrics();
+
+        expect(output).toMatch(
+            /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 2/,
+        );
+        expect(output).toMatch(
+            /integration_configured\{[^}]*name="webhook"[^}]*state="disabled"[^}]*\} 1/,
+        );
+        expect(output).toMatch(
+            /integration_configured\{[^}]*name="datadog"[^}]*state="disabled"[^}]*\} 1/,
+        );
+        // Datadog has no enabled rows — confirm the zero side is also emitted
+        // so dashboards have explicit zero, not absent series.
+        expect(output).toMatch(
+            /integration_configured\{[^}]*name="datadog"[^}]*state="enabled"[^}]*\} 0/,
+        );
+    });
+
+    test('reports auth providers as not_configured / enabled / disabled based on settings rows', async () => {
+        registerIntegrationMetrics({
+            addonProviders: {},
+            stores: stores([], {
+                'unleash.enterprise.auth.oidc': { enabled: true },
+                'unleash.enterprise.auth.saml': { enabled: false },
+                // google has a row but enabled is undefined-ish
+                'unleash.enterprise.auth.google': {},
+                // simple is missing entirely
+            }),
+            getLogger: noLogger,
+        });
+
+        const output = await register.metrics();
+
+        expect(output).toMatch(
+            /integration_configured\{[^}]*name="oidc"[^}]*kind="auth"[^}]*state="enabled"[^}]*\} 1/,
+        );
+        expect(output).toMatch(
+            /integration_configured\{[^}]*name="saml"[^}]*kind="auth"[^}]*state="disabled"[^}]*\} 1/,
+        );
+        // Row exists but enabled is falsy → disabled
+        expect(output).toMatch(
+            /integration_configured\{[^}]*name="google"[^}]*kind="auth"[^}]*state="disabled"[^}]*\} 1/,
+        );
+        // Missing row → not_configured
+        expect(output).toMatch(
+            /integration_configured\{[^}]*name="simple"[^}]*kind="auth"[^}]*state="not_configured"[^}]*\} 1/,
+        );
+    });
+
+    test('caches the DB read across scrapes within the TTL window', async () => {
+        let calls = 0;
+        const countingStores = {
+            addonStore: {
+                getAll: async () => {
+                    calls++;
+                    return [];
+                },
+            },
+            settingStore: {
+                get: async () => undefined,
+            },
+        } as any;
+
+        registerIntegrationMetrics({
+            addonProviders: {},
+            stores: countingStores,
+            getLogger: noLogger,
+            options: { cacheTtlMs: 60_000 },
+        });
+
+        await register.metrics();
+        await register.metrics();
+        await register.metrics();
+
+        // Each scrape only reads on the first call (cache miss). Two
+        // consecutive scrapes within 60s must not double-query.
+        expect(calls).toBe(1);
+    });
+
+    test('serves stale samples and never throws when the store fails', async () => {
+        let attempt = 0;
+        const flakyStores = {
+            addonStore: {
+                getAll: async () => {
+                    attempt++;
+                    if (attempt === 1) {
+                        return [{ provider: 'webhook', enabled: true }];
+                    }
+                    throw new Error('db is down');
+                },
+            },
+            settingStore: { get: async () => undefined },
+        } as any;
+
+        registerIntegrationMetrics({
+            addonProviders: {},
+            stores: flakyStores,
+            getLogger: noLogger,
+            options: { cacheTtlMs: 0 }, // force a refetch on every collect
+        });
+
+        // First scrape: warms the cache.
+        const first = await register.metrics();
+        expect(first).toMatch(
+            /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 1/,
+        );
+
+        // Second scrape: store throws — must not throw, must serve stale.
+        await expect(register.metrics()).resolves.toEqual(expect.any(String));
+        const second = await register.metrics();
+        expect(second).toMatch(
+            /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 1/,
+        );
+    });
+});
+
+describe('collectConfiguredSamples (helper)', () => {
+    test('skips auth providers whose store read throws (instead of corrupting state)', async () => {
+        const throwingStores = {
+            addonStore: { getAll: async () => [] },
+            settingStore: {
+                get: async () => {
+                    throw new Error('boom');
+                },
+            },
+        } as any;
+
+        const samples = await collectConfiguredSamples(throwingStores);
+        expect(samples).toEqual([]); // no auth samples produced; no exception
+    });
+});

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -99,15 +99,15 @@ describe('Integration Metrics', () => {
 
             // Non-deprecated addons: deprecated="false", removal_target=""
             expect(output).toMatch(
-                /integration_available\{[^}]*name="webhook"[^}]*kind="addon"[^}]*deprecated="false"[^}]*removal_target=""[^}]*\} 1/,
+                /integration_available\{[^}]*name="webhook"[^}]*deprecated="false"[^}]*removal_target=""[^}]*\} 1/,
             );
             expect(output).toMatch(
-                /integration_available\{[^}]*name="slack-app"[^}]*kind="addon"[^}]*deprecated="false"[^}]*removal_target=""[^}]*\} 1/,
+                /integration_available\{[^}]*name="slack-app"[^}]*deprecated="false"[^}]*removal_target=""[^}]*\} 1/,
             );
 
             // Deprecated addon: deprecated="true", removal_target="<message>"
             expect(output).toMatch(
-                /integration_available\{[^}]*name="slack"[^}]*kind="addon"[^}]*deprecated="true"[^}]*removal_target="Use slack-app instead\. Removed in v8\."[^}]*\} 1/,
+                /integration_available\{[^}]*name="slack"[^}]*deprecated="true"[^}]*removal_target="Use slack-app instead\. Removed in v8\."[^}]*\} 1/,
             );
 
             // All auth providers are present
@@ -120,7 +120,7 @@ describe('Integration Metrics', () => {
 
                 expect(output).toMatch(
                     new RegExp(
-                        `integration_available\\{[^}]*name="${provider.name}"[^}]*kind="auth"[^}]*deprecated="${expectedDeprecated}"[^}]*removal_target="${expectedRemovalTarget}"[^}]*\\} 1`,
+                        `integration_available\\{[^}]*name="${provider.name}"[^}]*deprecated="${expectedDeprecated}"[^}]*removal_target="${expectedRemovalTarget}"[^}]*\\} 1`,
                     ),
                 );
             }
@@ -147,7 +147,7 @@ describe('Integration Metrics', () => {
 
             // Verify Google auth provider (deprecated) has removal_target
             expect(output).toMatch(
-                /integration_available\{[^}]*name="google"[^}]*kind="auth"[^}]*deprecated="true"[^}]*removal_target="v8\.0\.0"[^}]*\} 1/,
+                /integration_available\{[^}]*name="google"[^}]*deprecated="true"[^}]*removal_target="v8\.0\.0"[^}]*\} 1/,
             );
         });
 
@@ -167,14 +167,14 @@ describe('Integration Metrics', () => {
 
             // Non-deprecated addon should have empty removal_target
             expect(output).toMatch(
-                /integration_available\{[^}]*name="webhook"[^}]*kind="addon"[^}]*deprecated="false"[^}]*removal_target=""[^}]*\} 1/,
+                /integration_available\{[^}]*name="webhook"[^}]*deprecated="false"[^}]*removal_target=""[^}]*\} 1/,
             );
 
             // Non-deprecated auth providers (simple, oidc, saml) have empty removal_target
             for (const providerName of ['simple', 'oidc', 'saml']) {
                 expect(output).toMatch(
                     new RegExp(
-                        `integration_available\\{[^}]*name="${providerName}"[^}]*kind="auth"[^}]*deprecated="false"[^}]*removal_target=""[^}]*\\} 1`,
+                        `integration_available\\{[^}]*name="${providerName}"[^}]*deprecated="false"[^}]*removal_target=""[^}]*\\} 1`,
                     ),
                 );
             }
@@ -230,17 +230,17 @@ describe('Integration Metrics', () => {
             const output = await register.metrics();
 
             expect(output).toMatch(
-                /integration_configured\{[^}]*name="oidc"[^}]*kind="auth"[^}]*state="enabled"[^}]*\} 1/,
+                /integration_configured\{[^}]*name="oidc"[^}]*state="enabled"[^}]*\} 1/,
             );
             expect(output).toMatch(
-                /integration_configured\{[^}]*name="saml"[^}]*kind="auth"[^}]*state="disabled"[^}]*\} 1/,
+                /integration_configured\{[^}]*name="saml"[^}]*state="disabled"[^}]*\} 1/,
             );
             expect(output).toMatch(
-                /integration_configured\{[^}]*name="google"[^}]*kind="auth"[^}]*state="disabled"[^}]*\} 1/,
+                /integration_configured\{[^}]*name="google"[^}]*state="disabled"[^}]*\} 1/,
             );
             // simple missing => enabled by default
             expect(output).toMatch(
-                /integration_configured\{[^}]*name="simple"[^}]*kind="auth"[^}]*state="enabled"[^}]*\} 1/,
+                /integration_configured\{[^}]*name="simple"[^}]*state="enabled"[^}]*\} 1/,
             );
         });
 
@@ -255,7 +255,7 @@ describe('Integration Metrics', () => {
 
             const output = await register.metrics();
             expect(output).toMatch(
-                /integration_configured\{[^}]*name="simple"[^}]*kind="auth"[^}]*state="disabled"[^}]*\} 1/,
+                /integration_configured\{[^}]*name="simple"[^}]*state="disabled"[^}]*\} 1/,
             );
         });
 
@@ -270,7 +270,7 @@ describe('Integration Metrics', () => {
 
             const output = await register.metrics();
             expect(output).toMatch(
-                /integration_configured\{[^}]*name="simple"[^}]*kind="auth"[^}]*state="enabled"[^}]*\} 1/,
+                /integration_configured\{[^}]*name="simple"[^}]*state="enabled"[^}]*\} 1/,
             );
         });
 

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -66,7 +66,10 @@ const fakeSettingStore = (
 
 const stores = (
     addons: Partial<IAddon>[],
-    settings: Record<string, { enabled?: boolean } | undefined>,
+    settings: Record<
+        string,
+        { enabled?: boolean; disabled?: boolean } | undefined
+    >,
 ) =>
     ({
         addonStore: fakeAddonStore(addons),
@@ -218,32 +221,56 @@ describe('Integration Metrics', () => {
                 stores: stores([], {
                     'unleash.enterprise.auth.oidc': { enabled: true },
                     'unleash.enterprise.auth.saml': { enabled: false },
-                    'unleash.enterprise.auth.google': {}, // google has a row but enabled is undefined-ish
-                    // simple is missing entirely
+                    'unleash.enterprise.auth.google': {}, // configured, disabled
+                    // simple missing => enabled by default
                 }),
             });
             await dbMetrics.refreshMetrics();
 
             const output = await register.metrics();
 
-            // enabled auth provider
             expect(output).toMatch(
                 /integration_configured\{[^}]*name="oidc"[^}]*kind="auth"[^}]*state="enabled"[^}]*\} 1/,
             );
-
-            // disabled auth provider
             expect(output).toMatch(
                 /integration_configured\{[^}]*name="saml"[^}]*kind="auth"[^}]*state="disabled"[^}]*\} 1/,
             );
-
-            // google configured but disabled
             expect(output).toMatch(
                 /integration_configured\{[^}]*name="google"[^}]*kind="auth"[^}]*state="disabled"[^}]*\} 1/,
             );
-
-            // not_configured
+            // simple missing => enabled by default
             expect(output).toMatch(
-                /integration_configured\{[^}]*name="simple"[^}]*kind="auth"[^}]*state="not_configured"[^}]*\} 1/,
+                /integration_configured\{[^}]*name="simple"[^}]*kind="auth"[^}]*state="enabled"[^}]*\} 1/,
+            );
+        });
+
+        test('simple auth: row with disabled=true is reported as disabled', async () => {
+            const { dbMetrics } = setupMetrics({
+                addonProviders: {},
+                stores: stores([], {
+                    'unleash.auth.simple': { disabled: true },
+                }),
+            });
+            await dbMetrics.refreshMetrics();
+
+            const output = await register.metrics();
+            expect(output).toMatch(
+                /integration_configured\{[^}]*name="simple"[^}]*kind="auth"[^}]*state="disabled"[^}]*\} 1/,
+            );
+        });
+
+        test('simple auth: empty row is reported as enabled', async () => {
+            const { dbMetrics } = setupMetrics({
+                addonProviders: {},
+                stores: stores([], {
+                    'unleash.auth.simple': {},
+                }),
+            });
+            await dbMetrics.refreshMetrics();
+
+            const output = await register.metrics();
+            expect(output).toMatch(
+                /integration_configured\{[^}]*name="simple"[^}]*kind="auth"[^}]*state="enabled"[^}]*\} 1/,
             );
         });
 

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -74,12 +74,12 @@ describe('Integration Metrics', () => {
                 /integration_available\{[^}]*name="slack-app"[^}]*kind="addon"[^}]*deprecated="false"[^}]*\} 1/,
             );
 
-            // The deprecated addon is still "available" (still selectable); the
-            // deprecated flag is the discriminator, not the absence of a series.
+            // Still available, but 'deprecated' flag is on
             expect(output).toMatch(
                 /integration_available\{[^}]*name="slack"[^}]*kind="addon"[^}]*deprecated="true"[^}]*\} 1/,
             );
-            // All known auth providers are present too.
+
+            // All auth providers are present too.
             for (const provider of AUTH_PROVIDERS_CATALOG) {
                 const expectedDeprecated = provider.deprecatedRemovalTarget
                     ? 'true'
@@ -111,15 +111,17 @@ describe('Integration Metrics', () => {
 
             const output = await register.metrics();
 
-            // Non-deprecated addon: must NOT appear in the deprecated gauge.
+            // Non-deprecated addon
             expect(output).not.toMatch(
                 /integration_deprecated_info\{[^}]*name="webhook"/,
             );
-            // Deprecated addon: must appear with the deprecation string.
+
+            // Deprecated addon
             expect(output).toMatch(
                 /integration_deprecated_info\{[^}]*name="legacy-foo"[^}]*kind="addon"[^}]*removal_target="will be removed in v9"[^}]*\} 1/,
             );
-            // Deprecated auth providers from the catalog appear too.
+
+            // Deprecated auth providers
             const deprecatedAuth = AUTH_PROVIDERS_CATALOG.filter(
                 (p) => p.deprecatedRemovalTarget,
             );
@@ -134,7 +136,7 @@ describe('Integration Metrics', () => {
     });
 
     describe('integration_configured', () => {
-        test('aggregates addons by provider × state', async () => {
+        test('aggregates addons by provider per state', async () => {
             const addonRows: Partial<IAddon>[] = [
                 { provider: 'webhook', enabled: true },
                 { provider: 'webhook', enabled: true },
@@ -159,21 +161,20 @@ describe('Integration Metrics', () => {
             expect(output).toMatch(
                 /integration_configured\{[^}]*name="datadog"[^}]*state="disabled"[^}]*\} 1/,
             );
-            // Datadog has no enabled rows — confirm the zero side is also emitted
-            // so dashboards have explicit zero, not absent series.
+
+            // Datadog has no enabled rows
             expect(output).toMatch(
                 /integration_configured\{[^}]*name="datadog"[^}]*state="enabled"[^}]*\} 0/,
             );
         });
 
-        test('reports auth providers as not_configured / enabled / disabled based on settings rows', async () => {
+        test('reports auth providers as not_configured / enabled / disabled based on settings', async () => {
             registerIntegrationMetrics({
                 addonProviders: {},
                 stores: stores([], {
                     'unleash.enterprise.auth.oidc': { enabled: true },
                     'unleash.enterprise.auth.saml': { enabled: false },
-                    // google has a row but enabled is undefined-ish
-                    'unleash.enterprise.auth.google': {},
+                    'unleash.enterprise.auth.google': {}, // google has a row but enabled is undefined-ish
                     // simple is missing entirely
                 }),
                 getLogger: noLogger,
@@ -181,23 +182,28 @@ describe('Integration Metrics', () => {
 
             const output = await register.metrics();
 
+            // enabled auth provider
             expect(output).toMatch(
                 /integration_configured\{[^}]*name="oidc"[^}]*kind="auth"[^}]*state="enabled"[^}]*\} 1/,
             );
+
+            // disabled auth provider
             expect(output).toMatch(
                 /integration_configured\{[^}]*name="saml"[^}]*kind="auth"[^}]*state="disabled"[^}]*\} 1/,
             );
-            // Row exists but enabled is falsy → disabled
+
+            // google configured but disabled
             expect(output).toMatch(
                 /integration_configured\{[^}]*name="google"[^}]*kind="auth"[^}]*state="disabled"[^}]*\} 1/,
             );
-            // Missing row → not_configured
+
+            // not_configured
             expect(output).toMatch(
                 /integration_configured\{[^}]*name="simple"[^}]*kind="auth"[^}]*state="not_configured"[^}]*\} 1/,
             );
         });
 
-        test('caches the DB read across scrapes within the TTL window', async () => {
+        test('caches the DB read across calls within the TTL window', async () => {
             let calls = 0;
             const countingStores = {
                 addonStore: {
@@ -222,8 +228,8 @@ describe('Integration Metrics', () => {
             await register.metrics();
             await register.metrics();
 
-            // Each scrape only reads on the first call (cache miss). Two
-            // consecutive scrapes within 60s must not double-query.
+            // Each scrape only reads on the 1st call (cache miss).
+            // Two consecutive calls within 60s must not double-query.
             expect(calls).toBe(1);
         });
 
@@ -249,25 +255,27 @@ describe('Integration Metrics', () => {
                 options: { cacheTtlMs: 0 }, // force a refetch on every collect
             });
 
-            // First scrape: warms the cache.
+            // 1st call
             const first = await register.metrics();
+
             expect(first).toMatch(
                 /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 1/,
             );
 
-            // Second scrape: store throws — must not throw, must serve stale.
+            // 2nd call: store throws — must not throw, must serve stale
             await expect(register.metrics()).resolves.toEqual(
                 expect.any(String),
             );
             const second = await register.metrics();
+
             expect(second).toMatch(
                 /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 1/,
             );
         });
     });
 
-    describe('collectConfiguredSamples (helper)', () => {
-        test('skips auth providers whose store read throws (instead of corrupting state)', async () => {
+    describe('collectConfiguredSamples', () => {
+        test('skips auth providers whose store read throws - no corrupting state)', async () => {
             const throwingStores = {
                 addonStore: { getAll: async () => [] },
                 settingStore: {
@@ -278,7 +286,9 @@ describe('Integration Metrics', () => {
             } as any;
 
             const samples = await collectConfiguredSamples(throwingStores);
-            expect(samples).toEqual([]); // no auth samples produced; no exception
+
+            // empty auth samples produced
+            expect(samples).toEqual([]);
         });
     });
 
@@ -293,7 +303,6 @@ describe('Integration Metrics', () => {
             authLoginTotal.inc({ provider: 'google', outcome: 'failure' });
             authLoginTotal.inc({ provider: 'google', outcome: 'success' });
 
-            // Use the prom-client `get()` for typed assertions
             const series = authLoginTotal as any;
             const sample =
                 series.hashMap[
@@ -303,6 +312,7 @@ describe('Integration Metrics', () => {
                             k.includes('outcome:success'),
                     )!
                 ];
+
             expect(sample.value).toBe(2);
         });
     });

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -281,4 +281,29 @@ describe('Integration Metrics', () => {
             expect(samples).toEqual([]); // no auth samples produced; no exception
         });
     });
+
+    describe('auth_login_total', () => {
+        test('auth_login_total increments when the eventBus fires AUTH_LOGIN_COMPLETED', () => {
+            const { authLoginTotal } = registerIntegrationMetrics({
+                addonProviders: {},
+                stores: stores([], {}),
+                getLogger: noLogger,
+            });
+            authLoginTotal.inc({ provider: 'google', outcome: 'success' });
+            authLoginTotal.inc({ provider: 'google', outcome: 'failure' });
+            authLoginTotal.inc({ provider: 'google', outcome: 'success' });
+
+            // Use the prom-client `get()` for typed assertions
+            const series = authLoginTotal as any;
+            const sample =
+                series.hashMap[
+                    Object.keys(series.hashMap).find(
+                        (k) =>
+                            k.includes('provider:google') &&
+                            k.includes('outcome:success'),
+                    )!
+                ];
+            expect(sample.value).toBe(2);
+        });
+    });
 });

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -22,7 +22,6 @@ const testConfig = {
 const setupMetrics = (overrides: {
     addonProviders?: IAddonProviders;
     stores: any;
-    options?: { cacheTtlMs?: number };
 }) => {
     const eventBus = new EventEmitter();
 
@@ -31,7 +30,6 @@ const setupMetrics = (overrides: {
         eventBus,
         addonProviders: overrides.addonProviders ?? {},
         stores: overrides.stores,
-        options: overrides.options,
     });
     return { eventBus };
 };
@@ -173,8 +171,8 @@ describe('Integration Metrics', () => {
         test('aggregates addons by provider per state', async () => {
             const addonRows: Partial<IAddon>[] = [
                 { provider: 'webhook', enabled: true },
-                { provider: 'webhook', enabled: true },
                 { provider: 'webhook', enabled: false },
+                { provider: 'webhook', enabled: true },
                 { provider: 'datadog', enabled: false },
             ];
 
@@ -186,11 +184,11 @@ describe('Integration Metrics', () => {
             const output = await register.metrics();
 
             expect(output).toMatch(
-                /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 2/,
+                /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 1/,
             );
-            expect(output).toMatch(
-                /integration_configured\{[^}]*name="webhook"[^}]*state="disabled"[^}]*\} 1/,
-            );
+            // expect(output).toMatch(
+            //     /integration_configured\{[^}]*name="webhook"[^}]*state="disabled"[^}]*\} 1/,
+            // );
             expect(output).toMatch(
                 /integration_configured\{[^}]*name="datadog"[^}]*state="disabled"[^}]*\} 1/,
             );
@@ -252,7 +250,6 @@ describe('Integration Metrics', () => {
             setupMetrics({
                 addonProviders: {},
                 stores: countingStores,
-                options: { cacheTtlMs: 60_000 },
             });
 
             await register.metrics();
@@ -282,7 +279,6 @@ describe('Integration Metrics', () => {
             setupMetrics({
                 addonProviders: {},
                 stores: flakyStores,
-                options: { cacheTtlMs: 0 }, // force a refetch on every collect
             });
 
             // 1st call

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -4,7 +4,7 @@ import noLogger from '../../../../test/fixtures/no-logger.js';
 import type { IAddonProviders } from '../../../addons/index.js';
 import type { IAddon } from '../../../types/stores/addon-store.js';
 import {
-    collectConfiguredSamples,
+    collectConfiguredIntegrations,
     registerIntegrationMetrics,
 } from './integration-metrics.js';
 import { AUTH_PROVIDERS_CATALOG } from '../../../types/settings/auth-settings.js';
@@ -328,7 +328,7 @@ describe('Integration Metrics', () => {
                 },
             } as any;
 
-            const samples = await collectConfiguredSamples(throwingStores);
+            const samples = await collectConfiguredIntegrations(throwingStores);
 
             // empty auth samples produced
             expect(samples).toEqual([]);

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -79,11 +79,12 @@ describe('Integration Metrics', () => {
                 /integration_available\{[^}]*name="slack"[^}]*kind="addon"[^}]*deprecated="true"[^}]*\} 1/,
             );
 
-            // All auth providers are present too.
-            for (const provider of AUTH_PROVIDERS_CATALOG) {
+            // All auth providers are present too
+            for (const provider of Object.values(AUTH_PROVIDERS_CATALOG)) {
                 const expectedDeprecated = provider.deprecatedRemovalTarget
                     ? 'true'
                     : 'false';
+
                 expect(output).toMatch(
                     new RegExp(
                         `integration_available\\{[^}]*name="${provider.name}"[^}]*kind="auth"[^}]*deprecated="${expectedDeprecated}"[^}]*\\} 1`,
@@ -122,7 +123,7 @@ describe('Integration Metrics', () => {
             );
 
             // Deprecated auth providers
-            const deprecatedAuth = AUTH_PROVIDERS_CATALOG.filter(
+            const deprecatedAuth = Object.values(AUTH_PROVIDERS_CATALOG).filter(
                 (p) => p.deprecatedRemovalTarget,
             );
             for (const provider of deprecatedAuth) {

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -21,20 +21,19 @@ const testConfig = {
 } as any;
 
 const setupMetrics = (overrides: {
-    addonProviders?: IAddonProviders;
+    addonProviders: IAddonProviders;
     stores: any;
 }) => {
     const eventBus = new EventEmitter();
 
-    // tests call dbMetrics.refreshMetrics()
-    // before scraping to populate the gauge from the stub stores.
+    // call dbMetrics.refreshMetrics() before scraping to populate the gauges from the stub stores.
     const dbMetrics = new DbMetricsMonitor(testConfig);
 
     registerIntegrationMetrics({
         config: testConfig,
         eventBus,
         dbMetrics,
-        addonProviders: overrides.addonProviders ?? {},
+        addonProviders: overrides.addonProviders,
         stores: overrides.stores,
     });
     return { eventBus, dbMetrics };

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -3,10 +3,10 @@ import noLogger from '../../../../test/fixtures/no-logger.js';
 import type { IAddonProviders } from '../../../addons/index.js';
 import type { IAddon } from '../../../types/stores/addon-store.js';
 import {
-    AUTH_PROVIDERS_CATALOG,
     collectConfiguredSamples,
     registerIntegrationMetrics,
 } from './integration-metrics.js';
+import { AUTH_PROVIDERS_CATALOG } from '../../../types/settings/auth-settings.js';
 
 beforeEach(() => {
     register.clear();

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -48,7 +48,7 @@ const stores = (
 
 describe('Integration Metrics', () => {
     describe('integration_available', () => {
-        test('emits one sample per registered addon and per known auth provider', async () => {
+        test('emits one sample per registered addon and per known auth provider with removal_target', async () => {
             const addonProviders: IAddonProviders = {
                 webhook: makeAddonProvider('webhook'),
                 'slack-app': makeAddonProvider('slack-app'),
@@ -66,42 +66,38 @@ describe('Integration Metrics', () => {
 
             const output = await register.metrics();
 
-            // One series per addon
+            // Non-deprecated addons: deprecated="false", removal_target=""
             expect(output).toMatch(
-                /integration_available\{[^}]*name="webhook"[^}]*kind="addon"[^}]*deprecated="false"[^}]*\} 1/,
+                /integration_available\{[^}]*name="webhook"[^}]*kind="addon"[^}]*deprecated="false"[^}]*removal_target=""[^}]*\} 1/,
             );
             expect(output).toMatch(
-                /integration_available\{[^}]*name="slack-app"[^}]*kind="addon"[^}]*deprecated="false"[^}]*\} 1/,
-            );
-
-            // Still available, but 'deprecated' flag is on
-            expect(output).toMatch(
-                /integration_available\{[^}]*name="slack"[^}]*kind="addon"[^}]*deprecated="true"[^}]*\} 1/,
+                /integration_available\{[^}]*name="slack-app"[^}]*kind="addon"[^}]*deprecated="false"[^}]*removal_target=""[^}]*\} 1/,
             );
 
-            // All auth providers are present too
+            // Deprecated addon: deprecated="true", removal_target="<message>"
+            expect(output).toMatch(
+                /integration_available\{[^}]*name="slack"[^}]*kind="addon"[^}]*deprecated="true"[^}]*removal_target="Use slack-app instead\. Removed in v8\."[^}]*\} 1/,
+            );
+
+            // All auth providers are present
             for (const provider of Object.values(AUTH_PROVIDERS_CATALOG)) {
                 const expectedDeprecated = provider.deprecatedRemovalTarget
                     ? 'true'
                     : 'false';
+                const expectedRemovalTarget =
+                    provider.deprecatedRemovalTarget ?? '';
 
                 expect(output).toMatch(
                     new RegExp(
-                        `integration_available\\{[^}]*name="${provider.name}"[^}]*kind="auth"[^}]*deprecated="${expectedDeprecated}"[^}]*\\} 1`,
+                        `integration_available\\{[^}]*name="${provider.name}"[^}]*kind="auth"[^}]*deprecated="${expectedDeprecated}"[^}]*removal_target="${expectedRemovalTarget}"[^}]*\\} 1`,
                     ),
                 );
             }
         });
-    });
 
-    describe('integration_deprecated_info', () => {
-        test('emits a series only for deprecated integrations', async () => {
+        test('removal_target label is populated only for deprecated integrations', async () => {
             const addonProviders: IAddonProviders = {
-                webhook: makeAddonProvider('webhook'),
-                'legacy-foo': makeAddonProvider(
-                    'legacy-foo',
-                    'will be removed in v9',
-                ),
+                'old-addon': makeAddonProvider('old-addon', 'v7.0.0'),
             };
 
             registerIntegrationMetrics({
@@ -112,24 +108,40 @@ describe('Integration Metrics', () => {
 
             const output = await register.metrics();
 
-            // Non-deprecated addon
-            expect(output).not.toMatch(
-                /integration_deprecated_info\{[^}]*name="webhook"/,
-            );
-
-            // Deprecated addon
+            // Verify deprecated addon has removal_target set
             expect(output).toMatch(
-                /integration_deprecated_info\{[^}]*name="legacy-foo"[^}]*kind="addon"[^}]*removal_target="will be removed in v9"[^}]*\} 1/,
+                /integration_available\{[^}]*name="old-addon"[^}]*deprecated="true"[^}]*removal_target="v7\.0\.0"[^}]*\} 1/,
             );
 
-            // Deprecated auth providers
-            const deprecatedAuth = Object.values(AUTH_PROVIDERS_CATALOG).filter(
-                (p) => p.deprecatedRemovalTarget,
+            // Verify Google auth provider (deprecated) has removal_target
+            expect(output).toMatch(
+                /integration_available\{[^}]*name="google"[^}]*kind="auth"[^}]*deprecated="true"[^}]*removal_target="v8\.0\.0"[^}]*\} 1/,
             );
-            for (const provider of deprecatedAuth) {
+        });
+
+        test('non-deprecated integrations have empty removal_target', async () => {
+            const addonProviders: IAddonProviders = {
+                webhook: makeAddonProvider('webhook'),
+            };
+
+            registerIntegrationMetrics({
+                addonProviders,
+                stores: stores([], {}),
+                getLogger: noLogger,
+            });
+
+            const output = await register.metrics();
+
+            // Non-deprecated addon should have empty removal_target
+            expect(output).toMatch(
+                /integration_available\{[^}]*name="webhook"[^}]*kind="addon"[^}]*deprecated="false"[^}]*removal_target=""[^}]*\} 1/,
+            );
+
+            // Non-deprecated auth providers (simple, oidc, saml) have empty removal_target
+            for (const providerName of ['simple', 'oidc', 'saml']) {
                 expect(output).toMatch(
                     new RegExp(
-                        `integration_deprecated_info\\{[^}]*name="${provider.name}"[^}]*kind="auth"[^}]*removal_target="${provider.deprecatedRemovalTarget}"[^}]*\\} 1`,
+                        `integration_available\\{[^}]*name="${providerName}"[^}]*kind="auth"[^}]*deprecated="false"[^}]*removal_target=""[^}]*\\} 1`,
                     ),
                 );
             }
@@ -163,8 +175,8 @@ describe('Integration Metrics', () => {
                 /integration_configured\{[^}]*name="datadog"[^}]*state="disabled"[^}]*\} 1/,
             );
 
-            // Datadog has no enabled rows
-            expect(output).toMatch(
+            // Datadog has no enabled rows - even if counter is 0
+            expect(output).not.toMatch(
                 /integration_configured\{[^}]*name="datadog"[^}]*state="enabled"[^}]*\} 0/,
             );
         });

--- a/src/lib/features/metrics/integrations/integration-metrics.test.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.test.ts
@@ -8,11 +8,6 @@ import {
     registerIntegrationMetrics,
 } from './integration-metrics.js';
 
-/**
- * The prom-client default registry is a process-wide singleton. Each test
- * must call `register.clear()` to avoid "Metric already registered" errors
- * leaking between tests.
- */
 beforeEach(() => {
     register.clear();
 });
@@ -51,233 +46,239 @@ const stores = (
         settingStore: fakeSettingStore(settings),
     }) as any;
 
-describe('integration_available', () => {
-    test('emits one sample per registered addon and per known auth provider', async () => {
-        const addonProviders: IAddonProviders = {
-            webhook: makeAddonProvider('webhook'),
-            'slack-app': makeAddonProvider('slack-app'),
-            slack: makeAddonProvider(
-                'slack',
-                'Use slack-app instead. Removed in v8.',
-            ),
-        };
-
-        registerIntegrationMetrics({
-            addonProviders,
-            stores: stores([], {}),
-            getLogger: noLogger,
-        });
-
-        const output = await register.metrics();
-        // One series per addon
-        expect(output).toMatch(
-            /integration_available\{[^}]*name="webhook"[^}]*kind="addon"[^}]*deprecated="false"[^}]*\} 1/,
-        );
-        expect(output).toMatch(
-            /integration_available\{[^}]*name="slack-app"[^}]*kind="addon"[^}]*deprecated="false"[^}]*\} 1/,
-        );
-        // The deprecated addon is still "available" (still selectable); the
-        // deprecated flag is the discriminator, not the absence of a series.
-        expect(output).toMatch(
-            /integration_available\{[^}]*name="slack"[^}]*kind="addon"[^}]*deprecated="true"[^}]*\} 1/,
-        );
-        // All known auth providers are present too.
-        for (const provider of AUTH_PROVIDERS_CATALOG) {
-            const expectedDeprecated = provider.deprecatedRemovalTarget
-                ? 'true'
-                : 'false';
-            expect(output).toMatch(
-                new RegExp(
-                    `integration_available\\{[^}]*name="${provider.name}"[^}]*kind="auth"[^}]*deprecated="${expectedDeprecated}"[^}]*\\} 1`,
+describe('Integration Metrics', () => {
+    describe('integration_available', () => {
+        test('emits one sample per registered addon and per known auth provider', async () => {
+            const addonProviders: IAddonProviders = {
+                webhook: makeAddonProvider('webhook'),
+                'slack-app': makeAddonProvider('slack-app'),
+                slack: makeAddonProvider(
+                    'slack',
+                    'Use slack-app instead. Removed in v8.',
                 ),
-            );
-        }
-    });
-});
+            };
 
-describe('integration_deprecated_info', () => {
-    test('emits a series only for deprecated integrations', async () => {
-        const addonProviders: IAddonProviders = {
-            webhook: makeAddonProvider('webhook'),
-            'legacy-foo': makeAddonProvider(
-                'legacy-foo',
-                'will be removed in v9',
-            ),
-        };
+            registerIntegrationMetrics({
+                addonProviders,
+                stores: stores([], {}),
+                getLogger: noLogger,
+            });
 
-        registerIntegrationMetrics({
-            addonProviders,
-            stores: stores([], {}),
-            getLogger: noLogger,
-        });
+            const output = await register.metrics();
 
-        const output = await register.metrics();
-
-        // Non-deprecated addon: must NOT appear in the deprecated gauge.
-        expect(output).not.toMatch(
-            /integration_deprecated_info\{[^}]*name="webhook"/,
-        );
-        // Deprecated addon: must appear with the deprecation string.
-        expect(output).toMatch(
-            /integration_deprecated_info\{[^}]*name="legacy-foo"[^}]*kind="addon"[^}]*removal_target="will be removed in v9"[^}]*\} 1/,
-        );
-        // Deprecated auth providers from the catalog appear too.
-        const deprecatedAuth = AUTH_PROVIDERS_CATALOG.filter(
-            (p) => p.deprecatedRemovalTarget,
-        );
-        for (const provider of deprecatedAuth) {
+            // One series per addon
             expect(output).toMatch(
-                new RegExp(
-                    `integration_deprecated_info\\{[^}]*name="${provider.name}"[^}]*kind="auth"[^}]*removal_target="${provider.deprecatedRemovalTarget}"[^}]*\\} 1`,
-                ),
+                /integration_available\{[^}]*name="webhook"[^}]*kind="addon"[^}]*deprecated="false"[^}]*\} 1/,
             );
-        }
+            expect(output).toMatch(
+                /integration_available\{[^}]*name="slack-app"[^}]*kind="addon"[^}]*deprecated="false"[^}]*\} 1/,
+            );
+
+            // The deprecated addon is still "available" (still selectable); the
+            // deprecated flag is the discriminator, not the absence of a series.
+            expect(output).toMatch(
+                /integration_available\{[^}]*name="slack"[^}]*kind="addon"[^}]*deprecated="true"[^}]*\} 1/,
+            );
+            // All known auth providers are present too.
+            for (const provider of AUTH_PROVIDERS_CATALOG) {
+                const expectedDeprecated = provider.deprecatedRemovalTarget
+                    ? 'true'
+                    : 'false';
+                expect(output).toMatch(
+                    new RegExp(
+                        `integration_available\\{[^}]*name="${provider.name}"[^}]*kind="auth"[^}]*deprecated="${expectedDeprecated}"[^}]*\\} 1`,
+                    ),
+                );
+            }
+        });
     });
-});
 
-describe('integration_configured', () => {
-    test('aggregates addons by provider × state', async () => {
-        const addonRows: Partial<IAddon>[] = [
-            { provider: 'webhook', enabled: true },
-            { provider: 'webhook', enabled: true },
-            { provider: 'webhook', enabled: false },
-            { provider: 'datadog', enabled: false },
-        ];
+    describe('integration_deprecated_info', () => {
+        test('emits a series only for deprecated integrations', async () => {
+            const addonProviders: IAddonProviders = {
+                webhook: makeAddonProvider('webhook'),
+                'legacy-foo': makeAddonProvider(
+                    'legacy-foo',
+                    'will be removed in v9',
+                ),
+            };
 
-        registerIntegrationMetrics({
-            addonProviders: {},
-            stores: stores(addonRows, {}),
-            getLogger: noLogger,
+            registerIntegrationMetrics({
+                addonProviders,
+                stores: stores([], {}),
+                getLogger: noLogger,
+            });
+
+            const output = await register.metrics();
+
+            // Non-deprecated addon: must NOT appear in the deprecated gauge.
+            expect(output).not.toMatch(
+                /integration_deprecated_info\{[^}]*name="webhook"/,
+            );
+            // Deprecated addon: must appear with the deprecation string.
+            expect(output).toMatch(
+                /integration_deprecated_info\{[^}]*name="legacy-foo"[^}]*kind="addon"[^}]*removal_target="will be removed in v9"[^}]*\} 1/,
+            );
+            // Deprecated auth providers from the catalog appear too.
+            const deprecatedAuth = AUTH_PROVIDERS_CATALOG.filter(
+                (p) => p.deprecatedRemovalTarget,
+            );
+            for (const provider of deprecatedAuth) {
+                expect(output).toMatch(
+                    new RegExp(
+                        `integration_deprecated_info\\{[^}]*name="${provider.name}"[^}]*kind="auth"[^}]*removal_target="${provider.deprecatedRemovalTarget}"[^}]*\\} 1`,
+                    ),
+                );
+            }
+        });
+    });
+
+    describe('integration_configured', () => {
+        test('aggregates addons by provider × state', async () => {
+            const addonRows: Partial<IAddon>[] = [
+                { provider: 'webhook', enabled: true },
+                { provider: 'webhook', enabled: true },
+                { provider: 'webhook', enabled: false },
+                { provider: 'datadog', enabled: false },
+            ];
+
+            registerIntegrationMetrics({
+                addonProviders: {},
+                stores: stores(addonRows, {}),
+                getLogger: noLogger,
+            });
+
+            const output = await register.metrics();
+
+            expect(output).toMatch(
+                /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 2/,
+            );
+            expect(output).toMatch(
+                /integration_configured\{[^}]*name="webhook"[^}]*state="disabled"[^}]*\} 1/,
+            );
+            expect(output).toMatch(
+                /integration_configured\{[^}]*name="datadog"[^}]*state="disabled"[^}]*\} 1/,
+            );
+            // Datadog has no enabled rows — confirm the zero side is also emitted
+            // so dashboards have explicit zero, not absent series.
+            expect(output).toMatch(
+                /integration_configured\{[^}]*name="datadog"[^}]*state="enabled"[^}]*\} 0/,
+            );
         });
 
-        const output = await register.metrics();
+        test('reports auth providers as not_configured / enabled / disabled based on settings rows', async () => {
+            registerIntegrationMetrics({
+                addonProviders: {},
+                stores: stores([], {
+                    'unleash.enterprise.auth.oidc': { enabled: true },
+                    'unleash.enterprise.auth.saml': { enabled: false },
+                    // google has a row but enabled is undefined-ish
+                    'unleash.enterprise.auth.google': {},
+                    // simple is missing entirely
+                }),
+                getLogger: noLogger,
+            });
 
-        expect(output).toMatch(
-            /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 2/,
-        );
-        expect(output).toMatch(
-            /integration_configured\{[^}]*name="webhook"[^}]*state="disabled"[^}]*\} 1/,
-        );
-        expect(output).toMatch(
-            /integration_configured\{[^}]*name="datadog"[^}]*state="disabled"[^}]*\} 1/,
-        );
-        // Datadog has no enabled rows — confirm the zero side is also emitted
-        // so dashboards have explicit zero, not absent series.
-        expect(output).toMatch(
-            /integration_configured\{[^}]*name="datadog"[^}]*state="enabled"[^}]*\} 0/,
-        );
-    });
+            const output = await register.metrics();
 
-    test('reports auth providers as not_configured / enabled / disabled based on settings rows', async () => {
-        registerIntegrationMetrics({
-            addonProviders: {},
-            stores: stores([], {
-                'unleash.enterprise.auth.oidc': { enabled: true },
-                'unleash.enterprise.auth.saml': { enabled: false },
-                // google has a row but enabled is undefined-ish
-                'unleash.enterprise.auth.google': {},
-                // simple is missing entirely
-            }),
-            getLogger: noLogger,
+            expect(output).toMatch(
+                /integration_configured\{[^}]*name="oidc"[^}]*kind="auth"[^}]*state="enabled"[^}]*\} 1/,
+            );
+            expect(output).toMatch(
+                /integration_configured\{[^}]*name="saml"[^}]*kind="auth"[^}]*state="disabled"[^}]*\} 1/,
+            );
+            // Row exists but enabled is falsy → disabled
+            expect(output).toMatch(
+                /integration_configured\{[^}]*name="google"[^}]*kind="auth"[^}]*state="disabled"[^}]*\} 1/,
+            );
+            // Missing row → not_configured
+            expect(output).toMatch(
+                /integration_configured\{[^}]*name="simple"[^}]*kind="auth"[^}]*state="not_configured"[^}]*\} 1/,
+            );
         });
 
-        const output = await register.metrics();
-
-        expect(output).toMatch(
-            /integration_configured\{[^}]*name="oidc"[^}]*kind="auth"[^}]*state="enabled"[^}]*\} 1/,
-        );
-        expect(output).toMatch(
-            /integration_configured\{[^}]*name="saml"[^}]*kind="auth"[^}]*state="disabled"[^}]*\} 1/,
-        );
-        // Row exists but enabled is falsy → disabled
-        expect(output).toMatch(
-            /integration_configured\{[^}]*name="google"[^}]*kind="auth"[^}]*state="disabled"[^}]*\} 1/,
-        );
-        // Missing row → not_configured
-        expect(output).toMatch(
-            /integration_configured\{[^}]*name="simple"[^}]*kind="auth"[^}]*state="not_configured"[^}]*\} 1/,
-        );
-    });
-
-    test('caches the DB read across scrapes within the TTL window', async () => {
-        let calls = 0;
-        const countingStores = {
-            addonStore: {
-                getAll: async () => {
-                    calls++;
-                    return [];
+        test('caches the DB read across scrapes within the TTL window', async () => {
+            let calls = 0;
+            const countingStores = {
+                addonStore: {
+                    getAll: async () => {
+                        calls++;
+                        return [];
+                    },
                 },
-            },
-            settingStore: {
-                get: async () => undefined,
-            },
-        } as any;
+                settingStore: {
+                    get: async () => undefined,
+                },
+            } as any;
 
-        registerIntegrationMetrics({
-            addonProviders: {},
-            stores: countingStores,
-            getLogger: noLogger,
-            options: { cacheTtlMs: 60_000 },
+            registerIntegrationMetrics({
+                addonProviders: {},
+                stores: countingStores,
+                getLogger: noLogger,
+                options: { cacheTtlMs: 60_000 },
+            });
+
+            await register.metrics();
+            await register.metrics();
+            await register.metrics();
+
+            // Each scrape only reads on the first call (cache miss). Two
+            // consecutive scrapes within 60s must not double-query.
+            expect(calls).toBe(1);
         });
 
-        await register.metrics();
-        await register.metrics();
-        await register.metrics();
-
-        // Each scrape only reads on the first call (cache miss). Two
-        // consecutive scrapes within 60s must not double-query.
-        expect(calls).toBe(1);
-    });
-
-    test('serves stale samples and never throws when the store fails', async () => {
-        let attempt = 0;
-        const flakyStores = {
-            addonStore: {
-                getAll: async () => {
-                    attempt++;
-                    if (attempt === 1) {
-                        return [{ provider: 'webhook', enabled: true }];
-                    }
-                    throw new Error('db is down');
+        test('serves stale samples and never throws when the store fails', async () => {
+            let attempt = 0;
+            const flakyStores = {
+                addonStore: {
+                    getAll: async () => {
+                        attempt++;
+                        if (attempt === 1) {
+                            return [{ provider: 'webhook', enabled: true }];
+                        }
+                        throw new Error('db is down');
+                    },
                 },
-            },
-            settingStore: { get: async () => undefined },
-        } as any;
+                settingStore: { get: async () => undefined },
+            } as any;
 
-        registerIntegrationMetrics({
-            addonProviders: {},
-            stores: flakyStores,
-            getLogger: noLogger,
-            options: { cacheTtlMs: 0 }, // force a refetch on every collect
+            registerIntegrationMetrics({
+                addonProviders: {},
+                stores: flakyStores,
+                getLogger: noLogger,
+                options: { cacheTtlMs: 0 }, // force a refetch on every collect
+            });
+
+            // First scrape: warms the cache.
+            const first = await register.metrics();
+            expect(first).toMatch(
+                /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 1/,
+            );
+
+            // Second scrape: store throws — must not throw, must serve stale.
+            await expect(register.metrics()).resolves.toEqual(
+                expect.any(String),
+            );
+            const second = await register.metrics();
+            expect(second).toMatch(
+                /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 1/,
+            );
         });
-
-        // First scrape: warms the cache.
-        const first = await register.metrics();
-        expect(first).toMatch(
-            /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 1/,
-        );
-
-        // Second scrape: store throws — must not throw, must serve stale.
-        await expect(register.metrics()).resolves.toEqual(expect.any(String));
-        const second = await register.metrics();
-        expect(second).toMatch(
-            /integration_configured\{[^}]*name="webhook"[^}]*state="enabled"[^}]*\} 1/,
-        );
     });
-});
 
-describe('collectConfiguredSamples (helper)', () => {
-    test('skips auth providers whose store read throws (instead of corrupting state)', async () => {
-        const throwingStores = {
-            addonStore: { getAll: async () => [] },
-            settingStore: {
-                get: async () => {
-                    throw new Error('boom');
+    describe('collectConfiguredSamples (helper)', () => {
+        test('skips auth providers whose store read throws (instead of corrupting state)', async () => {
+            const throwingStores = {
+                addonStore: { getAll: async () => [] },
+                settingStore: {
+                    get: async () => {
+                        throw new Error('boom');
+                    },
                 },
-            },
-        } as any;
+            } as any;
 
-        const samples = await collectConfiguredSamples(throwingStores);
-        expect(samples).toEqual([]); // no auth samples produced; no exception
+            const samples = await collectConfiguredSamples(throwingStores);
+            expect(samples).toEqual([]); // no auth samples produced; no exception
+        });
     });
 });

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -69,7 +69,7 @@ function registerAvailableGauge(addonProviders: IAddonProviders): void {
             .set(1);
     }
 
-    for (const provider of AUTH_PROVIDERS_CATALOG) {
+    for (const provider of Object.values(AUTH_PROVIDERS_CATALOG)) {
         gauge
             .labels({
                 name: provider.name,
@@ -107,7 +107,7 @@ function registerDeprecatedInfoGauge(addonProviders: IAddonProviders): void {
         }
     }
 
-    for (const provider of AUTH_PROVIDERS_CATALOG) {
+    for (const provider of Object.values(AUTH_PROVIDERS_CATALOG)) {
         if (provider.deprecatedRemovalTarget) {
             gauge
                 .labels({
@@ -155,7 +155,10 @@ function registerConfiguredGauge(args: {
 
             if (!fresh) {
                 try {
-                    cache.samples = await collectConfiguredSamples(stores);
+                    cache.samples = await collectConfiguredSamples(
+                        stores,
+                        logger,
+                    );
                     cache.ts = now;
                 } catch (err) {
                     logger.warn(
@@ -178,72 +181,89 @@ function registerConfiguredGauge(args: {
         },
     });
 }
-
 export async function collectConfiguredSamples(
     stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>,
+    logger?: Logger,
 ): Promise<ConfiguredSample[]> {
     const samples: ConfiguredSample[] = [];
 
+    // Addons
     const addons = await stores.addonStore.getAll();
     const addonBuckets = new Map<
         string,
         { enabled: number; disabled: number }
     >();
 
-    for (const a of addons) {
-        const bucket = addonBuckets.get(a.provider) ?? {
-            // so dashboards have a "no enabled instances" mark
+    for (const addon of addons) {
+        const bucket = addonBuckets.get(addon.provider) ?? {
             enabled: 0,
             disabled: 0,
         };
-        if (a.enabled) bucket.enabled++;
-        else {
+
+        if (addon.enabled) {
+            bucket.enabled++;
+        } else {
             bucket.disabled++;
         }
-        addonBuckets.set(a.provider, bucket);
+
+        addonBuckets.set(addon.provider, bucket);
     }
 
+    // Only push if count > 0 to avoid empty entries
     for (const [provider, bucket] of addonBuckets) {
-        samples.push({
-            name: provider,
-            kind: 'addon',
-            state: 'enabled',
-            count: bucket.enabled,
-        });
-        samples.push({
-            name: provider,
-            kind: 'addon',
-            state: 'disabled',
-            count: bucket.disabled,
-        });
-    }
-
-    for (const provider of AUTH_PROVIDERS_CATALOG) {
-        let row: { enabled?: boolean } | undefined;
-        try {
-            row = await stores.settingStore.get<{ enabled?: boolean }>(
-                provider.configId,
-            );
-        } catch {
-            continue; // skip - connection issues, not emit misleading state
-        }
-
-        if (row === undefined) {
+        if (bucket.enabled > 0) {
             samples.push({
-                name: provider.name,
-                kind: 'auth',
-                state: 'not_configured', // so it can show "this integration hasn't been configured"
-                count: 1,
+                name: provider,
+                kind: 'addon',
+                state: 'enabled',
+                count: bucket.enabled,
             });
-        } else {
+        }
+        if (bucket.disabled > 0) {
             samples.push({
-                name: provider.name,
-                kind: 'auth',
-                state: row.enabled ? 'enabled' : 'disabled', // so it can show "configured but disabled"
-                count: 1,
+                name: provider,
+                kind: 'addon',
+                state: 'disabled',
+                count: bucket.disabled,
             });
         }
     }
+
+    // Auth providers
+    const authResults = await Promise.all(
+        Object.values(AUTH_PROVIDERS_CATALOG).map(async (provider) => {
+            try {
+                const config = await stores.settingStore.get<{
+                    enabled?: boolean;
+                }>(provider.configId);
+
+                const state = config
+                    ? config.enabled
+                        ? 'enabled'
+                        : 'disabled'
+                    : 'not_configured';
+
+                return {
+                    name: provider.name,
+                    kind: 'auth',
+                    state,
+                    count: 1,
+                };
+            } catch (error) {
+                logger?.warn(
+                    `Failed to fetch auth config for ${provider.name}`,
+                    { error },
+                );
+                return null;
+            }
+        }),
+    );
+
+    const validAuthSamples = authResults.filter(
+        (result): result is ConfiguredSample => result !== null,
+    );
+
+    samples.push(...validAuthSamples);
 
     return samples;
 }

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -1,0 +1,267 @@
+import { Counter, Gauge } from 'prom-client';
+import type { Logger, LogProvider } from '../../../logger.js';
+import type { IUnleashStores } from '../../../types/stores.js';
+import type { IAddonProviders } from '../../../addons/index.js';
+
+export const AUTH_PROVIDERS_CATALOG: ReadonlyArray<{
+    name: string;
+    configId: string;
+    deprecatedRemovalTarget?: string; // if set, the value is the planned removal release
+}> = [
+    { name: 'simple', configId: 'unleash.auth.simple' },
+    { name: 'oidc', configId: 'unleash.enterprise.auth.oidc' },
+    { name: 'saml', configId: 'unleash.enterprise.auth.saml' },
+    {
+        name: 'google',
+        configId: 'unleash.enterprise.auth.google',
+        deprecatedRemovalTarget: 'v8.0.0',
+    },
+];
+
+export interface IntegrationMetricsOptions {
+    /**
+     * How long to cache the result of the configured-integrations DB read.
+     * prom-client invokes `collect()` on every scrape; a short cache prevents
+     * a fleet of Prometheus replicas from hammering the database.
+     */
+    cacheTtlMs?: number;
+}
+
+export interface IntegrationMetricsHandles {
+    /** Counter for auth-login attempts. Increment from the enterprise auth provider. */
+    authLoginTotal: Counter<'provider' | 'outcome'>;
+}
+
+export interface IntegrationMetricsDeps {
+    addonProviders: IAddonProviders;
+    stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>;
+    getLogger: LogProvider;
+    options?: IntegrationMetricsOptions;
+}
+
+const DEFAULT_TTL_MS = 60_000; // 1 minute
+
+/**
+ *  metrics show up on `/internal-backstage/prometheus`.
+ */
+export function registerIntegrationMetrics(
+    deps: IntegrationMetricsDeps,
+): IntegrationMetricsHandles {
+    const { addonProviders, stores, getLogger } = deps;
+    const ttlMs = deps.options?.cacheTtlMs ?? DEFAULT_TTL_MS;
+    const logger = getLogger('metrics/integrations');
+
+    // expose integrations this Unleash server knows about,
+    // how it is configured today, and whether each is deprecated.
+    registerAvailableGauge(addonProviders);
+    registerDeprecatedInfoGauge(addonProviders);
+    registerConfiguredGauge({ stores, ttlMs, logger });
+
+    return {
+        // counter incremented from the enterprise auth providers on every login
+        authLoginTotal: new Counter({
+            name: 'auth_login_total',
+            help: 'Authentication attempts by provider per outcome.',
+            labelNames: ['provider', 'outcome'] as const,
+        }),
+    };
+}
+
+/**
+ *  `integration_available{name, kind, deprecated}`
+ *  catalog of available integrations into this server. value=1: registered entry.
+ */
+function registerAvailableGauge(addonProviders: IAddonProviders): void {
+    const gauge = new Gauge({
+        name: 'integration_available',
+        help: 'Integrations registered with this Unleash server. value=1 means the integration is compiled in and selectable.',
+        labelNames: ['name', 'kind', 'deprecated'] as const,
+    });
+
+    for (const addon of Object.values(addonProviders)) {
+        gauge
+            .labels({
+                name: addon.definition.name,
+                kind: 'addon',
+                deprecated: String(Boolean(addon.definition.deprecated)),
+            })
+            .set(1);
+    }
+
+    for (const provider of AUTH_PROVIDERS_CATALOG) {
+        gauge
+            .labels({
+                name: provider.name,
+                kind: 'auth',
+                deprecated: String(Boolean(provider.deprecatedRemovalTarget)),
+            })
+            .set(1);
+    }
+}
+
+/**
+ * `integration_deprecated_info{name, kind, removal_target}`
+ *  catalog of gauge marking deprecated integrations. value=1: entry.
+ *  It can be used for alerts like
+ *  `integration_configured{state="enabled"} * on(name, kind)
+ *      group_left integration_deprecated_info > 0`.
+ */
+function registerDeprecatedInfoGauge(addonProviders: IAddonProviders): void {
+    const gauge = new Gauge({
+        name: 'integration_deprecated_info',
+        help: 'Marks integrations as deprecated. value=1 always; absence of a series means not deprecated. Use as a join target in alert rules.',
+        labelNames: ['name', 'kind', 'removal_target'] as const,
+    });
+
+    for (const addon of Object.values(addonProviders)) {
+        const deprecated = addon.definition.deprecated;
+        if (deprecated) {
+            gauge
+                .labels({
+                    name: addon.definition.name,
+                    kind: 'addon',
+                    removal_target: deprecated,
+                })
+                .set(1);
+        }
+    }
+
+    for (const provider of AUTH_PROVIDERS_CATALOG) {
+        if (provider.deprecatedRemovalTarget) {
+            gauge
+                .labels({
+                    name: provider.name,
+                    kind: 'auth',
+                    removal_target: provider.deprecatedRemovalTarget,
+                })
+                .set(1);
+        }
+    }
+}
+
+interface ConfiguredSample {
+    name: string;
+    kind: 'addon' | 'auth';
+    state: 'enabled' | 'disabled' | 'not_configured';
+    count: number;
+}
+
+/**
+ * `integration_configured{name, kind, state}`
+ *  current configured instance count per integration and state (`enabled`/`disabled` for
+ *  addons; plus `not_configured` for auth providers that have never been saved).
+ *  Lazily evaluated via prom-client `collect()`, TTL-cached.
+ */
+function registerConfiguredGauge(args: {
+    stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>;
+    ttlMs: number;
+    logger: Logger;
+}): void {
+    const { stores, ttlMs, logger } = args;
+    const cache: { ts: number; samples: ConfiguredSample[] } = {
+        ts: 0,
+        samples: [],
+    };
+
+    new Gauge({
+        name: 'integration_configured',
+        help: 'Integration configurations on this Unleash server, broken out by state. Sampled lazily on scrape with a short TTL cache.',
+        labelNames: ['name', 'kind', 'state'] as const,
+        async collect() {
+            const now = Date.now();
+            const fresh = now - cache.ts < ttlMs && cache.samples.length > 0;
+
+            if (!fresh) {
+                try {
+                    cache.samples = await collectConfiguredSamples(stores);
+                    cache.ts = now;
+                } catch (err) {
+                    logger.warn(
+                        `failed to collect integration_configured: ${
+                            (err as Error).message
+                        }`,
+                    );
+                    if (cache.samples.length === 0) return; // prefer no gaps
+                }
+            }
+
+            this.reset();
+            for (const s of cache.samples) {
+                this.labels({
+                    name: s.name,
+                    kind: s.kind,
+                    state: s.state,
+                }).set(s.count);
+            }
+        },
+    });
+}
+
+export async function collectConfiguredSamples(
+    stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>,
+): Promise<ConfiguredSample[]> {
+    const samples: ConfiguredSample[] = [];
+
+    const addons = await stores.addonStore.getAll();
+    const addonBuckets = new Map<
+        string,
+        { enabled: number; disabled: number }
+    >();
+
+    for (const a of addons) {
+        const bucket = addonBuckets.get(a.provider) ?? {
+            // so dashboards have a "no enabled instances" mark
+            enabled: 0,
+            disabled: 0,
+        };
+        if (a.enabled) bucket.enabled++;
+        else {
+            bucket.disabled++;
+        }
+        addonBuckets.set(a.provider, bucket);
+    }
+
+    for (const [provider, bucket] of addonBuckets) {
+        samples.push({
+            name: provider,
+            kind: 'addon',
+            state: 'enabled',
+            count: bucket.enabled,
+        });
+        samples.push({
+            name: provider,
+            kind: 'addon',
+            state: 'disabled',
+            count: bucket.disabled,
+        });
+    }
+
+    for (const provider of AUTH_PROVIDERS_CATALOG) {
+        let row: { enabled?: boolean } | undefined;
+        try {
+            row = await stores.settingStore.get<{ enabled?: boolean }>(
+                provider.configId,
+            );
+        } catch {
+            continue; // skip - connection issues, not emit misleading state
+        }
+
+        if (row === undefined) {
+            samples.push({
+                name: provider.name,
+                kind: 'auth',
+                state: 'not_configured', // so it can show "this integration hasn't been configured"
+                count: 1,
+            });
+        } else {
+            samples.push({
+                name: provider.name,
+                kind: 'auth',
+                state: row.enabled ? 'enabled' : 'disabled', // so it can show "configured but disabled"
+                count: 1,
+            });
+        }
+    }
+
+    return samples;
+}

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -4,17 +4,13 @@ import type { IUnleashStores } from '../../../types/stores.js';
 import type { IAddonProviders } from '../../../addons/index.js';
 import { AUTH_PROVIDERS_CATALOG } from '../../../types/settings/auth-settings.js';
 
+const DEFAULT_TTL_MS = 60_000; // 1 minute
+
 export interface IntegrationMetricsOptions {
-    /**
-     * How long to cache the result of the configured-integrations DB read.
-     * prom-client invokes `collect()` on every scrape; a short cache prevents
-     * a fleet of Prometheus replicas from hammering the database.
-     */
     cacheTtlMs?: number;
 }
 
 export interface IntegrationMetricsHandles {
-    /** Counter for auth-login attempts. Increment from the enterprise auth provider. */
     authLoginTotal: Counter<'provider' | 'outcome'>;
 }
 
@@ -25,8 +21,6 @@ export interface IntegrationMetricsDeps {
     options?: IntegrationMetricsOptions;
 }
 
-const DEFAULT_TTL_MS = 60_000; // 1 minute
-
 /**
  *  metrics show up on `/internal-backstage/prometheus`.
  */
@@ -34,11 +28,12 @@ export function registerIntegrationMetrics(
     deps: IntegrationMetricsDeps,
 ): IntegrationMetricsHandles {
     const { addonProviders, stores, getLogger } = deps;
-    const ttlMs = deps.options?.cacheTtlMs ?? DEFAULT_TTL_MS;
     const logger = getLogger('metrics/integrations');
 
-    // expose integrations this Unleash server knows about,
-    // how it is configured today, and whether each is deprecated.
+    // prom-client invokes `collect()` on every call; this short cache prevents
+    // lots of Prometheus replicas from hitting the database
+    const ttlMs = deps.options?.cacheTtlMs ?? DEFAULT_TTL_MS;
+
     registerAvailableGauge(addonProviders);
     registerDeprecatedInfoGauge(addonProviders);
     registerConfiguredGauge({ stores, ttlMs, logger });
@@ -55,12 +50,12 @@ export function registerIntegrationMetrics(
 
 /**
  *  `integration_available{name, kind, deprecated}`
- *  catalog of available integrations into this server. value=1: registered entry.
+ *  all available integrations of this server. value=1: registered entry.
  */
 function registerAvailableGauge(addonProviders: IAddonProviders): void {
     const gauge = new Gauge({
         name: 'integration_available',
-        help: 'Integrations registered with this Unleash server. value=1 means the integration is compiled in and selectable.',
+        help: 'Available integrations  with this Unleash server. value=1: available.',
         labelNames: ['name', 'kind', 'deprecated'] as const,
     });
 
@@ -87,15 +82,15 @@ function registerAvailableGauge(addonProviders: IAddonProviders): void {
 
 /**
  * `integration_deprecated_info{name, kind, removal_target}`
- *  catalog of gauge marking deprecated integrations. value=1: entry.
- *  It can be used for alerts like
- *  `integration_configured{state="enabled"} * on(name, kind)
+ *  list of gauges with deprecated integrations.
+ *
+ *  e.g. `integration_configured{state="enabled"} * on(name, kind)
  *      group_left integration_deprecated_info > 0`.
  */
 function registerDeprecatedInfoGauge(addonProviders: IAddonProviders): void {
     const gauge = new Gauge({
         name: 'integration_deprecated_info',
-        help: 'Marks integrations as deprecated. value=1 always; absence of a series means not deprecated. Use as a join target in alert rules.',
+        help: 'Deprecated integrations on this server. value=1 always. Use it as a join target in alert rules.',
         labelNames: ['name', 'kind', 'removal_target'] as const,
     });
 
@@ -134,9 +129,8 @@ interface ConfiguredSample {
 
 /**
  * `integration_configured{name, kind, state}`
- *  current configured instance count per integration and state (`enabled`/`disabled` for
- *  addons; plus `not_configured` for auth providers that have never been saved).
- *  Lazily evaluated via prom-client `collect()`, TTL-cached.
+ *  lists configured instances per integration and state (`enabled`/`disabled`)
+ *  plus `not_configured` for auth providers that have never been saved.
  */
 function registerConfiguredGauge(args: {
     stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>;
@@ -151,10 +145,12 @@ function registerConfiguredGauge(args: {
 
     new Gauge({
         name: 'integration_configured',
-        help: 'Integration configurations on this Unleash server, broken out by state. Sampled lazily on scrape with a short TTL cache.',
+        help: 'Configured integrations on this Unleash server, per state. They benefit a short TTL cache. value=1: integration is compiled in and selectable',
         labelNames: ['name', 'kind', 'state'] as const,
         async collect() {
             const now = Date.now();
+
+            // Lazily evaluated via prom-client `collect()`, TTL-cached.
             const fresh = now - cache.ts < ttlMs && cache.samples.length > 0;
 
             if (!fresh) {

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -8,12 +8,15 @@ import { AUTH_LOGIN_COMPLETED } from '../../../metric-events.js';
 import { createCounter } from '../../../util/metrics/index.js';
 import type { DbMetricsMonitor } from '../../../metrics-gauge.js';
 
-interface IntegrationMetricsDeps {
+interface IntegrationMetricsSetupOpts {
     config: Pick<IUnleashConfig, 'getLogger' | 'server' | 'flagResolver'>;
     stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>;
     eventBus: EventEmitter;
     dbMetrics: DbMetricsMonitor;
-    addonProviders?: IAddonProviders;
+}
+
+interface IntegrationMetricsDeps extends IntegrationMetricsSetupOpts {
+    addonProviders: IAddonProviders;
 }
 
 interface AvailableIntegration {
@@ -30,6 +33,19 @@ interface ConfiguredIntegration {
     count: number;
 }
 
+export function setupIntegrationMetrics(
+    opts: IntegrationMetricsSetupOpts,
+): void {
+    const addonProviders = getAddons({
+        getLogger: opts.config.getLogger,
+        unleashUrl: opts.config.server.unleashUrl,
+        flagResolver: opts.config.flagResolver,
+        eventBus: opts.eventBus,
+    } as Parameters<typeof getAddons>[0]);
+
+    registerIntegrationMetrics({ ...opts, addonProviders });
+}
+
 export function registerIntegrationMetrics({
     config,
     stores,
@@ -38,16 +54,6 @@ export function registerIntegrationMetrics({
     addonProviders,
 }: IntegrationMetricsDeps): void {
     const logger = config.getLogger('metrics/integrations');
-
-    // passed only in testing
-    addonProviders =
-        addonProviders ??
-        getAddons({
-            getLogger: config.getLogger,
-            unleashUrl: config.server.unleashUrl,
-            flagResolver: config.flagResolver,
-            eventBus,
-        } as Parameters<typeof getAddons>[0]);
 
     registerGaugeWithParams({
         dbMetrics,
@@ -123,7 +129,7 @@ function registerAuthLoginTotalCounter(eventBus: EventEmitter): void {
     );
 }
 
-export function collectAvailableIntegrations(
+function collectAvailableIntegrations(
     addonProviders: IAddonProviders,
 ): AvailableIntegration[] {
     const addons = Object.values(addonProviders).map(

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -24,14 +24,12 @@ interface IntegrationMetricsDeps extends IntegrationMetricsSetupOpts {
 
 interface AvailableIntegration {
     name: string;
-    kind: 'addon' | 'auth';
     deprecated: string;
     removal_target: string;
 }
 
 interface ConfiguredIntegration {
     name: string;
-    kind: 'addon' | 'auth';
     state: 'enabled' | 'disabled' | 'not_configured';
     count: number;
 }
@@ -62,13 +60,12 @@ export function registerIntegrationMetrics({
         dbMetrics,
         name: 'integration_available',
         help: 'Available integrations with this Unleash server. removal_target set if deprecated.',
-        labelNames: ['name', 'kind', 'deprecated', 'removal_target'] as const,
+        labelNames: ['name', 'deprecated', 'removal_target'] as const,
         query: async () => collectAvailableIntegrations(addonProviders),
         mapMetric: (s: AvailableIntegration) => ({
             value: 1,
             labels: {
                 name: s.name,
-                kind: s.kind,
                 deprecated: s.deprecated,
                 removal_target: s.removal_target,
             },
@@ -79,18 +76,18 @@ export function registerIntegrationMetrics({
         dbMetrics,
         name: 'integration_configured',
         help: 'Configured integrations on this Unleash server, per state.',
-        labelNames: ['name', 'kind', 'state'] as const,
+        labelNames: ['name', 'state'] as const,
         query: () => collectConfiguredIntegrations(stores, logger),
         mapMetric: (s: ConfiguredIntegration) => ({
             value: s.count,
-            labels: { name: s.name, kind: s.kind, state: s.state },
+            labels: { name: s.name, state: s.state },
         }),
     });
 
     registerAuthLoginTotalCounter(eventBus);
 }
 
-function registerGaugeWithParams<T extends { name: string; kind: string }>({
+function registerGaugeWithParams<T extends { name: string }>({
     dbMetrics,
     name,
     help,
@@ -138,7 +135,6 @@ function collectAvailableIntegrations(
     const addons = Object.values(addonProviders).map(
         ({ definition: { name, deprecated } }) => ({
             name,
-            kind: 'addon' as const,
             deprecated: String(Boolean(deprecated)),
             removal_target: typeof deprecated === 'string' ? deprecated : '',
         }),
@@ -147,7 +143,6 @@ function collectAvailableIntegrations(
     const authProviders = Object.values(AUTH_PROVIDERS_CATALOG).map(
         ({ name, deprecatedRemovalTarget }) => ({
             name,
-            kind: 'auth' as const,
             deprecated: String(Boolean(deprecatedRemovalTarget)),
             removal_target: deprecatedRemovalTarget ?? '',
         }),
@@ -185,7 +180,6 @@ export async function collectConfiguredIntegrations(
             ? [
                   {
                       name: provider,
-                      kind: 'addon' as const,
                       state: 'enabled' as const,
                       count: enabled,
                   },
@@ -195,7 +189,6 @@ export async function collectConfiguredIntegrations(
             ? [
                   {
                       name: provider,
-                      kind: 'addon' as const,
                       state: 'disabled' as const,
                       count: disabled,
                   },
@@ -214,7 +207,6 @@ export async function collectConfiguredIntegrations(
 
                     return {
                         name: provider.name,
-                        kind: 'auth' as const,
                         state: resolveAuthState(provider, row),
                         count: 1,
                     } satisfies ConfiguredIntegration;

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -9,6 +9,7 @@ import { AUTH_LOGIN_COMPLETED } from '../../../metric-events.js';
 import {
     createCounter,
     createGauge,
+    type Gauge,
     type GaugeSample,
 } from '../../../util/metrics/index.js';
 
@@ -78,31 +79,43 @@ export function registerIntegrationMetrics(deps: IntegrationMetricsDeps): void {
 }
 
 function registerAddons(
-    setLabels: (labels: Record<AvailableLabels, string | number>) => void,
+    gauge: Gauge<AvailableLabels>,
     addonProviders: IAddonProviders,
 ): void {
+    if (!gauge) {
+        throw new Error('Gauge must not be null');
+    }
+
     for (const addon of Object.values(addonProviders)) {
         const { name, deprecated } = addon.definition;
-        setLabels({
-            name,
-            kind: 'addon',
-            deprecated: String(Boolean(deprecated)),
-            removal_target: deprecated ?? '',
-        });
+
+        gauge
+            .labels({
+                name,
+                kind: 'addon',
+                deprecated: String(Boolean(deprecated)),
+                removal_target: deprecated ?? '',
+            })
+            .set(1);
     }
 }
 
-function registerAuthProviders(
-    setLabels: (labels: Record<AvailableLabels, string | number>) => void,
-): void {
+function registerAuthProviders(gauge: Gauge<AvailableLabels>): void {
+    if (!gauge) {
+        throw new Error('Gauge must not be null');
+    }
+
     for (const provider of Object.values(AUTH_PROVIDERS_CATALOG)) {
         const { name, deprecatedRemovalTarget } = provider;
-        setLabels({
-            name,
-            kind: 'auth',
-            deprecated: String(Boolean(deprecatedRemovalTarget)),
-            removal_target: deprecatedRemovalTarget ?? '',
-        });
+
+        gauge
+            .labels({
+                name,
+                kind: 'auth',
+                deprecated: String(Boolean(deprecatedRemovalTarget)),
+                removal_target: deprecatedRemovalTarget ?? '',
+            })
+            .set(1);
     }
 }
 
@@ -119,12 +132,8 @@ function registerAvailableGauge(addonProviders: IAddonProviders): void {
         labelNames: ['name', 'kind', 'deprecated', 'removal_target'] as const,
     });
 
-    const setLabels = (labels: Record<AvailableLabels, string | number>) => {
-        gauge.labels(labels).set(1);
-    };
-
-    registerAddons(setLabels, addonProviders);
-    registerAuthProviders(setLabels);
+    registerAddons(gauge, addonProviders);
+    registerAuthProviders(gauge);
 }
 
 /**

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -3,7 +3,10 @@ import type { Logger } from '../../../logger.js';
 import type { IUnleashConfig } from '../../../types/option.js';
 import type { IUnleashStores } from '../../../types/stores.js';
 import { getAddons, type IAddonProviders } from '../../../addons/index.js';
-import { AUTH_PROVIDERS_CATALOG } from '../../../types/settings/auth-settings.js';
+import {
+    AUTH_PROVIDERS_CATALOG,
+    type AuthProviderConfig,
+} from '../../../types/settings/auth-settings.js';
 import { AUTH_LOGIN_COMPLETED } from '../../../metric-events.js';
 import { createCounter } from '../../../util/metrics/index.js';
 import type { DbMetricsMonitor } from '../../../metrics-gauge.js';
@@ -206,16 +209,13 @@ export async function collectConfiguredIntegrations(
                 try {
                     const row = await stores.settingStore.get<{
                         enabled?: boolean;
+                        disabled?: boolean;
                     }>(provider.configId);
-                    const state: ConfiguredIntegration['state'] = row
-                        ? row.enabled
-                            ? 'enabled'
-                            : 'disabled'
-                        : 'not_configured';
+
                     return {
                         name: provider.name,
                         kind: 'auth' as const,
-                        state,
+                        state: resolveAuthState(provider, row),
                         count: 1,
                     } satisfies ConfiguredIntegration;
                 } catch (error) {
@@ -230,4 +230,29 @@ export async function collectConfiguredIntegrations(
     ).filter((r) => r !== null);
 
     return [...addonBuckets, ...authBuckets];
+}
+
+/**
+ * The providers in Unleash have two interpretations:
+ *   - `default === 'enabled'` (e.g. `simple`)
+ *     row stores `{disabled: boolean}`. If no config row, means addon enabled
+ *     the row only exists once user turns it off (disabled: true).
+ *   - `default === 'disabled'` (e.g. oidc, saml, google) —
+ *     row stores `{enabled: boolean}`. If no config row, means not_configured
+ *     so that dashboards show "nobody ever set this up".
+ */
+function resolveAuthState(
+    provider: AuthProviderConfig,
+    row: { enabled?: boolean; disabled?: boolean } | undefined,
+): ConfiguredIntegration['state'] {
+    if (provider.default === 'enabled') {
+        // e.g. in 'simple' auth, default is enabled, with no config
+        // otherwise stored field is `disabled`;
+        if (row === undefined) return 'enabled';
+        return row.disabled ? 'disabled' : 'enabled';
+    }
+
+    // Standard convention, no row means not_configured.
+    if (row === undefined) return 'not_configured';
+    return row.enabled ? 'enabled' : 'disabled';
 }

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -163,19 +163,12 @@ export async function collectConfiguredSamples(
     stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>,
     logger?: Logger,
 ): Promise<ConfiguredSample[]> {
-    const samples: ConfiguredSample[] = [];
-
     // Addons
     const addons = await stores.addonStore.getAll();
-    const addonBuckets = new Map<
-        string,
-        { enabled: number; disabled: number }
-    >();
-
-    collectAddonSamples(addons, addonBuckets);
+    const addonBuckets = collectAddonSamples(addons);
 
     // Only push if count > 0 to avoid empty entries
-    bucketAddonsByState(addonBuckets, samples);
+    const samples = bucketAddonsByState(addonBuckets);
 
     // Auth providers
     const authResults = await collectAuthSamples(stores, logger);
@@ -220,13 +213,15 @@ async function collectAuthSamples(
     const validAuthSamples = authResults.filter(
         (result): result is ConfiguredSample => result !== null,
     );
+
     return validAuthSamples;
 }
 
 function bucketAddonsByState(
     addonBuckets: Map<string, { enabled: number; disabled: number }>,
-    samples: ConfiguredSample[],
-) {
+): ConfiguredSample[] {
+    const samples: ConfiguredSample[] = [];
+
     for (const [provider, bucket] of addonBuckets) {
         if (bucket.enabled > 0) {
             samples.push({
@@ -245,14 +240,18 @@ function bucketAddonsByState(
             });
         }
     }
+
+    return samples;
 }
 
-function collectAddonSamples(
-    addons: IAddon[],
-    addonBuckets: Map<string, { enabled: number; disabled: number }>,
-) {
+function collectAddonSamples(addons: IAddon[]) {
+    const addonBuckets = new Map<
+        string,
+        { enabled: number; disabled: number }
+    >();
+
     for (const addon of addons) {
-        const bucket = addonBuckets.get(addon.provider) ?? {
+        const bucket = {
             enabled: 0,
             disabled: 0,
         };
@@ -265,4 +264,6 @@ function collectAddonSamples(
 
         addonBuckets.set(addon.provider, bucket);
     }
+
+    return addonBuckets;
 }

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -35,7 +35,6 @@ export function registerIntegrationMetrics(
     const ttlMs = deps.options?.cacheTtlMs ?? DEFAULT_TTL_MS;
 
     registerAvailableGauge(addonProviders);
-    registerDeprecatedInfoGauge(addonProviders);
     registerConfiguredGauge({ stores, ttlMs, logger });
 
     return {
@@ -49,14 +48,15 @@ export function registerIntegrationMetrics(
 }
 
 /**
- *  `integration_available{name, kind, deprecated}`
+ *  `integration_available{name, kind, deprecated, removal_target}`
  *  all available integrations of this server. value=1: registered entry.
+ *  removal_target: set only if deprecated, empty string otherwise.
  */
 function registerAvailableGauge(addonProviders: IAddonProviders): void {
     const gauge = new Gauge({
         name: 'integration_available',
-        help: 'Available integrations  with this Unleash server. value=1: available.',
-        labelNames: ['name', 'kind', 'deprecated'] as const,
+        help: 'Available integrations with this Unleash server. removal_target set if deprecated.',
+        labelNames: ['name', 'kind', 'deprecated', 'removal_target'] as const,
     });
 
     for (const addon of Object.values(addonProviders)) {
@@ -65,6 +65,7 @@ function registerAvailableGauge(addonProviders: IAddonProviders): void {
                 name: addon.definition.name,
                 kind: 'addon',
                 deprecated: String(Boolean(addon.definition.deprecated)),
+                removal_target: addon.definition.deprecated ?? '',
             })
             .set(1);
     }
@@ -75,48 +76,9 @@ function registerAvailableGauge(addonProviders: IAddonProviders): void {
                 name: provider.name,
                 kind: 'auth',
                 deprecated: String(Boolean(provider.deprecatedRemovalTarget)),
+                removal_target: provider.deprecatedRemovalTarget ?? '',
             })
             .set(1);
-    }
-}
-
-/**
- * `integration_deprecated_info{name, kind, removal_target}`
- *  list of gauges with deprecated integrations.
- *
- *  e.g. `integration_configured{state="enabled"} * on(name, kind)
- *      group_left integration_deprecated_info > 0`.
- */
-function registerDeprecatedInfoGauge(addonProviders: IAddonProviders): void {
-    const gauge = new Gauge({
-        name: 'integration_deprecated_info',
-        help: 'Deprecated integrations on this server. value=1 always. Use it as a join target in alert rules.',
-        labelNames: ['name', 'kind', 'removal_target'] as const,
-    });
-
-    for (const addon of Object.values(addonProviders)) {
-        const deprecated = addon.definition.deprecated;
-        if (deprecated) {
-            gauge
-                .labels({
-                    name: addon.definition.name,
-                    kind: 'addon',
-                    removal_target: deprecated,
-                })
-                .set(1);
-        }
-    }
-
-    for (const provider of Object.values(AUTH_PROVIDERS_CATALOG)) {
-        if (provider.deprecatedRemovalTarget) {
-            gauge
-                .labels({
-                    name: provider.name,
-                    kind: 'auth',
-                    removal_target: provider.deprecatedRemovalTarget,
-                })
-                .set(1);
-        }
     }
 }
 

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -6,41 +6,43 @@ import { getAddons, type IAddonProviders } from '../../../addons/index.js';
 import { AUTH_PROVIDERS_CATALOG } from '../../../types/settings/auth-settings.js';
 import type { IAddon } from '../../../types/stores/addon-store.js';
 import { AUTH_LOGIN_COMPLETED } from '../../../metric-events.js';
-import {
-    createCounter,
-    createGauge,
-    type Gauge,
-    type GaugeSample,
-} from '../../../util/metrics/index.js';
-import { minutesToMilliseconds } from 'date-fns';
+import { createCounter } from '../../../util/metrics/index.js';
+import type { DbMetricsMonitor } from '../../../metrics-gauge.js';
 
 interface IntegrationMetricsDeps {
-    addonProviders?: IAddonProviders; // used for testing
-    stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>;
     config: Pick<IUnleashConfig, 'getLogger' | 'server' | 'flagResolver'>;
+    stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>;
     eventBus: EventEmitter;
+    dbMetrics: DbMetricsMonitor;
+    addonProviders?: IAddonProviders; // only for testing
 }
 
-type ConfiguredLabels = 'name' | 'kind' | 'state';
-type AvailableLabels = 'name' | 'kind' | 'deprecated' | 'removal_target';
+/**
+ * row of the `integration_available` gauge
+ */
+interface AvailableIntegrationMetric {
+    name: string;
+    kind: 'addon' | 'auth';
+    deprecated: string;
+    removal_target: string;
+}
 
-interface ConfiguredSample {
+/**
+ * row of the `integration_configured` gauge
+ */
+interface ConfiguredIntegrationMetric {
     name: string;
     kind: 'addon' | 'auth';
     state: 'enabled' | 'disabled' | 'not_configured';
     count: number;
 }
 
-/**
- *  metrics show up on `/internal-backstage/prometheus`.
- */
 export function registerIntegrationMetrics(deps: IntegrationMetricsDeps): void {
-    const { config, stores, eventBus } = deps;
+    const { config, stores, eventBus, dbMetrics } = deps;
     const logger = config.getLogger('metrics/integrations');
 
-    // Get the Addon catalog. Used for tests - production always derives it.
     const addonProviders =
-        deps.addonProviders ?? // passed on tests
+        deps.addonProviders ??
         getAddons({
             getLogger: config.getLogger,
             unleashUrl: config.server.unleashUrl,
@@ -48,13 +50,13 @@ export function registerIntegrationMetrics(deps: IntegrationMetricsDeps): void {
             eventBus,
         } as Parameters<typeof getAddons>[0]);
 
-    registerAvailableGauge(addonProviders);
-    registerConfiguredGauge({ stores, logger });
+    registerAvailableGauge({ dbMetrics, addonProviders });
+    registerConfiguredGauge({ dbMetrics, stores, logger });
 
     registerAuthLoginTotalCounter(eventBus);
 }
 
-function registerAuthLoginTotalCounter(eventBus: EventEmitter<[never]>) {
+function registerAuthLoginTotalCounter(eventBus: EventEmitter): void {
     const authLoginTotal = createCounter({
         name: 'auth_login_total',
         help: 'Authentication attempts by provider per outcome.',
@@ -72,119 +74,103 @@ function registerAuthLoginTotalCounter(eventBus: EventEmitter<[never]>) {
     );
 }
 
-function registerAddons(
-    gauge: Gauge<AvailableLabels>,
-    addonProviders: IAddonProviders,
-): void {
-    if (!gauge) {
-        throw new Error('Gauge must not be null');
-    }
-
-    for (const addon of Object.values(addonProviders)) {
-        const { name, deprecated } = addon.definition;
-
-        gauge
-            .labels({
-                name,
-                kind: 'addon',
-                deprecated: String(Boolean(deprecated)),
-                removal_target: deprecated ?? '',
-            })
-            .set(1);
-    }
-}
-
-function registerAuthProviders(gauge: Gauge<AvailableLabels>): void {
-    if (!gauge) {
-        throw new Error('Gauge must not be null');
-    }
-
-    for (const provider of Object.values(AUTH_PROVIDERS_CATALOG)) {
-        const { name, deprecatedRemovalTarget } = provider;
-
-        gauge
-            .labels({
-                name,
-                kind: 'auth',
-                deprecated: String(Boolean(deprecatedRemovalTarget)),
-                removal_target: deprecatedRemovalTarget ?? '',
-            })
-            .set(1);
-    }
-}
-
 /**
- *  `integration_available{name, kind, deprecated, removal_target}`
+ * `integration_available{name, kind, deprecated, removal_target}`
  *
- *  all available integrations of this server. value=1: registered entry.
- *  removal_target: set only if deprecated, empty string otherwise.
+ * All available integrations (addons + auth providers). value=1 per entry.
+ * `removal_target` is empty if not deprecated.
  */
-function registerAvailableGauge(addonProviders: IAddonProviders): void {
-    const gauge = createGauge<AvailableLabels>({
+function registerAvailableGauge(args: {
+    dbMetrics: DbMetricsMonitor;
+    addonProviders: IAddonProviders;
+}): void {
+    const { dbMetrics, addonProviders } = args;
+
+    dbMetrics.registerGaugeDbMetric({
         name: 'integration_available',
         help: 'Available integrations with this Unleash server. removal_target set if deprecated.',
         labelNames: ['name', 'kind', 'deprecated', 'removal_target'] as const,
+        query: async () => collectAvailableSamples(addonProviders),
+        map: (samples) =>
+            samples.map((s) => ({
+                value: 1,
+                labels: {
+                    name: s.name,
+                    kind: s.kind,
+                    deprecated: s.deprecated,
+                    removal_target: s.removal_target,
+                },
+            })),
     });
-
-    registerAddons(gauge, addonProviders);
-    registerAuthProviders(gauge);
 }
 
 /**
  * `integration_configured{name, kind, state}`
  *
- *  lists configured instances per integration and state (`enabled`/`disabled`)
- *  plus `not_configured` for auth providers that have never been saved.
- *
- *  Uses createGauge's `fetchSamples` mode — the wrapper owns the TTL cache,
- *  the stale-on-error fallback, and the per-scrape reset. The fetcher here
- *  is a pure function from store reads → labelled samples.
+ * Configured addons and auth providers.
+ * For addons: `enabled`/`disabled`.
+ * For auth providers: `enabled`/`disabled`/ `not_configured` ( when no settings).
  */
 function registerConfiguredGauge(args: {
+    dbMetrics: DbMetricsMonitor;
     stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>;
     logger: Logger;
 }): void {
-    const { stores, logger } = args;
+    const { dbMetrics, stores, logger } = args;
 
-    createGauge<ConfiguredLabels>({
+    dbMetrics.registerGaugeDbMetric({
         name: 'integration_configured',
         help: 'Configured integrations on this Unleash server, per state.',
         labelNames: ['name', 'kind', 'state'] as const,
-        ttlMs: minutesToMilliseconds(1),
-        fetchSamples: () => fetchConfiguredSamples(stores, logger),
+        query: () => collectConfiguredSamples(stores, logger),
+        map: (samples) =>
+            samples.map((s) => ({
+                value: s.count,
+                labels: { name: s.name, kind: s.kind, state: s.state },
+            })),
     });
 }
 
-/**
- * Fetches and formats configured integration metrics.
- */
-async function fetchConfiguredSamples(
-    stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>,
-    logger: Logger,
-): Promise<GaugeSample<ConfiguredLabels>[]> {
-    const samples = await collectConfiguredSamples(stores, logger);
+export function collectAvailableSamples(
+    addonProviders: IAddonProviders,
+): AvailableIntegrationMetric[] {
+    const samples: AvailableIntegrationMetric[] = [];
 
-    return samples.map((s) => ({
-        labels: { name: s.name, kind: s.kind, state: s.state },
-        value: s.count,
-    }));
+    for (const addon of Object.values(addonProviders)) {
+        const { name, deprecated } = addon.definition;
+        samples.push({
+            name,
+            kind: 'addon',
+            deprecated: String(Boolean(deprecated)),
+            removal_target: typeof deprecated === 'string' ? deprecated : '',
+        });
+    }
+
+    for (const provider of Object.values(AUTH_PROVIDERS_CATALOG)) {
+        const { name, deprecatedRemovalTarget } = provider;
+        samples.push({
+            name,
+            kind: 'auth',
+            deprecated: String(Boolean(deprecatedRemovalTarget)),
+            removal_target: deprecatedRemovalTarget ?? '',
+        });
+    }
+
+    return samples;
 }
 
 export async function collectConfiguredSamples(
     stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>,
     logger?: Logger,
-): Promise<ConfiguredSample[]> {
-    // Addons
+): Promise<ConfiguredIntegrationMetric[]> {
+    // Addons — per provider × state.
     const addons = await stores.addonStore.getAll();
-    const addonBuckets = collectAddonSamples(addons);
+    const addonBuckets = bucketAddons(addons);
+    const samples = addonBucketsToSamples(addonBuckets);
 
-    // Only push if count > 0 to avoid empty entries
-    const samples = bucketAddonsByState(addonBuckets);
-
-    // Auth providers
-    const authResults = await collectAuthSamples(stores, logger);
-
-    samples.push(...authResults);
+    // Auth providers — one sample per entry
+    const authSamples = await collectAuthSamples(stores, logger);
+    samples.push(...authSamples);
 
     return samples;
 }
@@ -192,26 +178,26 @@ export async function collectConfiguredSamples(
 async function collectAuthSamples(
     stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>,
     logger: Logger | undefined,
-) {
-    const authResults = await Promise.all(
+): Promise<ConfiguredIntegrationMetric[]> {
+    const results = await Promise.all(
         Object.values(AUTH_PROVIDERS_CATALOG).map(async (provider) => {
             try {
-                const config = await stores.settingStore.get<{
+                const row = await stores.settingStore.get<{
                     enabled?: boolean;
                 }>(provider.configId);
 
-                const state = config
-                    ? config.enabled
+                const state: ConfiguredIntegrationMetric['state'] = row
+                    ? row.enabled
                         ? 'enabled'
                         : 'disabled'
                     : 'not_configured';
 
                 return {
                     name: provider.name,
-                    kind: 'auth',
+                    kind: 'auth' as const,
                     state,
                     count: 1,
-                };
+                } satisfies ConfiguredIntegrationMetric;
             } catch (error) {
                 logger?.warn(
                     `Failed to fetch auth config for ${provider.name}`,
@@ -221,17 +207,38 @@ async function collectAuthSamples(
             }
         }),
     );
-    const validAuthSamples = authResults.filter(
-        (result): result is ConfiguredSample => result !== null,
-    );
 
-    return validAuthSamples;
+    return results.filter((result) => result !== null);
 }
 
-function bucketAddonsByState(
+function bucketAddons(
+    addons: IAddon[],
+): Map<string, { enabled: number; disabled: number }> {
+    const addonBuckets = new Map<
+        string,
+        { enabled: number; disabled: number }
+    >();
+
+    for (const addon of addons) {
+        const bucket = addonBuckets.get(addon.provider) ?? {
+            enabled: 0,
+            disabled: 0,
+        };
+        if (addon.enabled) {
+            bucket.enabled++;
+        } else {
+            bucket.disabled++;
+        }
+        addonBuckets.set(addon.provider, bucket);
+    }
+
+    return addonBuckets;
+}
+
+function addonBucketsToSamples(
     addonBuckets: Map<string, { enabled: number; disabled: number }>,
-): ConfiguredSample[] {
-    const samples: ConfiguredSample[] = [];
+): ConfiguredIntegrationMetric[] {
+    const samples: ConfiguredIntegrationMetric[] = [];
 
     for (const [provider, bucket] of addonBuckets) {
         if (bucket.enabled > 0) {
@@ -253,28 +260,4 @@ function bucketAddonsByState(
     }
 
     return samples;
-}
-
-function collectAddonSamples(addons: IAddon[]) {
-    const addonBuckets = new Map<
-        string,
-        { enabled: number; disabled: number }
-    >();
-
-    for (const addon of addons) {
-        const bucket = {
-            enabled: 0,
-            disabled: 0,
-        };
-
-        if (addon.enabled) {
-            bucket.enabled++;
-        } else {
-            bucket.disabled++;
-        }
-
-        addonBuckets.set(addon.provider, bucket);
-    }
-
-    return addonBuckets;
 }

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -1,12 +1,14 @@
-import type { Logger, LogProvider } from '../../../logger.js';
+import type EventEmitter from 'events';
+import type { Logger } from '../../../logger.js';
+import type { IUnleashConfig } from '../../../types/option.js';
 import type { IUnleashStores } from '../../../types/stores.js';
-import type { IAddonProviders } from '../../../addons/index.js';
+import { getAddons, type IAddonProviders } from '../../../addons/index.js';
 import { AUTH_PROVIDERS_CATALOG } from '../../../types/settings/auth-settings.js';
 import type { IAddon } from '../../../types/stores/addon-store.js';
+import { AUTH_LOGIN_COMPLETED } from '../../../metric-events.js';
 import {
     createCounter,
     createGauge,
-    type Counter,
     type GaugeSample,
 } from '../../../util/metrics/index.js';
 
@@ -16,15 +18,12 @@ interface IntegrationMetricsOptions {
     cacheTtlMs?: number;
 }
 
-interface IntegrationMetricsHandles {
-    authLoginTotal: Counter<'provider' | 'outcome'>;
-}
-
 interface IntegrationMetricsDeps {
-    addonProviders: IAddonProviders;
+    addonProviders?: IAddonProviders;
     stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>;
-    getLogger: LogProvider;
+    config: Pick<IUnleashConfig, 'getLogger' | 'server' | 'flagResolver'>;
     options?: IntegrationMetricsOptions;
+    eventBus: EventEmitter;
 }
 
 type ConfiguredLabels = 'name' | 'kind' | 'state';
@@ -40,26 +39,42 @@ interface ConfiguredSample {
 /**
  *  metrics show up on `/internal-backstage/prometheus`.
  */
-export function registerIntegrationMetrics(
-    deps: IntegrationMetricsDeps,
-): IntegrationMetricsHandles {
-    const { addonProviders, stores, getLogger } = deps;
-    const logger = getLogger('metrics/integrations');
+export function registerIntegrationMetrics(deps: IntegrationMetricsDeps): void {
+    const { config, stores, eventBus } = deps;
+    const logger = config.getLogger('metrics/integrations');
 
     // prom-client invokes `collect()` on every call; this short cache prevents
     // lots of Prometheus replicas from hitting the database
     const ttlMs = deps.options?.cacheTtlMs ?? DEFAULT_TTL_MS;
 
+    // Get the Addon catalog. Used for tests - production always derives it.
+    const addonProviders =
+        deps.addonProviders ??
+        getAddons({
+            getLogger: config.getLogger,
+            unleashUrl: config.server.unleashUrl,
+            flagResolver: config.flagResolver,
+            eventBus,
+        } as Parameters<typeof getAddons>[0]);
+
     registerAvailableGauge(addonProviders);
     registerConfiguredGauge({ stores, ttlMs, logger });
 
-    return {
-        authLoginTotal: createCounter({
-            name: 'auth_login_total',
-            help: 'Authentication attempts by provider per outcome.',
-            labelNames: ['provider', 'outcome'] as const,
-        }),
-    };
+    const authLoginTotal = createCounter({
+        name: 'auth_login_total',
+        help: 'Authentication attempts by provider per outcome.',
+        labelNames: ['provider', 'outcome'] as const,
+    });
+
+    eventBus.on(
+        AUTH_LOGIN_COMPLETED,
+        (payload: { provider: string; outcome: 'success' | 'failure' }) => {
+            authLoginTotal.increment({
+                provider: payload.provider,
+                outcome: payload.outcome,
+            });
+        },
+    );
 }
 
 function registerAddons(

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -2,21 +2,7 @@ import { Counter, Gauge } from 'prom-client';
 import type { Logger, LogProvider } from '../../../logger.js';
 import type { IUnleashStores } from '../../../types/stores.js';
 import type { IAddonProviders } from '../../../addons/index.js';
-
-export const AUTH_PROVIDERS_CATALOG: ReadonlyArray<{
-    name: string;
-    configId: string;
-    deprecatedRemovalTarget?: string; // if set, the value is the planned removal release
-}> = [
-    { name: 'simple', configId: 'unleash.auth.simple' },
-    { name: 'oidc', configId: 'unleash.enterprise.auth.oidc' },
-    { name: 'saml', configId: 'unleash.enterprise.auth.saml' },
-    {
-        name: 'google',
-        configId: 'unleash.enterprise.auth.google',
-        deprecatedRemovalTarget: 'v8.0.0',
-    },
-];
+import { AUTH_PROVIDERS_CATALOG } from '../../../types/settings/auth-settings.js';
 
 export interface IntegrationMetricsOptions {
     /**

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -3,6 +3,7 @@ import type { Logger, LogProvider } from '../../../logger.js';
 import type { IUnleashStores } from '../../../types/stores.js';
 import type { IAddonProviders } from '../../../addons/index.js';
 import { AUTH_PROVIDERS_CATALOG } from '../../../types/settings/auth-settings.js';
+import type { IAddon } from '../../../types/stores/addon-store.js';
 
 const DEFAULT_TTL_MS = 60_000; // 1 minute
 
@@ -21,6 +22,12 @@ export interface IntegrationMetricsDeps {
     options?: IntegrationMetricsOptions;
 }
 
+interface ConfiguredSample {
+    name: string;
+    kind: 'addon' | 'auth';
+    state: 'enabled' | 'disabled' | 'not_configured';
+    count: number;
+}
 /**
  *  metrics show up on `/internal-backstage/prometheus`.
  */
@@ -47,6 +54,34 @@ export function registerIntegrationMetrics(
     };
 }
 
+function registerAddons(gauge: Gauge, addonProviders: IAddonProviders): void {
+    for (const addon of Object.values(addonProviders)) {
+        const { name, deprecated } = addon.definition;
+        gauge
+            .labels({
+                name,
+                kind: 'addon',
+                deprecated: String(Boolean(deprecated)),
+                removal_target: deprecated ?? '',
+            })
+            .set(1);
+    }
+}
+
+function registerAuthProviders(gauge: Gauge): void {
+    for (const provider of Object.values(AUTH_PROVIDERS_CATALOG)) {
+        const { name, deprecatedRemovalTarget } = provider;
+        gauge
+            .labels({
+                name,
+                kind: 'auth',
+                deprecated: String(Boolean(deprecatedRemovalTarget)),
+                removal_target: deprecatedRemovalTarget ?? '',
+            })
+            .set(1);
+    }
+}
+
 /**
  *  `integration_available{name, kind, deprecated, removal_target}`
  *  all available integrations of this server. value=1: registered entry.
@@ -59,34 +94,8 @@ function registerAvailableGauge(addonProviders: IAddonProviders): void {
         labelNames: ['name', 'kind', 'deprecated', 'removal_target'] as const,
     });
 
-    for (const addon of Object.values(addonProviders)) {
-        gauge
-            .labels({
-                name: addon.definition.name,
-                kind: 'addon',
-                deprecated: String(Boolean(addon.definition.deprecated)),
-                removal_target: addon.definition.deprecated ?? '',
-            })
-            .set(1);
-    }
-
-    for (const provider of Object.values(AUTH_PROVIDERS_CATALOG)) {
-        gauge
-            .labels({
-                name: provider.name,
-                kind: 'auth',
-                deprecated: String(Boolean(provider.deprecatedRemovalTarget)),
-                removal_target: provider.deprecatedRemovalTarget ?? '',
-            })
-            .set(1);
-    }
-}
-
-interface ConfiguredSample {
-    name: string;
-    kind: 'addon' | 'auth';
-    state: 'enabled' | 'disabled' | 'not_configured';
-    count: number;
+    registerAddons(gauge, addonProviders);
+    registerAuthProviders(gauge);
 }
 
 /**
@@ -124,7 +133,7 @@ function registerConfiguredGauge(args: {
                     cache.ts = now;
                 } catch (err) {
                     logger.warn(
-                        `failed to collect integration_configured: ${
+                        `Failed to collect integration_configured: ${
                             (err as Error).message
                         }`,
                     );
@@ -143,6 +152,7 @@ function registerConfiguredGauge(args: {
         },
     });
 }
+
 export async function collectConfiguredSamples(
     stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>,
     logger?: Logger,
@@ -156,42 +166,23 @@ export async function collectConfiguredSamples(
         { enabled: number; disabled: number }
     >();
 
-    for (const addon of addons) {
-        const bucket = addonBuckets.get(addon.provider) ?? {
-            enabled: 0,
-            disabled: 0,
-        };
-
-        if (addon.enabled) {
-            bucket.enabled++;
-        } else {
-            bucket.disabled++;
-        }
-
-        addonBuckets.set(addon.provider, bucket);
-    }
+    collectAddonSamples(addons, addonBuckets);
 
     // Only push if count > 0 to avoid empty entries
-    for (const [provider, bucket] of addonBuckets) {
-        if (bucket.enabled > 0) {
-            samples.push({
-                name: provider,
-                kind: 'addon',
-                state: 'enabled',
-                count: bucket.enabled,
-            });
-        }
-        if (bucket.disabled > 0) {
-            samples.push({
-                name: provider,
-                kind: 'addon',
-                state: 'disabled',
-                count: bucket.disabled,
-            });
-        }
-    }
+    bucketAddonsByState(addonBuckets, samples);
 
     // Auth providers
+    const authResults = await collectAuthSamples(stores, logger);
+
+    samples.push(...authResults);
+
+    return samples;
+}
+
+async function collectAuthSamples(
+    stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>,
+    logger: Logger | undefined,
+) {
     const authResults = await Promise.all(
         Object.values(AUTH_PROVIDERS_CATALOG).map(async (provider) => {
             try {
@@ -220,12 +211,52 @@ export async function collectConfiguredSamples(
             }
         }),
     );
-
     const validAuthSamples = authResults.filter(
         (result): result is ConfiguredSample => result !== null,
     );
+    return validAuthSamples;
+}
 
-    samples.push(...validAuthSamples);
+function bucketAddonsByState(
+    addonBuckets: Map<string, { enabled: number; disabled: number }>,
+    samples: ConfiguredSample[],
+) {
+    for (const [provider, bucket] of addonBuckets) {
+        if (bucket.enabled > 0) {
+            samples.push({
+                name: provider,
+                kind: 'addon',
+                state: 'enabled',
+                count: bucket.enabled,
+            });
+        }
+        if (bucket.disabled > 0) {
+            samples.push({
+                name: provider,
+                kind: 'addon',
+                state: 'disabled',
+                count: bucket.disabled,
+            });
+        }
+    }
+}
 
-    return samples;
+function collectAddonSamples(
+    addons: IAddon[],
+    addonBuckets: Map<string, { enabled: number; disabled: number }>,
+) {
+    for (const addon of addons) {
+        const bucket = addonBuckets.get(addon.provider) ?? {
+            enabled: 0,
+            disabled: 0,
+        };
+
+        if (addon.enabled) {
+            bucket.enabled++;
+        } else {
+            bucket.disabled++;
+        }
+
+        addonBuckets.set(addon.provider, bucket);
+    }
 }

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -1,26 +1,34 @@
-import { Counter, Gauge } from 'prom-client';
 import type { Logger, LogProvider } from '../../../logger.js';
 import type { IUnleashStores } from '../../../types/stores.js';
 import type { IAddonProviders } from '../../../addons/index.js';
 import { AUTH_PROVIDERS_CATALOG } from '../../../types/settings/auth-settings.js';
 import type { IAddon } from '../../../types/stores/addon-store.js';
+import {
+    createCounter,
+    createGauge,
+    type Counter,
+    type GaugeSample,
+} from '../../../util/metrics/index.js';
 
 const DEFAULT_TTL_MS = 60_000; // 1 minute
 
-export interface IntegrationMetricsOptions {
+interface IntegrationMetricsOptions {
     cacheTtlMs?: number;
 }
 
-export interface IntegrationMetricsHandles {
+interface IntegrationMetricsHandles {
     authLoginTotal: Counter<'provider' | 'outcome'>;
 }
 
-export interface IntegrationMetricsDeps {
+interface IntegrationMetricsDeps {
     addonProviders: IAddonProviders;
     stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>;
     getLogger: LogProvider;
     options?: IntegrationMetricsOptions;
 }
+
+type ConfiguredLabels = 'name' | 'kind' | 'state';
+type AvailableLabels = 'name' | 'kind' | 'deprecated' | 'removal_target';
 
 interface ConfiguredSample {
     name: string;
@@ -28,6 +36,7 @@ interface ConfiguredSample {
     state: 'enabled' | 'disabled' | 'not_configured';
     count: number;
 }
+
 /**
  *  metrics show up on `/internal-backstage/prometheus`.
  */
@@ -45,8 +54,7 @@ export function registerIntegrationMetrics(
     registerConfiguredGauge({ stores, ttlMs, logger });
 
     return {
-        // counter incremented from the enterprise auth providers on every login
-        authLoginTotal: new Counter({
+        authLoginTotal: createCounter({
             name: 'auth_login_total',
             help: 'Authentication attempts by provider per outcome.',
             labelNames: ['provider', 'outcome'] as const,
@@ -54,54 +62,65 @@ export function registerIntegrationMetrics(
     };
 }
 
-function registerAddons(gauge: Gauge, addonProviders: IAddonProviders): void {
+function registerAddons(
+    setLabels: (labels: Record<AvailableLabels, string | number>) => void,
+    addonProviders: IAddonProviders,
+): void {
     for (const addon of Object.values(addonProviders)) {
         const { name, deprecated } = addon.definition;
-        gauge
-            .labels({
-                name,
-                kind: 'addon',
-                deprecated: String(Boolean(deprecated)),
-                removal_target: deprecated ?? '',
-            })
-            .set(1);
+        setLabels({
+            name,
+            kind: 'addon',
+            deprecated: String(Boolean(deprecated)),
+            removal_target: deprecated ?? '',
+        });
     }
 }
 
-function registerAuthProviders(gauge: Gauge): void {
+function registerAuthProviders(
+    setLabels: (labels: Record<AvailableLabels, string | number>) => void,
+): void {
     for (const provider of Object.values(AUTH_PROVIDERS_CATALOG)) {
         const { name, deprecatedRemovalTarget } = provider;
-        gauge
-            .labels({
-                name,
-                kind: 'auth',
-                deprecated: String(Boolean(deprecatedRemovalTarget)),
-                removal_target: deprecatedRemovalTarget ?? '',
-            })
-            .set(1);
+        setLabels({
+            name,
+            kind: 'auth',
+            deprecated: String(Boolean(deprecatedRemovalTarget)),
+            removal_target: deprecatedRemovalTarget ?? '',
+        });
     }
 }
 
 /**
  *  `integration_available{name, kind, deprecated, removal_target}`
+ *
  *  all available integrations of this server. value=1: registered entry.
  *  removal_target: set only if deprecated, empty string otherwise.
  */
 function registerAvailableGauge(addonProviders: IAddonProviders): void {
-    const gauge = new Gauge({
+    const gauge = createGauge<AvailableLabels>({
         name: 'integration_available',
         help: 'Available integrations with this Unleash server. removal_target set if deprecated.',
         labelNames: ['name', 'kind', 'deprecated', 'removal_target'] as const,
     });
 
-    registerAddons(gauge, addonProviders);
-    registerAuthProviders(gauge);
+    const setLabels = (labels: Record<AvailableLabels, string | number>) => {
+        gauge.labels(labels).set(1);
+    };
+
+    registerAddons(setLabels, addonProviders);
+    registerAuthProviders(setLabels);
 }
 
 /**
  * `integration_configured{name, kind, state}`
+ *
  *  lists configured instances per integration and state (`enabled`/`disabled`)
  *  plus `not_configured` for auth providers that have never been saved.
+ *
+ *  Uses createGauge's `fetchSamples` mode — the wrapper owns the TTL cache,
+ *  the stale-on-error fallback, and the per-scrape reset. The fetcher here
+ *  is a pure function from store reads → labelled samples.
  */
 function registerConfiguredGauge(args: {
     stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>;
@@ -109,46 +128,18 @@ function registerConfiguredGauge(args: {
     logger: Logger;
 }): void {
     const { stores, ttlMs, logger } = args;
-    const cache: { ts: number; samples: ConfiguredSample[] } = {
-        ts: 0,
-        samples: [],
-    };
 
-    new Gauge({
+    createGauge<ConfiguredLabels>({
         name: 'integration_configured',
-        help: 'Configured integrations on this Unleash server, per state. They benefit a short TTL cache. value=1: integration is compiled in and selectable',
+        help: 'Configured integrations on this Unleash server, per state.',
         labelNames: ['name', 'kind', 'state'] as const,
-        async collect() {
-            const now = Date.now();
-
-            // Lazily evaluated via prom-client `collect()`, TTL-cached.
-            const fresh = now - cache.ts < ttlMs && cache.samples.length > 0;
-
-            if (!fresh) {
-                try {
-                    cache.samples = await collectConfiguredSamples(
-                        stores,
-                        logger,
-                    );
-                    cache.ts = now;
-                } catch (err) {
-                    logger.warn(
-                        `Failed to collect integration_configured: ${
-                            (err as Error).message
-                        }`,
-                    );
-                    if (cache.samples.length === 0) return; // prefer no gaps
-                }
-            }
-
-            this.reset();
-            for (const s of cache.samples) {
-                this.labels({
-                    name: s.name,
-                    kind: s.kind,
-                    state: s.state,
-                }).set(s.count);
-            }
+        ttlMs,
+        fetchSamples: async (): Promise<GaugeSample<ConfiguredLabels>[]> => {
+            const samples = await collectConfiguredSamples(stores, logger);
+            return samples.map((s) => ({
+                labels: { name: s.name, kind: s.kind, state: s.state },
+                value: s.count,
+            }));
         },
     });
 }

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -4,7 +4,6 @@ import type { IUnleashConfig } from '../../../types/option.js';
 import type { IUnleashStores } from '../../../types/stores.js';
 import { getAddons, type IAddonProviders } from '../../../addons/index.js';
 import { AUTH_PROVIDERS_CATALOG } from '../../../types/settings/auth-settings.js';
-import type { IAddon } from '../../../types/stores/addon-store.js';
 import { AUTH_LOGIN_COMPLETED } from '../../../metric-events.js';
 import { createCounter } from '../../../util/metrics/index.js';
 import type { DbMetricsMonitor } from '../../../metrics-gauge.js';
@@ -14,35 +13,35 @@ interface IntegrationMetricsDeps {
     stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>;
     eventBus: EventEmitter;
     dbMetrics: DbMetricsMonitor;
-    addonProviders?: IAddonProviders; // only for testing
+    addonProviders?: IAddonProviders;
 }
 
-/**
- * row of the `integration_available` gauge
- */
-interface AvailableIntegrationMetric {
+interface AvailableIntegration {
     name: string;
     kind: 'addon' | 'auth';
     deprecated: string;
     removal_target: string;
 }
 
-/**
- * row of the `integration_configured` gauge
- */
-interface ConfiguredIntegrationMetric {
+interface ConfiguredIntegration {
     name: string;
     kind: 'addon' | 'auth';
     state: 'enabled' | 'disabled' | 'not_configured';
     count: number;
 }
 
-export function registerIntegrationMetrics(deps: IntegrationMetricsDeps): void {
-    const { config, stores, eventBus, dbMetrics } = deps;
+export function registerIntegrationMetrics({
+    config,
+    stores,
+    eventBus,
+    dbMetrics,
+    addonProviders,
+}: IntegrationMetricsDeps): void {
     const logger = config.getLogger('metrics/integrations');
 
-    const addonProviders =
-        deps.addonProviders ??
+    // passed only in testing
+    addonProviders =
+        addonProviders ??
         getAddons({
             getLogger: config.getLogger,
             unleashUrl: config.server.unleashUrl,
@@ -50,10 +49,60 @@ export function registerIntegrationMetrics(deps: IntegrationMetricsDeps): void {
             eventBus,
         } as Parameters<typeof getAddons>[0]);
 
-    registerAvailableGauge({ dbMetrics, addonProviders });
-    registerConfiguredGauge({ dbMetrics, stores, logger });
+    registerGaugeWithParams({
+        dbMetrics,
+        name: 'integration_available',
+        help: 'Available integrations with this Unleash server. removal_target set if deprecated.',
+        labelNames: ['name', 'kind', 'deprecated', 'removal_target'] as const,
+        query: async () => collectAvailableIntegrations(addonProviders),
+        mapMetric: (s: AvailableIntegration) => ({
+            value: 1,
+            labels: {
+                name: s.name,
+                kind: s.kind,
+                deprecated: s.deprecated,
+                removal_target: s.removal_target,
+            },
+        }),
+    });
+
+    registerGaugeWithParams({
+        dbMetrics,
+        name: 'integration_configured',
+        help: 'Configured integrations on this Unleash server, per state.',
+        labelNames: ['name', 'kind', 'state'] as const,
+        query: () => collectConfiguredIntegrations(stores, logger),
+        mapMetric: (s: ConfiguredIntegration) => ({
+            value: s.count,
+            labels: { name: s.name, kind: s.kind, state: s.state },
+        }),
+    });
 
     registerAuthLoginTotalCounter(eventBus);
+}
+
+function registerGaugeWithParams<T extends { name: string; kind: string }>({
+    dbMetrics,
+    name,
+    help,
+    labelNames,
+    query,
+    mapMetric,
+}: {
+    dbMetrics: DbMetricsMonitor;
+    name: string;
+    help: string;
+    labelNames: readonly string[];
+    query: () => Promise<T[]>;
+    mapMetric: (m: T) => { value: number; labels: Record<string, string> };
+}): void {
+    dbMetrics.registerGaugeDbMetric({
+        name,
+        help,
+        labelNames: labelNames as string[],
+        query,
+        map: (metrics) => metrics.map(mapMetric),
+    });
 }
 
 function registerAuthLoginTotalCounter(eventBus: EventEmitter): void {
@@ -74,190 +123,105 @@ function registerAuthLoginTotalCounter(eventBus: EventEmitter): void {
     );
 }
 
-/**
- * `integration_available{name, kind, deprecated, removal_target}`
- *
- * All available integrations (addons + auth providers). value=1 per entry.
- * `removal_target` is empty if not deprecated.
- */
-function registerAvailableGauge(args: {
-    dbMetrics: DbMetricsMonitor;
-    addonProviders: IAddonProviders;
-}): void {
-    const { dbMetrics, addonProviders } = args;
-
-    dbMetrics.registerGaugeDbMetric({
-        name: 'integration_available',
-        help: 'Available integrations with this Unleash server. removal_target set if deprecated.',
-        labelNames: ['name', 'kind', 'deprecated', 'removal_target'] as const,
-        query: async () => collectAvailableSamples(addonProviders),
-        map: (samples) =>
-            samples.map((s) => ({
-                value: 1,
-                labels: {
-                    name: s.name,
-                    kind: s.kind,
-                    deprecated: s.deprecated,
-                    removal_target: s.removal_target,
-                },
-            })),
-    });
-}
-
-/**
- * `integration_configured{name, kind, state}`
- *
- * Configured addons and auth providers.
- * For addons: `enabled`/`disabled`.
- * For auth providers: `enabled`/`disabled`/ `not_configured` ( when no settings).
- */
-function registerConfiguredGauge(args: {
-    dbMetrics: DbMetricsMonitor;
-    stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>;
-    logger: Logger;
-}): void {
-    const { dbMetrics, stores, logger } = args;
-
-    dbMetrics.registerGaugeDbMetric({
-        name: 'integration_configured',
-        help: 'Configured integrations on this Unleash server, per state.',
-        labelNames: ['name', 'kind', 'state'] as const,
-        query: () => collectConfiguredSamples(stores, logger),
-        map: (samples) =>
-            samples.map((s) => ({
-                value: s.count,
-                labels: { name: s.name, kind: s.kind, state: s.state },
-            })),
-    });
-}
-
-export function collectAvailableSamples(
+export function collectAvailableIntegrations(
     addonProviders: IAddonProviders,
-): AvailableIntegrationMetric[] {
-    const samples: AvailableIntegrationMetric[] = [];
-
-    for (const addon of Object.values(addonProviders)) {
-        const { name, deprecated } = addon.definition;
-        samples.push({
+): AvailableIntegration[] {
+    const addons = Object.values(addonProviders).map(
+        ({ definition: { name, deprecated } }) => ({
             name,
-            kind: 'addon',
+            kind: 'addon' as const,
             deprecated: String(Boolean(deprecated)),
             removal_target: typeof deprecated === 'string' ? deprecated : '',
-        });
-    }
-
-    for (const provider of Object.values(AUTH_PROVIDERS_CATALOG)) {
-        const { name, deprecatedRemovalTarget } = provider;
-        samples.push({
-            name,
-            kind: 'auth',
-            deprecated: String(Boolean(deprecatedRemovalTarget)),
-            removal_target: deprecatedRemovalTarget ?? '',
-        });
-    }
-
-    return samples;
-}
-
-export async function collectConfiguredSamples(
-    stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>,
-    logger?: Logger,
-): Promise<ConfiguredIntegrationMetric[]> {
-    // Addons — per provider × state.
-    const addons = await stores.addonStore.getAll();
-    const addonBuckets = bucketAddons(addons);
-    const samples = addonBucketsToSamples(addonBuckets);
-
-    // Auth providers — one sample per entry
-    const authSamples = await collectAuthSamples(stores, logger);
-    samples.push(...authSamples);
-
-    return samples;
-}
-
-async function collectAuthSamples(
-    stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>,
-    logger: Logger | undefined,
-): Promise<ConfiguredIntegrationMetric[]> {
-    const results = await Promise.all(
-        Object.values(AUTH_PROVIDERS_CATALOG).map(async (provider) => {
-            try {
-                const row = await stores.settingStore.get<{
-                    enabled?: boolean;
-                }>(provider.configId);
-
-                const state: ConfiguredIntegrationMetric['state'] = row
-                    ? row.enabled
-                        ? 'enabled'
-                        : 'disabled'
-                    : 'not_configured';
-
-                return {
-                    name: provider.name,
-                    kind: 'auth' as const,
-                    state,
-                    count: 1,
-                } satisfies ConfiguredIntegrationMetric;
-            } catch (error) {
-                logger?.warn(
-                    `Failed to fetch auth config for ${provider.name}`,
-                    { error },
-                );
-                return null;
-            }
         }),
     );
 
-    return results.filter((result) => result !== null);
+    const authProviders = Object.values(AUTH_PROVIDERS_CATALOG).map(
+        ({ name, deprecatedRemovalTarget }) => ({
+            name,
+            kind: 'auth' as const,
+            deprecated: String(Boolean(deprecatedRemovalTarget)),
+            removal_target: deprecatedRemovalTarget ?? '',
+        }),
+    );
+
+    return [...addons, ...authProviders];
 }
 
-function bucketAddons(
-    addons: IAddon[],
-): Map<string, { enabled: number; disabled: number }> {
-    const addonBuckets = new Map<
-        string,
-        { enabled: number; disabled: number }
-    >();
+export async function collectConfiguredIntegrations(
+    stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>,
+    logger?: Logger,
+): Promise<ConfiguredIntegration[]> {
+    const addons = await stores.addonStore.getAll();
 
-    for (const addon of addons) {
-        const bucket = addonBuckets.get(addon.provider) ?? {
-            enabled: 0,
-            disabled: 0,
-        };
-        if (addon.enabled) {
-            bucket.enabled++;
-        } else {
-            bucket.disabled++;
-        }
-        addonBuckets.set(addon.provider, bucket);
-    }
+    const addonBuckets = Object.entries(
+        addons.reduce<Record<string, { enabled: number; disabled: number }>>(
+            (acc, addon) => {
+                const bucket = acc[addon.provider] ?? {
+                    enabled: 0,
+                    disabled: 0,
+                };
+                acc[addon.provider] = bucket;
 
-    return addonBuckets;
-}
+                if (addon.enabled) {
+                    bucket.enabled++;
+                } else {
+                    bucket.disabled++;
+                }
+                return acc;
+            },
+            {},
+        ),
+    ).flatMap(([provider, { enabled, disabled }]) => [
+        ...(enabled > 0
+            ? [
+                  {
+                      name: provider,
+                      kind: 'addon' as const,
+                      state: 'enabled' as const,
+                      count: enabled,
+                  },
+              ]
+            : []),
+        ...(disabled > 0
+            ? [
+                  {
+                      name: provider,
+                      kind: 'addon' as const,
+                      state: 'disabled' as const,
+                      count: disabled,
+                  },
+              ]
+            : []),
+    ]);
 
-function addonBucketsToSamples(
-    addonBuckets: Map<string, { enabled: number; disabled: number }>,
-): ConfiguredIntegrationMetric[] {
-    const samples: ConfiguredIntegrationMetric[] = [];
+    const authBuckets = (
+        await Promise.all(
+            Object.values(AUTH_PROVIDERS_CATALOG).map(async (provider) => {
+                try {
+                    const row = await stores.settingStore.get<{
+                        enabled?: boolean;
+                    }>(provider.configId);
+                    const state: ConfiguredIntegration['state'] = row
+                        ? row.enabled
+                            ? 'enabled'
+                            : 'disabled'
+                        : 'not_configured';
+                    return {
+                        name: provider.name,
+                        kind: 'auth' as const,
+                        state,
+                        count: 1,
+                    } satisfies ConfiguredIntegration;
+                } catch (error) {
+                    logger?.warn(
+                        `Failed to fetch auth config for ${provider.name}`,
+                        { error },
+                    );
+                    return null;
+                }
+            }),
+        )
+    ).filter((r) => r !== null);
 
-    for (const [provider, bucket] of addonBuckets) {
-        if (bucket.enabled > 0) {
-            samples.push({
-                name: provider,
-                kind: 'addon',
-                state: 'enabled',
-                count: bucket.enabled,
-            });
-        }
-        if (bucket.disabled > 0) {
-            samples.push({
-                name: provider,
-                kind: 'addon',
-                state: 'disabled',
-                count: bucket.disabled,
-            });
-        }
-    }
-
-    return samples;
+    return [...addonBuckets, ...authBuckets];
 }

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -12,18 +12,12 @@ import {
     type Gauge,
     type GaugeSample,
 } from '../../../util/metrics/index.js';
-
-const DEFAULT_TTL_MS = 60_000; // 1 minute
-
-interface IntegrationMetricsOptions {
-    cacheTtlMs?: number;
-}
+import { minutesToMilliseconds } from 'date-fns';
 
 interface IntegrationMetricsDeps {
-    addonProviders?: IAddonProviders;
+    addonProviders?: IAddonProviders; // used for testing
     stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>;
     config: Pick<IUnleashConfig, 'getLogger' | 'server' | 'flagResolver'>;
-    options?: IntegrationMetricsOptions;
     eventBus: EventEmitter;
 }
 
@@ -44,13 +38,9 @@ export function registerIntegrationMetrics(deps: IntegrationMetricsDeps): void {
     const { config, stores, eventBus } = deps;
     const logger = config.getLogger('metrics/integrations');
 
-    // prom-client invokes `collect()` on every call; this short cache prevents
-    // lots of Prometheus replicas from hitting the database
-    const ttlMs = deps.options?.cacheTtlMs ?? DEFAULT_TTL_MS;
-
     // Get the Addon catalog. Used for tests - production always derives it.
     const addonProviders =
-        deps.addonProviders ??
+        deps.addonProviders ?? // passed on tests
         getAddons({
             getLogger: config.getLogger,
             unleashUrl: config.server.unleashUrl,
@@ -59,8 +49,12 @@ export function registerIntegrationMetrics(deps: IntegrationMetricsDeps): void {
         } as Parameters<typeof getAddons>[0]);
 
     registerAvailableGauge(addonProviders);
-    registerConfiguredGauge({ stores, ttlMs, logger });
+    registerConfiguredGauge({ stores, logger });
 
+    registerAuthLoginTotalCounter(eventBus);
+}
+
+function registerAuthLoginTotalCounter(eventBus: EventEmitter<[never]>) {
     const authLoginTotal = createCounter({
         name: 'auth_login_total',
         help: 'Authentication attempts by provider per outcome.',
@@ -148,24 +142,32 @@ function registerAvailableGauge(addonProviders: IAddonProviders): void {
  */
 function registerConfiguredGauge(args: {
     stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>;
-    ttlMs: number;
     logger: Logger;
 }): void {
-    const { stores, ttlMs, logger } = args;
+    const { stores, logger } = args;
 
     createGauge<ConfiguredLabels>({
         name: 'integration_configured',
         help: 'Configured integrations on this Unleash server, per state.',
         labelNames: ['name', 'kind', 'state'] as const,
-        ttlMs,
-        fetchSamples: async (): Promise<GaugeSample<ConfiguredLabels>[]> => {
-            const samples = await collectConfiguredSamples(stores, logger);
-            return samples.map((s) => ({
-                labels: { name: s.name, kind: s.kind, state: s.state },
-                value: s.count,
-            }));
-        },
+        ttlMs: minutesToMilliseconds(1),
+        fetchSamples: () => fetchConfiguredSamples(stores, logger),
     });
+}
+
+/**
+ * Fetches and formats configured integration metrics.
+ */
+async function fetchConfiguredSamples(
+    stores: Pick<IUnleashStores, 'addonStore' | 'settingStore'>,
+    logger: Logger,
+): Promise<GaugeSample<ConfiguredLabels>[]> {
+    const samples = await collectConfiguredSamples(stores, logger);
+
+    return samples.map((s) => ({
+        labels: { name: s.name, kind: s.kind, state: s.state },
+        value: s.count,
+    }));
 }
 
 export async function collectConfiguredSamples(

--- a/src/lib/features/metrics/integrations/integration-metrics.ts
+++ b/src/lib/features/metrics/integrations/integration-metrics.ts
@@ -157,44 +157,32 @@ export async function collectConfiguredIntegrations(
 ): Promise<ConfiguredIntegration[]> {
     const addons = await stores.addonStore.getAll();
 
-    const addonBuckets = Object.entries(
-        addons.reduce<Record<string, { enabled: number; disabled: number }>>(
-            (acc, addon) => {
-                const bucket = acc[addon.provider] ?? {
-                    enabled: 0,
-                    disabled: 0,
-                };
-                acc[addon.provider] = bucket;
+    const addonBuckets: Array<{
+        name: string;
+        state: 'enabled' | 'disabled';
+        count: number;
+    }> = [];
+    addons.forEach((addon) => {
+        const enabled = addons.filter(
+            (a) => a.provider === addon.provider && a.enabled,
+        ).length;
+        const disabled = addons.filter(
+            (a) => a.provider === addon.provider && !a.enabled,
+        ).length;
 
-                if (addon.enabled) {
-                    bucket.enabled++;
-                } else {
-                    bucket.disabled++;
-                }
-                return acc;
-            },
-            {},
-        ),
-    ).flatMap(([provider, { enabled, disabled }]) => [
-        ...(enabled > 0
-            ? [
-                  {
-                      name: provider,
-                      state: 'enabled' as const,
-                      count: enabled,
-                  },
-              ]
-            : []),
-        ...(disabled > 0
-            ? [
-                  {
-                      name: provider,
-                      state: 'disabled' as const,
-                      count: disabled,
-                  },
-              ]
-            : []),
-    ]);
+        if (enabled > 0)
+            addonBuckets.push({
+                name: addon.provider,
+                state: 'enabled',
+                count: enabled,
+            });
+        if (disabled > 0)
+            addonBuckets.push({
+                name: addon.provider,
+                state: 'disabled',
+                count: disabled,
+            });
+    });
 
     const authBuckets = (
         await Promise.all(

--- a/src/lib/metric-events.ts
+++ b/src/lib/metric-events.ts
@@ -15,6 +15,7 @@ const USER_LOGIN = 'user-login' as const;
 const EXCEEDS_LIMIT = 'exceeds-limit' as const;
 const REQUEST_ORIGIN = 'request_origin' as const;
 const ADDON_EVENTS_HANDLED = 'addon-event-handled' as const;
+const AUTH_LOGIN_COMPLETED = 'auth-login-completed' as const;
 const CLIENT_METRICS_NAMEPREFIX = 'client-api-nameprefix';
 const CLIENT_METRICS_TAGS = 'client-api-tags';
 const CLIENT_METRICS_PROJECT = 'client-api-project';
@@ -107,6 +108,7 @@ export {
     EXCEEDS_LIMIT,
     REQUEST_ORIGIN,
     ADDON_EVENTS_HANDLED,
+    AUTH_LOGIN_COMPLETED,
     CLIENT_METRICS_NAMEPREFIX,
     CLIENT_METRICS_TAGS,
     CLIENT_METRICS_PROJECT,

--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -370,3 +370,36 @@ test('should collect read_only_users metrics', async () => {
         await prometheusRegister.getSingleMetricAsString('read_only_users');
     expect(recordedMetric).toMatch(/read_only_users 0/);
 });
+
+test('registerPrometheusMetrics exposes integration_available for every registered addon', async () => {
+    const output = await register.metrics();
+
+    expect(output).toMatch(
+        /integration_available\{[^}]*name="webhook"[^}]*kind="addon"/,
+    );
+    expect(output).toMatch(
+        /integration_available\{[^}]*name="oidc"[^}]*kind="auth"/,
+    );
+    expect(output).toMatch(
+        /integration_available\{[^}]*name="google"[^}]*kind="auth"[^}]*deprecated="true"/,
+    );
+});
+
+test('AUTH_LOGIN_COMPLETED event increments auth_login_total', async () => {
+    eventBus.emit('auth-login-completed', {
+        provider: 'google',
+        outcome: 'success',
+    });
+    eventBus.emit('auth-login-completed', {
+        provider: 'google',
+        outcome: 'failure',
+    });
+
+    const output = await register.metrics();
+    expect(output).toMatch(
+        /auth_login_total\{[^}]*provider="google"[^}]*outcome="success"[^}]*\} 1/,
+    );
+    expect(output).toMatch(
+        /auth_login_total\{[^}]*provider="google"[^}]*outcome="failure"[^}]*\} 1/,
+    );
+});

--- a/src/lib/metrics.test.ts
+++ b/src/lib/metrics.test.ts
@@ -374,14 +374,10 @@ test('should collect read_only_users metrics', async () => {
 test('registerPrometheusMetrics exposes integration_available for every registered addon', async () => {
     const output = await register.metrics();
 
+    expect(output).toMatch(/integration_available\{[^}]*name="webhook"[^}]/);
+    expect(output).toMatch(/integration_available\{[^}]*name="oidc"[^}]/);
     expect(output).toMatch(
-        /integration_available\{[^}]*name="webhook"[^}]*kind="addon"/,
-    );
-    expect(output).toMatch(
-        /integration_available\{[^}]*name="oidc"[^}]*kind="auth"/,
-    );
-    expect(output).toMatch(
-        /integration_available\{[^}]*name="google"[^}]*kind="auth"[^}]*deprecated="true"/,
+        /integration_available\{[^}]*name="google"[^}]*deprecated="true"/,
     );
 });
 

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -43,7 +43,6 @@ import type { IClientMetricsEnv } from './features/metrics/client-metrics/client
 import { DbMetricsMonitor } from './metrics-gauge.js';
 import * as impactMetrics from './features/metrics/impact/define-impact-metrics.js';
 import HyperLogLog from 'hyperloglog-lite';
-import { getAddons } from './addons/index.js';
 import { registerIntegrationMetrics } from './features/metrics/integrations/integration-metrics.js';
 
 const DISTINCT_HLL_REGISTERS_EXPONENT = 14;
@@ -1223,31 +1222,7 @@ export function registerPrometheusMetrics(
         addonEventsHandledCounter.increment({ result, destination });
     });
 
-    const addonProvidersForMetrics = getAddons({
-        getLogger: config.getLogger,
-        unleashUrl: config.server.unleashUrl,
-        flagResolver: config.flagResolver,
-        eventBus,
-    } as Parameters<typeof getAddons>[0]);
-
-    const integrationHandles = registerIntegrationMetrics({
-        addonProviders: addonProvidersForMetrics,
-        stores,
-        getLogger: config.getLogger,
-    });
-
-    eventBus.on(
-        events.AUTH_LOGIN_COMPLETED,
-        ({
-            provider,
-            outcome,
-        }: {
-            provider: string;
-            outcome: 'success' | 'failure';
-        }) => {
-            integrationHandles.authLoginTotal.increment({ provider, outcome });
-        },
-    );
+    registerIntegrationMetrics({ config, stores, eventBus });
 
     return {
         collectAggDbMetrics: dbMetrics.refreshMetrics,

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -43,6 +43,8 @@ import type { IClientMetricsEnv } from './features/metrics/client-metrics/client
 import { DbMetricsMonitor } from './metrics-gauge.js';
 import * as impactMetrics from './features/metrics/impact/define-impact-metrics.js';
 import HyperLogLog from 'hyperloglog-lite';
+import { getAddons } from './addons/index.js';
+import { registerIntegrationMetrics } from './features/metrics/integrations/integration-metrics.js';
 
 const DISTINCT_HLL_REGISTERS_EXPONENT = 14;
 
@@ -1220,6 +1222,32 @@ export function registerPrometheusMetrics(
     eventBus.on(events.ADDON_EVENTS_HANDLED, ({ result, destination }) => {
         addonEventsHandledCounter.increment({ result, destination });
     });
+
+    const addonProvidersForMetrics = getAddons({
+        getLogger: config.getLogger,
+        unleashUrl: config.server.unleashUrl,
+        flagResolver: config.flagResolver,
+        eventBus,
+    } as Parameters<typeof getAddons>[0]);
+
+    const integrationHandles = registerIntegrationMetrics({
+        addonProviders: addonProvidersForMetrics,
+        stores,
+        getLogger: config.getLogger,
+    });
+
+    eventBus.on(
+        events.AUTH_LOGIN_COMPLETED,
+        ({
+            provider,
+            outcome,
+        }: {
+            provider: string;
+            outcome: 'success' | 'failure';
+        }) => {
+            integrationHandles.authLoginTotal.inc({ provider, outcome });
+        },
+    );
 
     return {
         collectAggDbMetrics: dbMetrics.refreshMetrics,

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1222,7 +1222,7 @@ export function registerPrometheusMetrics(
         addonEventsHandledCounter.increment({ result, destination });
     });
 
-    registerIntegrationMetrics({ config, stores, eventBus });
+    registerIntegrationMetrics({ config, stores, eventBus, dbMetrics });
 
     return {
         collectAggDbMetrics: dbMetrics.refreshMetrics,

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1245,7 +1245,7 @@ export function registerPrometheusMetrics(
             provider: string;
             outcome: 'success' | 'failure';
         }) => {
-            integrationHandles.authLoginTotal.inc({ provider, outcome });
+            integrationHandles.authLoginTotal.increment({ provider, outcome });
         },
     );
 

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -43,7 +43,7 @@ import type { IClientMetricsEnv } from './features/metrics/client-metrics/client
 import { DbMetricsMonitor } from './metrics-gauge.js';
 import * as impactMetrics from './features/metrics/impact/define-impact-metrics.js';
 import HyperLogLog from 'hyperloglog-lite';
-import { registerIntegrationMetrics } from './features/metrics/integrations/integration-metrics.js';
+import { setupIntegrationMetrics } from './features/metrics/integrations/integration-metrics.js';
 
 const DISTINCT_HLL_REGISTERS_EXPONENT = 14;
 
@@ -1222,7 +1222,7 @@ export function registerPrometheusMetrics(
         addonEventsHandledCounter.increment({ result, destination });
     });
 
-    registerIntegrationMetrics({ config, stores, eventBus, dbMetrics });
+    setupIntegrationMetrics({ config, stores, eventBus, dbMetrics });
 
     return {
         collectAggDbMetrics: dbMetrics.refreshMetrics,

--- a/src/lib/types/settings/auth-settings.ts
+++ b/src/lib/types/settings/auth-settings.ts
@@ -12,3 +12,10 @@ export const AUTH_PROVIDERS_CATALOG: ReadonlyArray<{
         deprecatedRemovalTarget: 'v8.0.0',
     },
 ];
+
+export function getAuthConfigId(providerName: string): string {
+    const provider = AUTH_PROVIDERS_CATALOG.find(
+        (p) => p.name === providerName,
+    );
+    return provider?.configId ?? '';
+}

--- a/src/lib/types/settings/auth-settings.ts
+++ b/src/lib/types/settings/auth-settings.ts
@@ -1,0 +1,14 @@
+export const AUTH_PROVIDERS_CATALOG: ReadonlyArray<{
+    name: string;
+    configId: string;
+    deprecatedRemovalTarget?: string; // if set, the value is the planned removal release
+}> = [
+    { name: 'simple', configId: 'unleash.auth.simple' },
+    { name: 'oidc', configId: 'unleash.enterprise.auth.oidc' },
+    { name: 'saml', configId: 'unleash.enterprise.auth.saml' },
+    {
+        name: 'google',
+        configId: 'unleash.enterprise.auth.google',
+        deprecatedRemovalTarget: 'v8.0.0',
+    },
+];

--- a/src/lib/types/settings/auth-settings.ts
+++ b/src/lib/types/settings/auth-settings.ts
@@ -2,27 +2,35 @@ interface AuthProvider {
     readonly name: string;
     readonly configId: string;
     readonly deprecatedRemovalTarget?: string;
+    readonly default: 'enabled' | 'disabled';
 }
 
 export const AUTH_PROVIDERS_CATALOG = {
     Simple: {
         name: 'simple',
         configId: 'unleash.auth.simple',
+        default: 'enabled',
     } as AuthProvider,
 
     OIDC: {
         name: 'oidc',
         configId: 'unleash.enterprise.auth.oidc',
+        default: 'disabled',
     } as AuthProvider,
 
     SAML: {
         name: 'saml',
         configId: 'unleash.enterprise.auth.saml',
+        default: 'disabled',
     } as AuthProvider,
 
     Google: {
         name: 'google',
         configId: 'unleash.enterprise.auth.google',
         deprecatedRemovalTarget: 'v8.0.0',
+        default: 'disabled',
     } as AuthProvider,
 } as const;
+
+export type AuthProviderConfig =
+    (typeof AUTH_PROVIDERS_CATALOG)[keyof typeof AUTH_PROVIDERS_CATALOG];

--- a/src/lib/types/settings/auth-settings.ts
+++ b/src/lib/types/settings/auth-settings.ts
@@ -1,21 +1,28 @@
-export const AUTH_PROVIDERS_CATALOG: ReadonlyArray<{
-    name: string;
-    configId: string;
-    deprecatedRemovalTarget?: string; // if set, the value is the planned removal release
-}> = [
-    { name: 'simple', configId: 'unleash.auth.simple' },
-    { name: 'oidc', configId: 'unleash.enterprise.auth.oidc' },
-    { name: 'saml', configId: 'unleash.enterprise.auth.saml' },
-    {
+interface AuthProvider {
+    readonly name: string;
+    readonly configId: string;
+    readonly deprecatedRemovalTarget?: string;
+}
+
+export const AUTH_PROVIDERS_CATALOG = {
+    Simple: {
+        name: 'simple',
+        configId: 'unleash.auth.simple',
+    } as AuthProvider,
+
+    OIDC: {
+        name: 'oidc',
+        configId: 'unleash.enterprise.auth.oidc',
+    } as AuthProvider,
+
+    SAML: {
+        name: 'saml',
+        configId: 'unleash.enterprise.auth.saml',
+    } as AuthProvider,
+
+    Google: {
         name: 'google',
         configId: 'unleash.enterprise.auth.google',
         deprecatedRemovalTarget: 'v8.0.0',
-    },
-];
-
-export function getAuthConfigId(providerName: string): string {
-    const provider = AUTH_PROVIDERS_CATALOG.find(
-        (p) => p.name === providerName,
-    );
-    return provider?.configId ?? '';
-}
+    } as AuthProvider,
+} as const;

--- a/src/lib/util/metrics/createGauge.ts
+++ b/src/lib/util/metrics/createGauge.ts
@@ -16,7 +16,7 @@ export type Gauge<T extends string = string> = {
  */
 
 /**
- * One labelled sample produced by a `fetchSamples` collector.
+ * A labelled sample. used by `fetchSamples`
  */
 export type GaugeSample<T extends string> = {
     labels: Record<T, string | number>;

--- a/src/lib/util/metrics/createGauge.ts
+++ b/src/lib/util/metrics/createGauge.ts
@@ -14,17 +14,36 @@ export type Gauge<T extends string = string> = {
  * Additional options for createGauge that allow registering a lazy collect function
  * which caches values for a given TTL.
  */
+
+/**
+ * One labelled sample produced by a `fetchSamples` collector.
+ */
+export type GaugeSample<T extends string> = {
+    labels: Record<T, string | number>;
+    value: number;
+};
+
 export type CreateGaugeOptions<T extends string> = GaugeConfiguration<T> & {
     /**
-     * Time to live for cached values in milliseconds. Used together with `fetchValue`.
+     * Time to live for cached values in milliseconds. Used together with `fetchValue` or `fetchSamples`.
      */
     ttlMs?: number;
     /**
      * Optional fetcher used to populate the gauge value lazily on scrape.
      * If provided together with `ttlMs`, a `collect` function will be installed that
      * caches the value for the TTL. Return null to indicate unknown (we'll set NaN).
+     *
+     * Use this for single-value gauges. For labelled aggregates, use `fetchSamples`.
      */
     fetchValue?: () => Promise<number | null>;
+    /**
+     * Optional fetcher used to populate a full set of labelled samples on each scrape.
+     * Cached for `ttlMs`; the previous sample set is served if the fetch throws. It `.reset()` before each refresh.
+     *
+     * Use this for multiple series per scrape (e.g. one sample per integration × state combination).
+     * It's either this or `fetchValue`, they cannot be combined.
+     */
+    fetchSamples?: () => Promise<GaugeSample<T>[]>;
 };
 
 /**
@@ -37,8 +56,14 @@ export type CreateGaugeOptions<T extends string> = GaugeConfiguration<T> & {
 export const createGauge = <T extends string>(
     options: CreateGaugeOptions<T>,
 ): Gauge<T> => {
-    const { ttlMs, fetchValue, ...gaugeOptions } =
+    const { ttlMs, fetchValue, fetchSamples, ...gaugeOptions } =
         options as CreateGaugeOptions<T>;
+
+    if (fetchValue && fetchSamples) {
+        throw new Error(
+            'createGauge: pass either fetchValue (single value) or fetchSamples (labelled), not both',
+        );
+    }
 
     // If fetchValue is provided, attach a TTL-cached collect. We preserve any existing collect
     // by calling it afterwards.
@@ -80,6 +105,49 @@ export const createGauge = <T extends string>(
             }
 
             // Call any original collect afterwards, allowing additional instrumentation if present
+            if (typeof originalCollect === 'function') {
+                try {
+                    await originalCollect.call(this);
+                } catch {
+                    // ignore errors from original collect to avoid breaking the scrape
+                }
+            }
+        } as unknown as GaugeConfiguration<T>['collect'];
+    }
+
+    // Same as fetchValue but supports multiple series per Gauge.
+    if (fetchSamples && typeof fetchSamples === 'function') {
+        // If fetchSamples is provided, attach a TTL-cached collects
+        const ttl =
+            typeof ttlMs === 'number' && Number.isFinite(ttlMs) ? ttlMs : 0;
+        const last: { ts: number; samples: GaugeSample<T>[] } = {
+            ts: 0,
+            samples: [],
+        };
+        const originalCollect = (gaugeOptions as GaugeConfiguration<T>).collect;
+
+        (gaugeOptions as GaugeConfiguration<T>).collect = async function (
+            this: PromGauge<T>,
+        ) {
+            const now = Date.now();
+            const fresh =
+                ttl > 0 && now - last.ts < ttl && last.samples.length > 0;
+
+            if (!fresh) {
+                try {
+                    last.samples = await fetchSamples();
+                    last.ts = now;
+                } catch {
+                    // If nothing cached yet, skip this scrape silently.
+                    if (last.samples.length === 0) return;
+                }
+            }
+
+            this.reset();
+            for (const s of last.samples) {
+                this.labels(s.labels).set(s.value);
+            }
+
             if (typeof originalCollect === 'function') {
                 try {
                     await originalCollect.call(this);

--- a/src/lib/util/metrics/createGauge.ts
+++ b/src/lib/util/metrics/createGauge.ts
@@ -14,36 +14,17 @@ export type Gauge<T extends string = string> = {
  * Additional options for createGauge that allow registering a lazy collect function
  * which caches values for a given TTL.
  */
-
-/**
- * A labelled sample. used by `fetchSamples`
- */
-export type GaugeSample<T extends string> = {
-    labels: Record<T, string | number>;
-    value: number;
-};
-
 export type CreateGaugeOptions<T extends string> = GaugeConfiguration<T> & {
     /**
-     * Time to live for cached values in milliseconds. Used together with `fetchValue` or `fetchSamples`.
+     * Time to live for cached values in milliseconds. Used together with `fetchValue`.
      */
     ttlMs?: number;
     /**
      * Optional fetcher used to populate the gauge value lazily on scrape.
      * If provided together with `ttlMs`, a `collect` function will be installed that
      * caches the value for the TTL. Return null to indicate unknown (we'll set NaN).
-     *
-     * Use this for single-value gauges. For labelled aggregates, use `fetchSamples`.
      */
     fetchValue?: () => Promise<number | null>;
-    /**
-     * Optional fetcher used to populate a full set of labelled samples on each scrape.
-     * Cached for `ttlMs`; the previous sample set is served if the fetch throws. It `.reset()` before each refresh.
-     *
-     * Use this for multiple series per scrape (e.g. one sample per integration × state combination).
-     * It's either this or `fetchValue`, they cannot be combined.
-     */
-    fetchSamples?: () => Promise<GaugeSample<T>[]>;
 };
 
 /**
@@ -56,14 +37,8 @@ export type CreateGaugeOptions<T extends string> = GaugeConfiguration<T> & {
 export const createGauge = <T extends string>(
     options: CreateGaugeOptions<T>,
 ): Gauge<T> => {
-    const { ttlMs, fetchValue, fetchSamples, ...gaugeOptions } =
+    const { ttlMs, fetchValue, ...gaugeOptions } =
         options as CreateGaugeOptions<T>;
-
-    if (fetchValue && fetchSamples) {
-        throw new Error(
-            'createGauge: pass either fetchValue (single value) or fetchSamples (labelled), not both',
-        );
-    }
 
     // If fetchValue is provided, attach a TTL-cached collect. We preserve any existing collect
     // by calling it afterwards.
@@ -105,49 +80,6 @@ export const createGauge = <T extends string>(
             }
 
             // Call any original collect afterwards, allowing additional instrumentation if present
-            if (typeof originalCollect === 'function') {
-                try {
-                    await originalCollect.call(this);
-                } catch {
-                    // ignore errors from original collect to avoid breaking the scrape
-                }
-            }
-        } as unknown as GaugeConfiguration<T>['collect'];
-    }
-
-    // Same as fetchValue but supports multiple series per Gauge.
-    if (fetchSamples && typeof fetchSamples === 'function') {
-        // If fetchSamples is provided, attach a TTL-cached collects
-        const ttl =
-            typeof ttlMs === 'number' && Number.isFinite(ttlMs) ? ttlMs : 0;
-        const last: { ts: number; samples: GaugeSample<T>[] } = {
-            ts: 0,
-            samples: [],
-        };
-        const originalCollect = (gaugeOptions as GaugeConfiguration<T>).collect;
-
-        (gaugeOptions as GaugeConfiguration<T>).collect = async function (
-            this: PromGauge<T>,
-        ) {
-            const now = Date.now();
-            const fresh =
-                ttl > 0 && now - last.ts < ttl && last.samples.length > 0;
-
-            if (!fresh) {
-                try {
-                    last.samples = await fetchSamples();
-                    last.ts = now;
-                } catch {
-                    // If nothing cached yet, skip this scrape silently.
-                    if (last.samples.length === 0) return;
-                }
-            }
-
-            this.reset();
-            for (const s of last.samples) {
-                this.labels(s.labels).set(s.value);
-            }
-
             if (typeof originalCollect === 'function') {
                 try {
                     await originalCollect.call(this);


### PR DESCRIPTION
## ❔ Why
As first phase of [deprecation of Google Auth](https://linear.app/unleash/issue/EG-4389/remove-deprecated-google-auth-integration#comment-a2839212) integration towards v8, we first need to know how many users are still using it and decide if full deprecation is safe or to partially disable it for now.

To collect this evidence, [we checked the logs](https://platform.getunleash.io/grafana/explore?schemaVersion=1&panes=%7B%22m1h%22%3A%7B%22datasource%22%3A%224QZtDTP4z%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22sum%28increase%28http_request_duration_milliseconds_count%7Bpath%3D%7E%5C%22.*%2Fauth%2F.*%2Flogin%5C%22%7D%29%29+by%28path%29%22%2C%22range%22%3Atrue%2C%22datasource%22%3A%7B%22type%22%3A%22prometheus%22%2C%22uid%22%3A%224QZtDTP4z%22%7D%2C%22editorMode%22%3A%22code%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-30d%22%2C%22to%22%3A%22now%22%7D%7D%7D&orgId=1) for the callback url `/auth/*/login` but there was is no register for google login `/auth/google/login`.

Looked for generic /auth/*/login paths instead. When we exec:
```
sum by (path, method) (
  increase(http_request_duration_milliseconds_count{path=~"/auth/(oidc|saml|simple)/login|/auth/\\(hidden\\)"}[$__range])
)
```
we see many `/auth/(hidden)` paths. 
Grabbing only these ones:
```
sum(increase(http_request_duration_milliseconds_count{path="/auth/(hidden)"}[$__range])) by (status)
```
We don't get any `200`s . But we get: 80 `401`s, 2 `403`s and **4 `404`s.** 

Most likely  `/auth/google/*` is not mounted as a route. Looks like a label normalization - the `prom-client` express middleware might record route templates, not concrete URLs. The 4 × `404`s are users hitting `/auth/google/login` and the server has no idea what to do with it. _This_ missing bucket could be the count we're looking for.

We could make a fix to normalize the url properly but _still_ we won't receive the old metrics and lose information.

## 🔧 What we do here

As a more overall solution (_kudos to Gastón_), we add new metrics into prometheus to expose all available integrations, not just events
We need to answer the questions:
"How many users actually completed (or attempted) a Google sign-in?"
"Is the Google auth enabled in this Unleash's settings table right now?"


### Add counter of auth logins `auth_login_total`

Now the enterprise provider (_[on this PR](https://github.com/bricks-software/unleash-enterprise/pull/1098)_) emits a `AUTH_LOGIN_COMPLETED` event on `config.eventBus` on both `successfulLoginEvent` and `failedLoginEvent`:
```            
this.eventBus.emit(AUTH_LOGIN_COMPLETED, {
            provider: this.name.toLowerCase(),
            outcome: 'success',
        });
```            

Here, on OSS metrics, we add the new `AUTH_LOGIN_COMPLETED` metric-event and call the new `registerIntegrationMetrics(...) ` at startup, which binds the `AUTH_LOGIN_COMPLETED` eventBus listener to the counter.

``` 
eventBus.on(AUTH_LOGIN_COMPLETED, ...)  

integrationHandles.authLoginTotal  
          .inc({ provider, outcome })
``` 

this after a new successful hit to `/auth/google/login` will expose the metric:
``` 
auth_login_total{provider="google", outcome="success"} += 1
```

### List of configured integrations `integration_configured`

To identify the configured integrations, we read the setting store of the server of the `unleash.x.x.google` record (the key lies in enterprise side)
if row: undefined --> `not_configured`
if row.enabled --> `enabled`
if row.enabled! --> `disabled`
This way we can know how many integrations are configured and in which state right now. The emitted metric looks like:
```
 integration_configured{name="google", state="..."} <count>
```

Samely it works **for all addons** (Read new tests to check it out)

## 📊 How to use in Grafana

```
# Test if google auth is turned on
sum(integration_configured{name="google",state="enabled"})

# Find how many users still have it on
count(integration_configured{name="google",state="enabled"} > 0)

# How many successful Google logins in the last x days?
sum(increase(auth_login_total{provider="google",outcome="success"}[7d]))

# Test if there is a spike on failures (sign that gAuth got removed and users are still trying)
sum by (outcome) (rate(auth_login_total{provider="google"}[1h]))

# How many users migrated to OIDC the last 30d?
sum(increase(auth_login_total{provider=~"oidc|google",outcome="success"}[30d]))

# Are there any deprecated integration still enabled anywhere [join query -- useful to have `integration_deprecated_info`]
integration_configured{state="enabled"} * on(name)
    group_left(removal_target) integration_available{deprecated="true"}
```

## 🧪 How we tested

Check [Enterprise's PR](https://github.com/bricks-software/unleash-enterprise/pull/1098) section.


### ✍🏽  Notes

- 60-second TTL cache means integration_configured lags reality by up to a minute.


Thank youuu 🌹 