### PR TITLE
trust tinyexec trust policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,8 @@ allowBuilds:
   ssh2: true
 
 trustPolicy: no-downgrade
+trustPolicyExclude:
+  - 'tinyexec@1.2.2'
 
 # The minimum age of a release to be considered for dependency installation.
 # The value is in minutes (1440 minutes = 1 day).


### PR DESCRIPTION
this didn't help https://github.com/Unleash/unleash/pull/12143 

But, I'm not sure about the the package: https://github.com/tinylibs/tinyexec/releases 

there are some versions that were not published from Github actions: https://socket.dev/npm/package/tinyexec/versions/1.2.4

But, the diff looks ok: https://socket.dev/npm/package/tinyexec/diff/1.2.2 
