### PR TITLE
test: use currently installed lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-pnpm dlx lint-staged
+pnpm exec lint-staged
 
 node .husky/update-openapi-spec-list.js
 


### PR DESCRIPTION
Trying to commit I got: 


> [ERR_PNPM_TRUST_DOWNGRADE] High-risk trust downgrade for "tinyexec@1.2.2" (possible package takeover)
> 
> This error happened while installing the dependencies of lint-staged@17.0.5
> 
> Trust checks are based solely on publish date, not semver. A package cannot be installed if any earlier-published version had stronger trust evidence. Earlier versions had trusted publisher, but this version has provenance attestation. A trust downgrade may indicate a supply chain incident.
> Progress: resolved 1, reused 0, downloaded 0, added 0
> husky - pre-commit script failed (code 1)



> pnpm dlx is meant for one-off tools you don't want to install. For anything in devDependencies, pnpm exec is correct — it's faster, deterministic, and keeps you within your audited dependency tree. This change should be committed alongside your original change.


https://stackoverflow.com/questions/73427676/what-is-difference-between-pnpm-create-pnpx-dlx