### PR TITLE
refactor: move sdk ecaluation components into one file

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -6,7 +6,6 @@ import {
     styled,
     Typography,
 } from '@mui/material';
-import CheckIcon from '@mui/icons-material/Check';
 import type { SdkName } from 'component/onboarding/dialog/sharedTypes';
 import useFeatureMetrics from 'hooks/api/getters/useFeatureMetrics/useFeatureMetrics';
 import { useProjectSdkNamesFromFirstApplicationsPage } from 'hooks/api/getters/useProjectSdkNames/useProjectSdkNamesFromFirstApplicationsPage';
@@ -14,6 +13,7 @@ import { ImplementFlagInformation } from './ImplementFlagInformation.tsx';
 import { FlagUsageSnippet } from './FlagUsageSnippet.tsx';
 import { SelectSdk } from './SelectSdk.tsx';
 import { DialogWithAside } from 'component/common/DialogWithAside/DialogWithAside';
+import { ListeningStatus } from 'component/onboarding/dialog/SdkEvaluationStatus';
 
 const LoadingContainer = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -37,91 +37,6 @@ const Footer = styled('div')(({ theme }) => ({
     justifyContent: 'flex-end',
     gap: theme.spacing(2),
 }));
-
-const ListeningCard = styled('div')(({ theme }) => ({
-    backgroundColor: theme.palette.secondary.light,
-    border: `1px solid ${theme.palette.secondary.border}`,
-    borderRadius: theme.shape.borderRadiusMedium,
-    padding: theme.spacing(2),
-    display: 'flex',
-    gap: theme.spacing(1),
-    alignItems: 'center',
-}));
-
-const ListeningIcon = styled('div')(({ theme }) => ({
-    width: 44,
-    height: 44,
-    borderRadius: '50%',
-    backgroundColor: theme.palette.primary.main,
-    color: theme.palette.primary.contrastText,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexShrink: 0,
-    gap: 3,
-    '@keyframes bubble': {
-        '0%, 80%, 100%': {
-            transform: 'scale(0.4)',
-            opacity: 0.5,
-        },
-        '40%': {
-            transform: 'scale(1)',
-            opacity: 1,
-        },
-    },
-    '& span': {
-        width: 6,
-        height: 6,
-        borderRadius: '50%',
-        backgroundColor: theme.palette.primary.contrastText,
-        animation: 'bubble 1.4s infinite ease-in-out both',
-    },
-    '& span:nth-of-type(1)': {
-        animationDelay: '-0.32s',
-    },
-    '& span:nth-of-type(2)': {
-        animationDelay: '-0.16s',
-    },
-}));
-
-const ListeningText = styled('div')({
-    display: 'flex',
-    flexDirection: 'column',
-});
-
-const ListeningStatus = ({ evaluated }: { evaluated: boolean }) => (
-    <ListeningCard>
-        <ListeningIcon>
-            {evaluated ? (
-                <CheckIcon />
-            ) : (
-                <>
-                    <span />
-                    <span />
-                    <span />
-                </>
-            )}
-        </ListeningIcon>
-        <ListeningText>
-            <Typography
-                variant='body2'
-                color='primary'
-                sx={{
-                    fontWeight: 'bold',
-                }}
-            >
-                {evaluated
-                    ? 'Got the first evaluation!'
-                    : 'Listening for the first evaluation…'}
-            </Typography>
-            <Typography variant='caption' color='primary'>
-                {evaluated
-                    ? 'Your flag is wired up. Finish setup to close this dialog.'
-                    : 'Render the code path above anywhere to check that we receive metric evaluations.'}
-            </Typography>
-        </ListeningText>
-    </ListeningCard>
-);
 
 interface ImplementFlagDialogProps {
     open: boolean;

--- a/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/ConfigureSdk.tsx
+++ b/frontend/src/component/onboarding/dialog/NewConnectSdkDialog/ConfigureSdk.tsx
@@ -1,4 +1,4 @@
-import { Alert, alpha, styled, Typography } from '@mui/material';
+import { styled } from '@mui/material';
 import { Markdown } from 'component/common/Markdown/Markdown.tsx';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig.ts';
 import { CodeRenderer, codeRenderSnippets } from '../CodeRenderer.tsx';
@@ -6,66 +6,12 @@ import { buildSdkApiUrl } from '../buildSdkApiUrl.ts';
 import type { Sdk } from '../sharedTypes.ts';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview.ts';
 import { useEffect, useState } from 'react';
-import { PulsingAvatar } from 'component/common/PulsingAvatar/PulsingAvatar.tsx';
-import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import { SdkConnectionStatus } from 'component/onboarding/dialog/SdkEvaluationStatus';
 
 const StyledSpacedContainer = styled('div')(({ theme }) => ({
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(3),
-}));
-
-const StyledSdkConnectionAlert = styled('div')(({ theme }) => ({
-    display: 'flex',
-    flexDirection: 'row',
-    gap: theme.spacing(2),
-    padding: theme.spacing(2),
-    fontSize: theme.typography.body2.fontSize,
-    borderRadius: theme.shape.borderRadiusMedium,
-    backgroundColor: theme.palette.secondary.light,
-    border: `1px solid ${theme.palette.secondary.border}`,
-}));
-
-const StyledSdkConnectedAlert = styled(StyledSdkConnectionAlert)(
-    ({ theme }) => ({
-        backgroundColor: theme.palette.success.light,
-        border: `1px solid ${theme.palette.success.border}`,
-    }),
-);
-
-const StyledPulsingAvatar = styled(PulsingAvatar)(({ theme }) => ({
-    marginLeft: theme.spacing(1),
-    marginTop: theme.spacing(1),
-    width: theme.spacing(3),
-    height: theme.spacing(3),
-    '@keyframes pulse': {
-        '0%': {
-            boxShadow: `0 0 0 0px ${alpha(theme.palette.primary.main, 0.4)}`,
-        },
-        '100%': {
-            boxShadow: `0 0 0 16px ${alpha(theme.palette.primary.main, 0.0)}`,
-        },
-    },
-}));
-
-const StyledConnectedIcon = styled(CheckCircleIcon)(({ theme }) => ({
-    marginLeft: theme.spacing(1),
-    marginTop: theme.spacing(1),
-    width: theme.spacing(3),
-    height: theme.spacing(3),
-    color: theme.palette.success.main,
-}));
-
-const StyledTroubleshootingAlert = styled(Alert)(({ theme }) => ({
-    marginTop: theme.spacing(2),
-    padding: theme.spacing(2, 3),
-    '& .MuiAlert-message': {
-        padding: 0,
-    },
-    '& .MuiAlert-icon': {
-        marginRight: theme.spacing(1),
-    },
 }));
 
 interface IConfigureSdkProps {
@@ -129,43 +75,10 @@ export const ConfigureSdk = ({
                     {connectSnippet}
                 </Markdown>
             </div>
-            {sdkConnected ? (
-                <StyledSdkConnectedAlert>
-                    <div>
-                        <StyledConnectedIcon />
-                    </div>
-                    <div>
-                        <strong>
-                            We received metrics from your application
-                        </strong>
-                        <Typography variant='body2' color='textSecondary'>
-                            Your SDK is connected and evaluating flags.
-                        </Typography>
-                    </div>
-                </StyledSdkConnectedAlert>
-            ) : (
-                <StyledSdkConnectionAlert>
-                    <div>
-                        <StyledPulsingAvatar active>
-                            <MoreHorizIcon />
-                        </StyledPulsingAvatar>
-                    </div>
-                    <div>
-                        <strong>Waiting for SDK data...</strong>
-                        <Typography variant='body2' color='textSecondary'>
-                            Run your app and evaluate your flag. This step
-                            completes on its own.
-                        </Typography>
-                        {showTroubleshooting && (
-                            <StyledTroubleshootingAlert severity='warning'>
-                                Not seeing evaluations after ~30s? Make sure
-                                your app has started and that the client was
-                                initialized with the API key from step 2.
-                            </StyledTroubleshootingAlert>
-                        )}
-                    </div>
-                </StyledSdkConnectionAlert>
-            )}
+            <SdkConnectionStatus
+                sdkConnected={sdkConnected}
+                showTroubleshooting={showTroubleshooting}
+            />
         </StyledSpacedContainer>
     );
 };

--- a/frontend/src/component/onboarding/dialog/SdkEvaluationStatus.story.tsx
+++ b/frontend/src/component/onboarding/dialog/SdkEvaluationStatus.story.tsx
@@ -1,0 +1,56 @@
+import { styled, Typography } from '@mui/material';
+import type { Story, StoryMeta } from 'component/stories/types';
+import { ListeningStatus, SdkConnectionStatus } from './SdkEvaluationStatus';
+
+export const meta: StoryMeta = {
+    title: 'Onboarding/SdkEvaluationStatus',
+    background: 'paper',
+};
+
+const Container = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(4),
+    maxWidth: 600,
+}));
+
+const Section = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+}));
+
+export const Default: Story = () => (
+    <Container>
+        <Section>
+            <Typography variant='subtitle2'>
+                ListeningStatus — waiting
+            </Typography>
+            <ListeningStatus evaluated={false} />
+        </Section>
+        <Section>
+            <Typography variant='subtitle2'>
+                ListeningStatus — evaluated
+            </Typography>
+            <ListeningStatus evaluated={true} />
+        </Section>
+        <Section>
+            <Typography variant='subtitle2'>
+                SdkConnectionStatus — waiting
+            </Typography>
+            <SdkConnectionStatus sdkConnected={false} />
+        </Section>
+        <Section>
+            <Typography variant='subtitle2'>
+                SdkConnectionStatus — waiting with troubleshooting
+            </Typography>
+            <SdkConnectionStatus sdkConnected={false} showTroubleshooting />
+        </Section>
+        <Section>
+            <Typography variant='subtitle2'>
+                SdkConnectionStatus — connected
+            </Typography>
+            <SdkConnectionStatus sdkConnected={true} />
+        </Section>
+    </Container>
+);

