### PR TITLE
show sdk image

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
@@ -71,9 +71,30 @@ export const SelectSdk = ({ value, onChange }: SelectSdkProps) => {
                     <StyledSdkName>{option.name}</StyledSdkName>
                 </StyledOptionRow>
             )}
-            renderInput={(params) => (
-                <TextField {...params} label='SDK' size='small' />
-            )}
+            renderInput={(params) => {
+                const selectedOption = options.find(
+                    (opt) => opt.name === value,
+                );
+                return (
+                    <TextField
+                        {...params}
+                        label='SDK'
+                        size='small'
+                        slotProps={{
+                            ...params.slotProps,
+                            input: {
+                                ...(params.slotProps?.input as object),
+                                startAdornment: selectedOption && (
+                                    <StyledSdkIcon
+                                        src={selectedOption.icon}
+                                        alt=''
+                                    />
+                                ),
+                            },
+                        }}
+                    />
+                );
+            }}
         />
     );
 };


### PR DESCRIPTION
Show image in the picker

It's looking a little off when you clear the input and want to pick something else but the "currently selected sdk" image is still shown 🤔 . 

<img width="676" height="619" alt="Screenshot 2026-05-29 at 16 11 45" src="https://github.com/user-attachments/assets/a49fb460-89cb-4489-b80e-8011e33e554d" />
<img width="855" height="664" alt="Screenshot 2026-05-29 at 16 11 35" src="https://github.com/user-attachments/assets/496c5272-9b56-4117-b4d2-7ac150ca2556" />
<img width="875" height="679" alt="Screenshot 2026-05-29 at 16 11 27" src="https://github.com/user-attachments/assets/574877f5-e1b6-4ce0-90eb-139bf5533d79" />
