### PR TITLE
chore: add observability to GET /admin/projects

### DIFF
--- a/frontend/src/hooks/api/getters/useProjects/useProjects.ts
+++ b/frontend/src/hooks/api/getters/useProjects/useProjects.ts
@@ -32,10 +32,9 @@ const useProjects = (options: SWRConfiguration & GetProjectsParams = {}) => {
             method: 'GET',
         })
             .then(handleErrorResponses('Projects'))
-            .then((res) => res.json())
-            .then((data) => {
+            .then((res) => {
                 observe(performance.now() - start);
-                return data;
+                return res.json();
             });
     };
 

--- a/frontend/src/hooks/api/getters/useProjects/useProjects.ts
+++ b/frontend/src/hooks/api/getters/useProjects/useProjects.ts
@@ -5,6 +5,7 @@ import { formatApiPath } from 'utils/formatPath';
 import handleErrorResponses from '../httpErrorResponseHandler.js';
 import type { GetProjectsParams, ProjectSchema, ProjectsSchema } from 'openapi';
 import type { OnboardingStatusSchema } from 'openapi';
+import { useImpactMetricsHistogram } from 'hooks/useImpactMetrics';
 
 // TODO: `onboardingStatus` and `cleanupCount` are currently gated behind the 'newProjectList' flag
 // and not included on `projectSchema` (see openapi/spec/project-schema.ts).
@@ -18,13 +19,24 @@ export type ProjectListItem = ProjectSchema & {
 const useProjects = (options: SWRConfiguration & GetProjectsParams = {}) => {
     const KEY = `api/admin/projects${options.archived ? '?archived=true' : ''}`;
 
+    const { observe } = useImpactMetricsHistogram(
+        'project_list_load_ms',
+        'Client-side load time for the project list',
+        [50, 100, 200, 500, 1000, 2000, 5000],
+    );
+
     const fetcher = () => {
         const path = formatApiPath(KEY);
+        const start = performance.now();
         return fetch(path, {
             method: 'GET',
         })
             .then(handleErrorResponses('Projects'))
-            .then((res) => res.json());
+            .then((res) => res.json())
+            .then((data) => {
+                observe(performance.now() - start);
+                return data;
+            });
     };
 
     const { data, error } = useSWR<{ projects: ProjectsSchema['projects'] }>(

--- a/frontend/src/hooks/api/getters/useProjects/useProjects.ts
+++ b/frontend/src/hooks/api/getters/useProjects/useProjects.ts
@@ -19,6 +19,7 @@ export type ProjectListItem = ProjectSchema & {
 const useProjects = (options: SWRConfiguration & GetProjectsParams = {}) => {
     const KEY = `api/admin/projects${options.archived ? '?archived=true' : ''}`;
 
+    // TODO: remove when cleaning up 'newProjectList' flag
     const { observe } = useImpactMetricsHistogram(
         'project_list_load_ms',
         'Client-side load time for the project list',

--- a/frontend/src/hooks/useImpactMetrics.test.tsx
+++ b/frontend/src/hooks/useImpactMetrics.test.tsx
@@ -1,9 +1,13 @@
 import { expect, test } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
 import { UnleashClient, InMemoryStorageProvider } from 'unleash-proxy-client';
 import FlagProvider from '@unleash/proxy-client-react';
-import { useImpactMetricsCounter } from './useImpactMetrics';
+import {
+    useImpactMetricsCounter,
+    useImpactMetricsHistogram,
+} from './useImpactMetrics';
 import { testServerRoute, testServerSetup } from 'utils/testServer';
 
 const server = testServerSetup();
@@ -17,7 +21,20 @@ const TestCounterComponent = () => {
     );
 };
 
-test('defines counter and increments via real SDK', async () => {
+const TestHistogramComponent = () => {
+    const { observe } = useImpactMetricsHistogram(
+        'my_histogram',
+        'A histogram',
+        [50, 100, 200, 500],
+    );
+    return (
+        <button type='button' onClick={() => observe(100)}>
+            Observe
+        </button>
+    );
+};
+
+const setup = (ui: ReactNode) => {
     const { requests }: { requests: any[] } = testServerRoute(
         server,
         'http://localhost:12345//client/metrics',
@@ -37,9 +54,15 @@ test('defines counter and increments via real SDK', async () => {
 
     render(
         <FlagProvider unleashClient={client} startClient={false}>
-            <TestCounterComponent />
+            {ui}
         </FlagProvider>,
     );
+
+    return { client, requests };
+};
+
+test('defines counter and increments via real SDK', async () => {
+    const { client, requests } = setup(<TestCounterComponent />);
 
     const button = await screen.findByText('Increment');
     await userEvent.click(button);
@@ -53,6 +76,26 @@ test('defines counter and increments via real SDK', async () => {
                 name: 'my_counter',
                 type: 'counter',
                 samples: [{ value: 2 }],
+            },
+        ],
+    });
+});
+
+test('defines histogram and observes via real SDK', async () => {
+    const { client, requests } = setup(<TestHistogramComponent />);
+
+    const button = await screen.findByText('Observe');
+    await userEvent.click(button);
+    await userEvent.click(button);
+
+    await client.sendMetrics();
+
+    expect(requests[0]).toMatchObject({
+        impactMetrics: [
+            {
+                name: 'my_histogram',
+                type: 'histogram',
+                samples: [{ count: 2, sum: 200 }],
             },
         ],
     });

--- a/frontend/src/hooks/useImpactMetrics.ts
+++ b/frontend/src/hooks/useImpactMetrics.ts
@@ -17,3 +17,24 @@ export const useImpactMetricsCounter = (name: string, help: string) => {
 
     return { increment };
 };
+
+export const useImpactMetricsHistogram = (
+    name: string,
+    help: string,
+    buckets?: number[],
+) => {
+    const client = useUnleashClient();
+
+    useEffect(() => {
+        client?.impactMetrics?.defineHistogram(name, help, buckets);
+    }, [client, name, help, buckets]);
+
+    const observe = useCallback(
+        (value: number) => {
+            client?.impactMetrics?.observeHistogram(name, value);
+        },
+        [client, name],
+    );
+
+    return { observe };
+};

--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -261,6 +261,7 @@ export default class ProjectService {
 
         if (this.flagResolver.isEnabled('newProjectList')) {
             //TODO: update project-schema when removing this flag
+            const stopTimer = this.timer('newProjectListFields');
             const projectIds = projects.map((p) => p.id);
             const [onboardingStatuses, cleanupByProject] = await Promise.all([
                 this.onboardingReadModel
@@ -279,6 +280,8 @@ export default class ProjectService {
                     })
                     .catch(() => new Map<string, number>()),
             ]);
+
+            stopTimer();
 
             for (const project of projects) {
                 project.onboardingStatus = onboardingStatuses.get(project.id);


### PR DESCRIPTION
We added a couple of extra fetched to the projects service, so we want to add observability to be able to tell if those cause a degradation in performance. 
So this:

- Adds a `newProjectListFields` timer which measures the extra flag-gated fetches in the projects service.  Emits to the `functionDuration` Prometheus histogram (viewable in Grafana).
- Adds histograms (`useImpactMetricsHistogram` hook) to our frontend impact metrics.
- Adds a histogram to record client side load time for the project list GET, which we can then use to set a safeguard on the rollout.