### PR TITLE
chore: cosmetic improvements on the permissions overview ui

### DIFF
--- a/frontend/src/component/admin/users/AccessOverview/AccessOverviewAccordion/NewAccessOverviewAccordion.tsx
+++ b/frontend/src/component/admin/users/AccessOverview/AccessOverviewAccordion/NewAccessOverviewAccordion.tsx
@@ -94,7 +94,6 @@ export const NewAccessOverviewAccordion = ({
                         rootRole={rootRole}
                         roles={roles}
                         groups={groups}
-                        noScroll
                     />
                 )}
                 {children}

--- a/frontend/src/component/admin/users/AccessOverview/AccessOverviewAccordion/NewAccessOverviewList.tsx
+++ b/frontend/src/component/admin/users/AccessOverview/AccessOverviewAccordion/NewAccessOverviewList.tsx
@@ -106,13 +106,11 @@ export const NewAccessOverviewList = ({
     rootRole,
     roles,
     groups,
-    noScroll,
 }: {
     categories: IAccessOverviewPermissionCategory[];
     rootRole: IRole | undefined;
     roles: number[] | undefined;
     groups: IGroup[] | undefined;
-    noScroll?: boolean;
 }) => {
     const { searchQuery } = useSearchHighlightContext();
 
@@ -146,7 +144,6 @@ export const NewAccessOverviewList = ({
         </StyledList>
     );
 
-    if (noScroll) return list;
     return <Box sx={{ maxHeight: 500, overflow: 'auto' }}>{list}</Box>;
 };
 

--- a/frontend/src/component/admin/users/AccessOverview/AccessOverviewAccordion/RootAccessOverviewAccordion.tsx
+++ b/frontend/src/component/admin/users/AccessOverview/AccessOverviewAccordion/RootAccessOverviewAccordion.tsx
@@ -44,7 +44,6 @@ const StyledPersonIconWrapper = styled('div')(({ theme }) => ({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: theme.palette.info.light,
     borderRadius: theme.shape.borderRadius,
     padding: theme.spacing(0.25),
     color: theme.palette.info.main,

--- a/frontend/src/component/admin/users/AccessOverview/ProjectAccess/ProjectAccess.tsx
+++ b/frontend/src/component/admin/users/AccessOverview/ProjectAccess/ProjectAccess.tsx
@@ -1,11 +1,12 @@
 import { Badge } from 'component/common/Badge/Badge';
 import { NewAccessOverviewAccordion } from '../AccessOverviewAccordion/NewAccessOverviewAccordion.tsx';
-import FolderOutlined from '@mui/icons-material/FolderOutlined';
+import TopicOutlinedIcon from '@mui/icons-material/TopicOutlined';
 import { useMemo } from 'react';
 import { useUserAccessOverview } from 'hooks/api/getters/useUserAccessOverview/useUserAccessOverview';
 import { createProjectPermissionsStructure } from 'component/admin/roles/RoleForm/RolePermissionCategories/createProjectPermissionsStructure';
 import type { IAccessOverviewPermissionCategory } from '../AccessOverviewAccordion/AccessOverviewList.tsx';
 import { EnvironmentAccessTable } from './EnvironmentAccessTable.tsx';
+import { styled } from '@mui/material';
 
 export const filterCategory = (
     category: IAccessOverviewPermissionCategory,
@@ -20,6 +21,11 @@ export const filterCategory = (
         return { ...category, permissions: filteredPermissions };
     }
 };
+
+const StyledTopicOutlined = styled(TopicOutlinedIcon)(({ theme }) => ({
+    flexShrink: 0,
+    color: theme.palette.primary.main,
+}));
 
 export const ProjectAccess = ({
     id,
@@ -68,10 +74,7 @@ export const ProjectAccess = ({
         <NewAccessOverviewAccordion
             title={
                 <>
-                    <FolderOutlined
-                        fontSize='small'
-                        sx={{ flexShrink: 0, color: 'text.secondary' }}
-                    />
+                    <StyledTopicOutlined fontSize='small' />
                     <span>{projectName}</span>
                     {projectRoles?.map((role) => {
                         const isCustom = ![

--- a/frontend/src/component/admin/users/AccessOverview/ProjectAccess/ProjectAccessSection.tsx
+++ b/frontend/src/component/admin/users/AccessOverview/ProjectAccess/ProjectAccessSection.tsx
@@ -9,7 +9,7 @@ import {
     Typography,
     styled,
 } from '@mui/material';
-import { useCallback, useMemo, useState } from 'react';
+import { useState } from 'react';
 import { ProjectMenuItem } from './ProjectMenuItem';
 import { ProjectAccess } from './ProjectAccess';
 
@@ -55,32 +55,6 @@ export const ProjectAccessSection = ({
     const [selectedProjectIds, setSelectedProjectIds] = useState<string[]>([]);
     const [selectedEnvironments, setSelectedEnvironments] = useState<string[]>(
         [],
-    );
-    const [memberProjectIds, setMemberProjectIds] = useState<Set<string>>(
-        new Set(),
-    );
-
-    const handleAccessResolved = useCallback(
-        (projectId: string, isMember: boolean) => {
-            setMemberProjectIds((prev) => {
-                if (isMember === prev.has(projectId)) return prev;
-                const next = new Set(prev);
-                isMember ? next.add(projectId) : next.delete(projectId);
-                return next;
-            });
-        },
-        [],
-    );
-
-    const sortedProjects = useMemo(
-        () =>
-            [...projects].sort((a, b) => {
-                const aIsMember = memberProjectIds.has(a.id);
-                const bIsMember = memberProjectIds.has(b.id);
-                if (aIsMember !== bIsMember) return aIsMember ? -1 : 1;
-                return a.name.localeCompare(b.name);
-            }),
-        [projects, memberProjectIds],
     );
 
     const visibleProjects = projects.filter((p) =>
@@ -131,7 +105,7 @@ export const ProjectAccessSection = ({
                             sx: { '& .MuiPaper-root': { maxWidth: 200 } },
                         }}
                     >
-                        {sortedProjects.map((project) => (
+                        {projects.map((project) => (
                             <ProjectMenuItem
                                 key={project.id}
                                 id={id}
@@ -140,7 +114,6 @@ export const ProjectAccessSection = ({
                                 selected={selectedProjectIds.includes(
                                     project.id,
                                 )}
-                                onAccessResolved={handleAccessResolved}
                             />
                         ))}
                     </Select>

--- a/frontend/src/component/admin/users/AccessOverview/ProjectAccess/ProjectMenuItem.tsx
+++ b/frontend/src/component/admin/users/AccessOverview/ProjectAccess/ProjectMenuItem.tsx
@@ -1,30 +1,17 @@
-import { useUserAccessOverview } from 'hooks/api/getters/useUserAccessOverview/useUserAccessOverview';
 import type { ProjectSchema } from 'openapi';
-import { useEffect } from 'react';
 import { Checkbox, ListItemText, MenuItem } from '@mui/material';
 
 export const ProjectMenuItem = ({
     id,
     project,
     selected,
-    onAccessResolved,
     ...props
 }: {
     id: string;
     project: ProjectSchema;
     selected: boolean;
-    onAccessResolved: (projectId: string, isMember: boolean) => void;
     [key: string]: unknown;
 }) => {
-    const { projectRoles } = useUserAccessOverview(id, project.id);
-    const isMember = Boolean(projectRoles?.length);
-
-    useEffect(() => {
-        if (projectRoles !== undefined) {
-            onAccessResolved(project.id, isMember);
-        }
-    }, [project.id, projectRoles, isMember, onAccessResolved]);
-
     return (
         <MenuItem {...props} value={project.id}>
             <Checkbox checked={selected} size='small' />

--- a/frontend/src/component/admin/users/AccessOverview/RootRoleGroupAccess.tsx
+++ b/frontend/src/component/admin/users/AccessOverview/RootRoleGroupAccess.tsx
@@ -14,7 +14,7 @@ const StyledGroupRow = styled(Box)(({ theme }) => ({
     alignItems: 'center',
     gap: theme.spacing(2),
     padding: theme.spacing(1, 2),
-    border: `2px solid ${theme.palette.divider}`,
+    border: `1px solid ${theme.palette.divider}`,
     borderRadius: theme.shape.borderRadiusLarge,
 }));
 
@@ -53,9 +53,7 @@ export const RootRoleGroupAccess = ({ groups }: { groups: IGroup[] }) => {
 
     return (
         <Box>
-            <Typography variant='body1' sx={{ fontWeight: 'bold' }}>
-                Groups
-            </Typography>
+            <Typography variant='body1'>Groups</Typography>
             <Typography variant='body2' color='text.secondary'>
                 The group an user is a part of might affect the root access
             </Typography>


### PR DESCRIPTION
Fixes the differing scroll issue, removes background color from icon, groups header normal not bold. and 1px border on each. Corrects the icon for project access accordions. Removes a sorting feature that relied on A. being rendered (so post selection) and B. many network calls to work