### PR TITLE
chore: fix onboarding dialogs consistency

### DIFF
--- a/frontend/src/component/common/DialogWithAside/DialogWithAside.story.tsx
+++ b/frontend/src/component/common/DialogWithAside/DialogWithAside.story.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import type { Story, StoryMeta } from 'component/stories/types';
+import { DialogWithAside } from './DialogWithAside';
+
+export const meta: StoryMeta = {
+    title: 'Common/DialogWithAside',
+    background: 'application',
+};
+
+const PlaceholderAside = () => (
+    <Box sx={{ p: 3, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Typography variant='body2' sx={{ fontWeight: 'bold' }}>
+            Aside panel
+        </Typography>
+        <Typography variant='body2'>
+            This area is always 320 px wide and hidden below the md breakpoint.
+            The close button in the header handles dismissal on all screen
+            sizes.
+        </Typography>
+    </Box>
+);
+
+export const Default: Story = () => {
+    const [open, setOpen] = useState(true);
+    return (
+        <>
+            <Button variant='contained' onClick={() => setOpen(true)}>
+                Open dialog
+            </Button>
+            <DialogWithAside
+                open={open}
+                onClose={() => setOpen(false)}
+                title='Dialog title'
+                aside={<PlaceholderAside />}
+            >
+                <Box
+                    sx={{
+                        p: 3,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 2,
+                    }}
+                >
+                    <Typography variant='body1' sx={{ fontWeight: 'bold' }}>
+                        Main content
+                    </Typography>
+                    <Typography variant='body2'>
+                        Children are rendered in the scrollable left column.
+                    </Typography>
+                </Box>
+            </DialogWithAside>
+        </>
+    );
+};
+
+export const WithLongContent: Story = () => {
+    const [open, setOpen] = useState(false);
+    return (
+        <>
+            <Button variant='contained' onClick={() => setOpen(true)}>
+                Open dialog
+            </Button>
+            <DialogWithAside
+                open={open}
+                onClose={() => setOpen(false)}
+                title='Scrolling content'
+                aside={<PlaceholderAside />}
+            >
+                <Box
+                    sx={{
+                        p: 3,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 3,
+                    }}
+                >
+                    {Array.from({ length: 12 }, (_, i) => (
+                        <Box key={i}>
+                            <Typography
+                                variant='body2'
+                                sx={{ fontWeight: 'bold', mb: 0.5 }}
+                            >
+                                Section {i + 1}
+                            </Typography>
+                            <Typography variant='body2'>
+                                Content scrolls inside the left column while the
+                                aside and header stay fixed.
+                            </Typography>
+                        </Box>
+                    ))}
+                </Box>
+            </DialogWithAside>
+        </>
+    );
+};

--- a/frontend/src/component/common/DialogWithAside/DialogWithAside.tsx
+++ b/frontend/src/component/common/DialogWithAside/DialogWithAside.tsx
@@ -1,0 +1,143 @@
+import { Dialog, IconButton, styled } from '@mui/material';
+import type { Breakpoint } from '@mui/material/styles';
+import CloseIcon from '@mui/icons-material/Close';
+import type { ReactNode } from 'react';
+
+const ASIDE_WIDTH = 40; // theme.spacing units = 320px
+const ASIDE_BREAKPOINT: Breakpoint = 'md';
+
+const StyledDialog = styled(Dialog, {
+    shouldForwardProp: (prop) =>
+        prop !== 'dialogMaxWidth' && prop !== 'fullHeight',
+})<{ dialogMaxWidth?: number; fullHeight?: boolean }>(
+    ({ theme, dialogMaxWidth = 170, fullHeight }) => ({
+        '& .MuiDialog-paper': {
+            borderRadius: theme.shape.borderRadiusLarge,
+            maxWidth: theme.spacing(dialogMaxWidth),
+            width: '100%',
+            ...(fullHeight && { height: '100%' }),
+            overflow: 'hidden',
+            display: 'flex',
+            flexDirection: 'column',
+            backgroundColor: theme.palette.background.sidebar,
+        },
+    }),
+);
+
+const Header = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexShrink: 0,
+    borderBottom: `1px solid ${theme.palette.divider}`,
+}));
+
+const HeaderMain = styled('div')(({ theme }) => ({
+    flex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: theme.palette.background.paper,
+    paddingRight: theme.spacing(1.5),
+    '& .closeButton': {
+        [theme.breakpoints.up(ASIDE_BREAKPOINT)]: {
+            display: 'none',
+        },
+    },
+}));
+
+const HeaderTitle = styled('h2')(({ theme }) => ({
+    margin: 0,
+    padding: theme.spacing(1.5, 3),
+    fontWeight: theme.typography.fontWeightBold,
+    fontSize: theme.typography.body1.fontSize,
+    lineHeight: theme.spacing(2.75),
+}));
+
+const HeaderAside = styled('div')(({ theme }) => ({
+    width: theme.spacing(ASIDE_WIDTH),
+    flexShrink: 0,
+    backgroundColor: theme.palette.background.sidebar,
+    color: theme.palette.primary.contrastText,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    paddingRight: theme.spacing(1.5),
+    [theme.breakpoints.down(ASIDE_BREAKPOINT)]: {
+        display: 'none',
+    },
+}));
+
+const Body = styled('div')({
+    display: 'flex',
+    flex: 1,
+    overflow: 'hidden',
+});
+
+const Content = styled('div')(({ theme }) => ({
+    flex: 1,
+    overflowY: 'auto',
+    backgroundColor: theme.palette.background.paper,
+}));
+
+const Aside = styled('aside')(({ theme }) => ({
+    width: theme.spacing(ASIDE_WIDTH),
+    flexShrink: 0,
+    backgroundColor: theme.palette.background.sidebar,
+    color: theme.palette.primary.contrastText,
+    [theme.breakpoints.down(ASIDE_BREAKPOINT)]: {
+        display: 'none',
+    },
+}));
+
+interface DialogWithAsideProps {
+    open: boolean;
+    onClose: () => void;
+    title: string;
+    aside: ReactNode;
+    children: ReactNode;
+    maxWidth?: number;
+    fullHeight?: boolean;
+}
+
+export const DialogWithAside = ({
+    open,
+    onClose,
+    title,
+    aside,
+    children,
+    maxWidth,
+    fullHeight,
+}: DialogWithAsideProps) => (
+    <StyledDialog
+        open={open}
+        onClose={onClose}
+        maxWidth={false}
+        dialogMaxWidth={maxWidth}
+        fullHeight={fullHeight}
+    >
+        <Header>
+            <HeaderMain>
+                <HeaderTitle>{title}</HeaderTitle>
+                <IconButton
+                    size='small'
+                    className='closeButton'
+                    onClick={onClose}
+                >
+                    <CloseIcon />
+                </IconButton>
+            </HeaderMain>
+            <HeaderAside>
+                <IconButton
+                    size='small'
+                    onClick={onClose}
+                    sx={{ color: 'inherit' }}
+                >
+                    <CloseIcon />
+                </IconButton>
+            </HeaderAside>
+        </Header>
+        <Body>
+            <Content>{children}</Content>
+            <Aside>{aside}</Aside>
+        </Body>
+    </StyledDialog>
+);

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { render } from 'utils/testRenderer';
+import { testServerRoute, testServerSetup } from 'utils/testServer';
+import { ImplementFlagDialog } from './ImplementFlagDialog';
+
+const server = testServerSetup();
+
+const setupApi = (seenApplications: string[] = []) => {
+    testServerRoute(server, '/api/admin/projects/test-project/applications', {
+        applications: [],
+    });
+    testServerRoute(server, '/api/admin/client-metrics/features/test-flag', {
+        lastHourUsage: [],
+        seenApplications,
+    });
+};
+
+const defaultProps = {
+    onClose: vi.fn(),
+    projectId: 'test-project',
+    feature: 'test-flag',
+};
+
+describe('ImplementFlagDialog', () => {
+    it('does not render when closed', () => {
+        setupApi();
+        render(<ImplementFlagDialog {...defaultProps} open={false} />);
+
+        expect(
+            screen.queryByText('Use the flag in your code'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('renders the title when open', () => {
+        setupApi();
+        render(<ImplementFlagDialog {...defaultProps} open />);
+
+        expect(
+            screen.getByText('Use the flag in your code'),
+        ).toBeInTheDocument();
+    });
+
+    it('"Finish setup" is disabled before any evaluations', () => {
+        setupApi();
+        render(<ImplementFlagDialog {...defaultProps} open />);
+
+        expect(
+            screen.getByRole('button', { name: 'Finish setup' }),
+        ).toBeDisabled();
+    });
+
+    it('"Finish setup" is enabled after the first evaluation', async () => {
+        setupApi(['my-app']);
+        render(<ImplementFlagDialog {...defaultProps} open />);
+
+        await screen.findByText('Got the first evaluation!');
+        expect(
+            screen.getByRole('button', { name: 'Finish setup' }),
+        ).toBeEnabled();
+    });
+});

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -3,11 +3,8 @@ import {
     Box,
     Button,
     CircularProgress,
-    Dialog,
     styled,
     Typography,
-    useMediaQuery,
-    useTheme,
 } from '@mui/material';
 import CheckIcon from '@mui/icons-material/Check';
 import { allSdks, type SdkName } from 'component/onboarding/dialog/sharedTypes';
@@ -16,41 +13,7 @@ import { useProjectSdkNamesFromFirstApplicationsPage } from 'hooks/api/getters/u
 import { ImplementFlagInformation } from './ImplementFlagInformation.tsx';
 import { FlagUsageSnippet } from './FlagUsageSnippet.tsx';
 import { SelectSdk } from './SelectSdk.tsx';
-
-const StyledDialog = styled(Dialog)(({ theme }) => ({
-    '& .MuiDialog-paper': {
-        borderRadius: theme.shape.borderRadiusLarge,
-        maxWidth: theme.spacing(135),
-        width: '100%',
-        backgroundColor: 'transparent',
-    },
-    padding: 0,
-    '& .MuiPaper-root > section': {
-        overflowX: 'hidden',
-    },
-}));
-
-const Container = styled('section')({
-    width: '100%',
-    display: 'flex',
-});
-
-const Content = styled('main')(({ theme }) => ({
-    backgroundColor: theme.palette.background.paper,
-    display: 'flex',
-    flexDirection: 'column',
-    flexGrow: 1,
-    flexShrink: 1,
-    minWidth: 0,
-}));
-
-const Header = styled('div')(({ theme }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    padding: theme.spacing(1, 3),
-    borderBottom: `1px solid ${theme.palette.divider}`,
-    minHeight: theme.spacing(5),
-}));
+import { DialogWithAside } from 'component/common/DialogWithAside/DialogWithAside';
 
 const LoadingContainer = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -66,7 +29,6 @@ const Body = styled('div')(({ theme }) => ({
     flexDirection: 'column',
     gap: theme.spacing(3),
     flex: 1,
-    overflowY: 'auto',
 }));
 
 const Footer = styled('div')(({ theme }) => ({
@@ -74,24 +36,6 @@ const Footer = styled('div')(({ theme }) => ({
     alignItems: 'center',
     justifyContent: 'flex-end',
     gap: theme.spacing(2),
-    padding: theme.spacing(2, 3),
-}));
-
-const StatusIndicator = styled('div')(({ theme }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(0.5),
-}));
-
-const StatusDot = styled('span', {
-    shouldForwardProp: (prop) => prop !== 'connected',
-})<{ connected?: boolean }>(({ theme, connected }) => ({
-    width: 6,
-    height: 6,
-    borderRadius: '50%',
-    backgroundColor: connected
-        ? theme.palette.success.main
-        : theme.palette.warning.main,
 }));
 
 const ListeningCard = styled('div')(({ theme }) => ({
@@ -192,7 +136,13 @@ export const ImplementFlagDialog = ({
     projectId,
     feature,
 }: ImplementFlagDialogProps) => (
-    <StyledDialog open={open} onClose={onClose}>
+    <DialogWithAside
+        open={open}
+        onClose={onClose}
+        title='Use the flag in your code'
+        aside={<ImplementFlagInformation />}
+        maxWidth={135}
+    >
         {open && (
             <DialogBody
                 projectId={projectId}
@@ -200,7 +150,7 @@ export const ImplementFlagDialog = ({
                 onClose={onClose}
             />
         )}
-    </StyledDialog>
+    </DialogWithAside>
 );
 
 interface DialogBodyProps {
@@ -210,8 +160,6 @@ interface DialogBodyProps {
 }
 
 const DialogBody = ({ projectId, feature, onClose }: DialogBodyProps) => {
-    const theme = useTheme();
-    const isLargeScreen = useMediaQuery(theme.breakpoints.up('lg'));
     const { sdkNames: projectSdkNames, loading: loadingProjectSdks } =
         useProjectSdkNamesFromFirstApplicationsPage(projectId);
     const defaultSdkName = projectSdkNames[0] ?? allSdks[0].name;
@@ -226,84 +174,55 @@ const DialogBody = ({ projectId, feature, onClose }: DialogBodyProps) => {
     const evaluated = metrics.seenApplications.length > 0;
 
     return (
-        <Container>
-            <Content>
-                <Header>
-                    <Typography
-                        variant='body1'
-                        sx={{
-                            fontWeight: 'bold',
-                        }}
-                    >
-                        Use the flag in your code
-                    </Typography>
-                </Header>
-                <Body>
-                    {loadingProjectSdks ? (
-                        <LoadingContainer>
-                            <CircularProgress />
-                        </LoadingContainer>
-                    ) : (
-                        <>
-                            <SelectSdk
-                                projectSdks={projectSdkNames}
-                                value={sdkName}
-                                onChange={setSelectedSdkName}
-                            />
+        <Body>
+            {loadingProjectSdks ? (
+                <LoadingContainer>
+                    <CircularProgress />
+                </LoadingContainer>
+            ) : (
+                <>
+                    <SelectSdk
+                        projectSdks={projectSdkNames}
+                        value={sdkName}
+                        onChange={setSelectedSdkName}
+                    />
 
-                            <Box>
-                                <Typography
-                                    variant='body2'
-                                    sx={{
-                                        fontWeight: 'bold',
-                                        mb: 1,
-                                    }}
-                                >
-                                    Code example
-                                </Typography>
-                                <FlagUsageSnippet
-                                    sdkName={sdkName}
-                                    feature={feature}
-                                />
-                            </Box>
-
-                            <Box>
-                                <Typography
-                                    variant='body1'
-                                    sx={{
-                                        fontWeight: 'bold',
-                                        mb: 1,
-                                    }}
-                                >
-                                    Test flag
-                                </Typography>
-                                <ListeningStatus evaluated={evaluated} />
-                            </Box>
-                        </>
-                    )}
-                </Body>
-                <Footer>
-                    <StatusIndicator>
-                        <StatusDot connected={evaluated} />
+                    <Box>
                         <Typography
                             variant='body2'
-                            color={evaluated ? 'success.main' : 'warning.main'}
+                            sx={{
+                                fontWeight: 'bold',
+                                mb: 1,
+                            }}
                         >
-                            {evaluated
-                                ? 'Connected'
-                                : 'Waiting for evaluations'}
+                            Code example
                         </Typography>
-                    </StatusIndicator>
-                    <Button
-                        variant='contained'
-                        disabled={!evaluated}
-                        onClick={onClose}
-                    >
-                        Finish setup
-                    </Button>
-                </Footer>
-            </Content>
-            {isLargeScreen && <ImplementFlagInformation onClose={onClose} />}
-        </Container>
+                        <FlagUsageSnippet sdkName={sdkName} feature={feature} />
+                    </Box>
+
+                    <Box>
+                        <Typography
+                            variant='body1'
+                            sx={{
+                                fontWeight: 'bold',
+                                mb: 1,
+                            }}
+                        >
+                            Test flag
+                        </Typography>
+                        <ListeningStatus evaluated={evaluated} />
+                    </Box>
+                </>
+            )}
+            <Footer>
+                <Button
+                    variant='contained'
+                    disabled={!evaluated}
+                    onClick={onClose}
+                >
+                    Finish setup
+                </Button>
+            </Footer>
+        </Body>
     );
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagInformation.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagInformation.tsx
@@ -1,26 +1,12 @@
-import { IconButton, Link, styled, Typography } from '@mui/material';
-import CloseIcon from '@mui/icons-material/Close';
+import { Link, styled, Typography } from '@mui/material';
 import MenuBookIcon from '@mui/icons-material/MenuBook';
 import GitHubIcon from '@mui/icons-material/GitHub';
 
-const Container = styled('aside')(({ theme }) => ({
-    backgroundColor: theme.palette.background.sidebar,
-    color: theme.palette.primary.contrastText,
+const Container = styled('div')(({ theme }) => ({
     padding: theme.spacing(3, 4),
-    width: 320,
-    flexGrow: 0,
-    flexShrink: 0,
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(2),
-    position: 'relative',
-}));
-
-const CloseButton = styled(IconButton)(({ theme }) => ({
-    position: 'absolute',
-    top: theme.spacing(1),
-    right: theme.spacing(1),
-    color: theme.palette.primary.contrastText,
 }));
 
 const InlineLink = styled(Link)(({ theme }) => ({
@@ -48,24 +34,9 @@ const ResourceLink = styled(Link)(({ theme }) => ({
     },
 }));
 
-interface ImplementFlagInformationProps {
-    onClose: () => void;
-}
-
-export const ImplementFlagInformation = ({
-    onClose,
-}: ImplementFlagInformationProps) => (
+export const ImplementFlagInformation = () => (
     <Container>
-        <CloseButton onClick={onClose} size='small'>
-            <CloseIcon />
-        </CloseButton>
-        <Typography
-            variant='body2'
-            sx={{
-                fontWeight: 'bold',
-                mt: 4,
-            }}
-        >
+        <Typography variant='body2' sx={{ fontWeight: 'bold' }}>
             Define a safe default value
         </Typography>
         <Typography variant='body2'>

--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
@@ -15,6 +15,20 @@ const StyledDialogFooter = styled(Box)({
     justifyContent: 'flex-end',
 });
 
+const StyledContent = styled('div')(({ theme }) => ({
+    flex: 1,
+    padding: theme.spacing(3),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+}));
+
+const StyledAsideContent = styled('div')(({ theme }) => ({
+    padding: theme.spacing(3),
+    display: 'flex',
+    flexDirection: 'column',
+}));
+
 type Step = {
     title: string;
     content: React.ReactNode;
@@ -110,20 +124,12 @@ const InnerDialog = ({
             title='Connect SDK'
             fullHeight
             aside={
-                <Box sx={{ p: 3, display: 'flex', flexDirection: 'column' }}>
+                <StyledAsideContent>
                     <NewConnectSdkDialogAside />
-                </Box>
+                </StyledAsideContent>
             }
         >
-            <Box
-                sx={{
-                    flex: 1,
-                    p: 3,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 2,
-                }}
-            >
+            <StyledContent>
                 {steps.map(({ title, content, summary }, index) => {
                     const isCompleted = index < currentStep;
                     const isDisabled = index > currentStep;
@@ -154,7 +160,7 @@ const InnerDialog = ({
                         Finish setup
                     </Button>
                 </StyledDialogFooter>
-            </Box>
+            </StyledContent>
         </DialogWithAside>
     );
 };

--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/NewConnectSdkDialog.tsx
@@ -1,13 +1,4 @@
-import {
-    Box,
-    Button,
-    Dialog,
-    DialogContent,
-    IconButton,
-    styled,
-} from '@mui/material';
-import CloseIcon from '@mui/icons-material/Close';
-import { Truncator } from 'component/common/Truncator/Truncator.tsx';
+import { Box, Button, styled } from '@mui/material';
 import { NewConnectSdkDialogAside } from './NewConnectSdkDialogAside';
 import { useState } from 'react';
 import { ConnectSdkDialogStep } from './ConnectSdkDialogStep';
@@ -17,120 +8,12 @@ import { SelectSdkSummary } from './SelectSdk/SelectSdkSummary';
 import { GenerateApiKey } from './GenerateApiKey/GenerateApiKey';
 import { GenerateApiKeySummary } from './GenerateApiKey/GenerateApiKeySummary';
 import { ConfigureSdk } from './ConfigureSdk';
-
-const StyledDialog = styled(Dialog)(({ theme }) => ({
-    '& .MuiDialog-paper': {
-        borderRadius: theme.shape.borderRadiusLarge,
-        maxWidth: theme.spacing(170),
-        width: '100%',
-        height: '100%',
-        overflow: 'hidden',
-        display: 'flex',
-        flexDirection: 'column',
-        backgroundColor: theme.palette.background.sidebar,
-    },
-}));
-
-const StyledDialogHeader = styled(Box)(({ theme }) => ({
-    display: 'flex',
-    flexShrink: 0,
-    borderBottom: `1px solid ${theme.palette.divider}`,
-}));
-
-const StyledDialogHeaderMain = styled(Box)(({ theme }) => ({
-    flex: 1,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    backgroundColor: theme.palette.background.paper,
-    paddingRight: theme.spacing(1.5),
-    '& .closeButton': {
-        display: 'none',
-        [theme.breakpoints.down('md')]: {
-            display: 'flex',
-        },
-    },
-}));
-
-const StyledDialogHeaderTitle = styled('h2')(({ theme }) => ({
-    padding: theme.spacing(1.5, 3),
-    fontWeight: theme.typography.fontWeightBold,
-    fontSize: theme.typography.body1.fontSize,
-    lineHeight: theme.spacing(2.75),
-}));
-
-const StyledDialogHeaderAside = styled(Box)(({ theme }) => ({
-    width: theme.spacing(40),
-    flexShrink: 0,
-    backgroundColor: theme.palette.background.sidebar,
-    color: theme.palette.primary.contrastText,
-    '& svg': {
-        color: theme.palette.primary.contrastText,
-    },
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'end',
-    paddingRight: theme.spacing(1.5),
-    [theme.breakpoints.down('md')]: {
-        display: 'none',
-    },
-}));
-
-const StyledDialogBody = styled(Box)({
-    display: 'flex',
-    flex: 1,
-    overflow: 'hidden',
-});
-
-const StyledDialogContent = styled(DialogContent)(({ theme }) => ({
-    flex: 1,
-    padding: theme.spacing(3),
-    display: 'flex',
-    flexDirection: 'column',
-    overflowY: 'auto',
-    backgroundColor: theme.palette.background.paper,
-    gap: theme.spacing(2),
-}));
+import { DialogWithAside } from 'component/common/DialogWithAside/DialogWithAside';
 
 const StyledDialogFooter = styled(Box)({
     display: 'flex',
     justifyContent: 'flex-end',
 });
-
-const StyledDialogAside = styled('aside')(({ theme }) => ({
-    width: theme.spacing(40),
-    flexShrink: 0,
-    backgroundColor: theme.palette.background.sidebar,
-    color: theme.palette.primary.contrastText,
-    padding: theme.spacing(3),
-    display: 'flex',
-    flexDirection: 'column',
-    [theme.breakpoints.down('md')]: {
-        display: 'none',
-    },
-}));
-
-const DialogHeader = ({ onClose }: Pick<IConnectSDKDialogProps, 'onClose'>) => {
-    const CloseButton = () => (
-        <IconButton size='small' className='closeButton' onClick={onClose}>
-            <CloseIcon />
-        </IconButton>
-    );
-
-    return (
-        <StyledDialogHeader>
-            <StyledDialogHeaderMain>
-                <StyledDialogHeaderTitle>
-                    <Truncator>Connect SDK</Truncator>
-                </StyledDialogHeaderTitle>
-                <CloseButton />
-            </StyledDialogHeaderMain>
-            <StyledDialogHeaderAside>
-                <CloseButton />
-            </StyledDialogHeaderAside>
-        </StyledDialogHeader>
-    );
-};
 
 type Step = {
     title: string;
@@ -221,46 +104,58 @@ const InnerDialog = ({
     };
 
     return (
-        <StyledDialog open onClose={onClose}>
-            <DialogHeader onClose={onClose} />
-            <StyledDialogBody>
-                <StyledDialogContent>
-                    {steps.map(({ title, content, summary }, index) => {
-                        const isCompleted = index < currentStep;
-                        const isDisabled = index > currentStep;
-
-                        return (
-                            <ConnectSdkDialogStep
-                                key={title}
-                                stepNumber={index + 1}
-                                title={title}
-                                isExpanded={expandedStep === index}
-                                isCompleted={isCompleted}
-                                isDisabled={isDisabled}
-                                onExpand={() => handleStepExpand(index)}
-                                summary={isCompleted && summary}
-                            >
-                                {content}
-                            </ConnectSdkDialogStep>
-                        );
-                    })}
-                    <StyledDialogFooter>
-                        <Button
-                            variant='contained'
-                            disabled={!complete}
-                            onClick={
-                                complete ? () => onFinish(sdk.name) : undefined
-                            }
-                        >
-                            Finish setup
-                        </Button>
-                    </StyledDialogFooter>
-                </StyledDialogContent>
-                <StyledDialogAside>
+        <DialogWithAside
+            open
+            onClose={onClose}
+            title='Connect SDK'
+            fullHeight
+            aside={
+                <Box sx={{ p: 3, display: 'flex', flexDirection: 'column' }}>
                     <NewConnectSdkDialogAside />
-                </StyledDialogAside>
-            </StyledDialogBody>
-        </StyledDialog>
+                </Box>
+            }
+        >
+            <Box
+                sx={{
+                    flex: 1,
+                    p: 3,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 2,
+                }}
+            >
+                {steps.map(({ title, content, summary }, index) => {
+                    const isCompleted = index < currentStep;
+                    const isDisabled = index > currentStep;
+
+                    return (
+                        <ConnectSdkDialogStep
+                            key={title}
+                            stepNumber={index + 1}
+                            title={title}
+                            isExpanded={expandedStep === index}
+                            isCompleted={isCompleted}
+                            isDisabled={isDisabled}
+                            onExpand={() => handleStepExpand(index)}
+                            summary={isCompleted && summary}
+                        >
+                            {content}
+                        </ConnectSdkDialogStep>
+                    );
+                })}
+                <StyledDialogFooter>
+                    <Button
+                        variant='contained'
+                        disabled={!complete}
+                        onClick={
+                            complete ? () => onFinish(sdk.name) : undefined
+                        }
+                    >
+                        Finish setup
+                    </Button>
+                </StyledDialogFooter>
+            </Box>
+        </DialogWithAside>
     );
 };
 


### PR DESCRIPTION
1. Extract a component from ConnectSDK
2. Change the breakpoint to `md` as it seems to work better even in ConnectSDK
3. Use it in both dialogs
4. Fix small issues in ImplementFlagDialog.test.tsx
  * remove extra status element
  * footer is now in scroll area

<img width="1311" height="918" alt="Screenshot 2026-05-28 at 15 21 00" src="https://github.com/user-attachments/assets/e09af9eb-f144-4346-ad45-5df7c12c0187" />
<img width="1133" height="628" alt="Screenshot 2026-05-28 at 15 20 51" src="https://github.com/user-attachments/assets/e4c22314-272e-41b4-9ea6-28c9c04b2427" />