--- a/frontend/src/component/onboarding/dialog/SdkEvaluationStatus.tsx
+++ b/frontend/src/component/onboarding/dialog/SdkEvaluationStatus.tsx
@@ -1,0 +1,192 @@
+import { Alert, alpha, styled, Typography } from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import { PulsingAvatar } from 'component/common/PulsingAvatar/PulsingAvatar.tsx';
+
+// --- ListeningStatus (used by ImplementFlagDialog) ---
+
+const ListeningCard = styled('div')(({ theme }) => ({
+    backgroundColor: theme.palette.secondary.light,
+    border: `1px solid ${theme.palette.secondary.border}`,
+    borderRadius: theme.shape.borderRadiusMedium,
+    padding: theme.spacing(2),
+    display: 'flex',
+    gap: theme.spacing(1),
+    alignItems: 'center',
+}));
+
+const ListeningIcon = styled('div')(({ theme }) => ({
+    width: 44,
+    height: 44,
+    borderRadius: '50%',
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    gap: 3,
+    '@keyframes bubble': {
+        '0%, 80%, 100%': {
+            transform: 'scale(0.4)',
+            opacity: 0.5,
+        },
+        '40%': {
+            transform: 'scale(1)',
+            opacity: 1,
+        },
+    },
+    '& span': {
+        width: 6,
+        height: 6,
+        borderRadius: '50%',
+        backgroundColor: theme.palette.primary.contrastText,
+        animation: 'bubble 1.4s infinite ease-in-out both',
+    },
+    '& span:nth-of-type(1)': {
+        animationDelay: '-0.32s',
+    },
+    '& span:nth-of-type(2)': {
+        animationDelay: '-0.16s',
+    },
+}));
+
+const ListeningText = styled('div')({
+    display: 'flex',
+    flexDirection: 'column',
+});
+
+export const ListeningStatus = ({ evaluated }: { evaluated: boolean }) => (
+    <ListeningCard>
+        <ListeningIcon>
+            {evaluated ? (
+                <CheckIcon />
+            ) : (
+                <>
+                    <span />
+                    <span />
+                    <span />
+                </>
+            )}
+        </ListeningIcon>
+        <ListeningText>
+            <Typography
+                variant='body2'
+                color='primary'
+                sx={{ fontWeight: 'bold' }}
+            >
+                {evaluated
+                    ? 'Got the first evaluation!'
+                    : 'Listening for the first evaluation…'}
+            </Typography>
+            <Typography variant='caption' color='primary'>
+                {evaluated
+                    ? 'Your flag is wired up. Finish setup to close this dialog.'
+                    : 'Render the code path above anywhere to check that we receive metric evaluations.'}
+            </Typography>
+        </ListeningText>
+    </ListeningCard>
+);
+
+// --- SdkConnectionStatus (used by ConfigureSdk) ---
+
+const ConnectionAlert = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'row',
+    gap: theme.spacing(2),
+    padding: theme.spacing(2),
+    fontSize: theme.typography.body2.fontSize,
+    borderRadius: theme.shape.borderRadiusMedium,
+    backgroundColor: theme.palette.secondary.light,
+    border: `1px solid ${theme.palette.secondary.border}`,
+}));
+
+const ConnectedAlert = styled(ConnectionAlert)(({ theme }) => ({
+    backgroundColor: theme.palette.success.light,
+    border: `1px solid ${theme.palette.success.border}`,
+}));
+
+const ConnectionPulsingAvatar = styled(PulsingAvatar)(({ theme }) => ({
+    marginLeft: theme.spacing(1),
+    marginTop: theme.spacing(1),
+    width: theme.spacing(3),
+    height: theme.spacing(3),
+    '@keyframes pulse': {
+        '0%': {
+            boxShadow: `0 0 0 0px ${alpha(theme.palette.primary.main, 0.4)}`,
+        },
+        '100%': {
+            boxShadow: `0 0 0 16px ${alpha(theme.palette.primary.main, 0.0)}`,
+        },
+    },
+}));
+
+const ConnectedIcon = styled(CheckCircleIcon)(({ theme }) => ({
+    marginLeft: theme.spacing(1),
+    marginTop: theme.spacing(1),
+    width: theme.spacing(3),
+    height: theme.spacing(3),
+    color: theme.palette.success.main,
+}));
+
+const TroubleshootingAlert = styled(Alert)(({ theme }) => ({
+    marginTop: theme.spacing(2),
+    padding: theme.spacing(2, 3),
+    '& .MuiAlert-message': {
+        padding: 0,
+    },
+    '& .MuiAlert-icon': {
+        marginRight: theme.spacing(1),
+    },
+}));
+
+interface SdkConnectionStatusProps {
+    sdkConnected: boolean;
+    showTroubleshooting?: boolean;
+}
+
+export const SdkConnectionStatus = ({
+    sdkConnected,
+    showTroubleshooting = false,
+}: SdkConnectionStatusProps) => {
+    if (sdkConnected) {
+        return (
+            <ConnectedAlert>
+                <div>
+                    <ConnectedIcon />
+                </div>
+                <div>
+                    <strong>We received metrics from your application</strong>
+                    <Typography variant='body2' color='textSecondary'>
+                        Your SDK is connected and evaluating flags.
+                    </Typography>
+                </div>
+            </ConnectedAlert>
+        );
+    }
+
+    return (
+        <ConnectionAlert>
+            <div>
+                <ConnectionPulsingAvatar active>
+                    <MoreHorizIcon />
+                </ConnectionPulsingAvatar>
+            </div>
+            <div>
+                <strong>Waiting for SDK data...</strong>
+                <Typography variant='body2' color='textSecondary'>
+                    Run your app and evaluate your flag. This step completes on
+                    its own.
+                </Typography>
+                {showTroubleshooting && (
+                    <TroubleshootingAlert severity='warning'>
+                        Not seeing evaluations after ~30s? Make sure your app
+                        has started and that the client was initialized with the
+                        API key from step 2.
+                    </TroubleshootingAlert>
+                )}
+            </div>
+        </ConnectionAlert>
+    );
+};


### PR DESCRIPTION
I want to align those components, but to make it easier to review the first step is just moving them to the same file. 

This should be backwards compatible and we should be able to merge it as is, but I can also continue making changes here if you prefer. 

<img width="926" height="919" alt="Screenshot 2026-06-01 at 10 06 17" src="https://github.com/user-attachments/assets/ca89c956-86b9-4074-8b74-a33947463d77" />
