### PR TITLE
chore: include grep used in check-imports.rc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ ARG NODE_VERSION=22.22-alpine3.23
 
 FROM node:$NODE_VERSION AS builder
 
+RUN apk add --no-cache grep
+
 WORKDIR /unleash
 
 COPY . /unleash


### PR DESCRIPTION
## Summary

Install GNU grep in the Docker builder image to ensure frontend builds work consistently on Alpine-based images.

## Problem

The frontend build runs `frontend/check-imports.rc`, which relies on GNU grep options such as:

```sh
grep -R --include="*.js" ...
```

On Alpine, the default BusyBox implementation of `grep` does not support `--include`, causing Docker builds to fail when the frontend build is executed.

This issue was surfaced in the Docker publishing workflow when the frontend build was triggered inside the container.

## Solution

Install the `grep` package in the builder stage:

```dockerfile
RUN apk add --no-cache grep
```

This provides GNU grep and ensures compatibility with the existing frontend validation script.

## Impact

* Fixes Docker builds on Alpine-based images.
* Keeps the runtime image unchanged, as the package is only installed in the builder stage.
* No application behavior changes. Only affects the build environment.
