### PR TITLE
feat: add flightRecorderSdk to IFlagKey

### DIFF
--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -68,6 +68,7 @@ export type IFlagKey =
     | 'oidcPkceSupport'
     | 'remoteMcpServer'
     | 'flightRecorder'
+    | 'flightRecorderSdk'
     | 'regexConstraintOperator'
     | 'enterpriseEdgeTokensList'
     | 'impactMetricsFlagPage'

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -317,6 +317,10 @@ const flags: IFlags = {
         process.env.UNLEASH_EXPERIMENTAL_FLIGHT_RECORDER,
         false,
     ),
+    flightRecorderSdk: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_FLIGHT_RECORDER_SDK,
+        false,
+    ),
     regexConstraintOperator: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_REGEX_CONSTRAINT_OPERATOR,
         false,


### PR DESCRIPTION
## Summary

Adds `flightRecorderSdk` to `IFlagKey` and the experimental flags map, controlled by `UNLEASH_EXPERIMENTAL_FLIGHT_RECORDER_SDK`.

The flag gates whether the cloud control plane's flag resolver forwards impression events to the flight recorder ingestion API, enabling runtime toggling without a restart.
