### PR TITLE
fix: column "name" of relation "milestone_strategies" does not exist

### DIFF
--- a/src/lib/features/release-plans/release-plan-milestone-strategy-store.ts
+++ b/src/lib/features/release-plans/release-plan-milestone-strategy-store.ts
@@ -135,7 +135,7 @@ export class ReleasePlanMilestoneStrategyStore
         return fromRow(row);
     }
 
-    private async updateStrategy(
+    async update(
         strategyId: string,
         { segments, ...strategy }: Partial<MilestoneStrategyConfigUpdate>,
     ): Promise<ReleasePlanMilestoneStrategy> {
@@ -150,7 +150,7 @@ export class ReleasePlanMilestoneStrategyStore
         strategyId: string,
         { segments, ...strategy }: Partial<MilestoneStrategyConfigUpdate>,
     ): Promise<ReleasePlanMilestoneStrategy> {
-        const releasePlanMilestoneStrategy = await this.updateStrategy(
+        const releasePlanMilestoneStrategy = await this.update(
             strategyId,
             strategy,
         );


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-590/fix-error-column-name-of-relation-milestone-strategies-does-not-exist

Fixes an error: column "name" of relation "milestone_strategies" does not exist.

`updateMilestoneStrategy` was calling the base `CRUDStore.update()` with the raw `strategyUpdate` object, which included a `name` field. However the `milestone_strategies` table has no `name` column.

The store already had a private `updateStrategy` method that used `toUpdateRow`, which only maps the actually updatable fields and correctly omits `name`, so we promoted that to a public `update()` override instead.