### PR TITLE
chore: use one flag status component

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/ImplementFlagDialog.tsx
@@ -13,7 +13,7 @@ import { ImplementFlagInformation } from './ImplementFlagInformation.tsx';
 import { FlagUsageSnippet } from './FlagUsageSnippet.tsx';
 import { SelectSdk } from './SelectSdk.tsx';
 import { DialogWithAside } from 'component/common/DialogWithAside/DialogWithAside';
-import { ListeningStatus } from 'component/onboarding/dialog/SdkEvaluationStatus';
+import { SdkConnectionStatus } from 'component/onboarding/dialog/SdkEvaluationStatus';
 
 const LoadingContainer = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -121,7 +121,13 @@ const DialogBody = ({ projectId, feature, onClose }: DialogBodyProps) => {
                         >
                             Test flag
                         </Typography>
-                        <ListeningStatus evaluated={evaluated} />
+                        <SdkConnectionStatus
+                            sdkConnected={evaluated}
+                            connectedTitle='Got the first evaluation!'
+                            connectedBody='Your flag is wired up. Finish setup to close this dialog.'
+                            waitingTitle='Listening for the first evaluation…'
+                            waitingBody='Run your app and evaluate your flag.'
+                        />
                     </Box>
                 </>
             )}

--- a/frontend/src/component/onboarding/dialog/ConnectSdkDialog/ConfigureSdk.tsx
+++ b/frontend/src/component/onboarding/dialog/ConnectSdkDialog/ConfigureSdk.tsx
@@ -77,7 +77,12 @@ export const ConfigureSdk = ({
             </div>
             <SdkConnectionStatus
                 sdkConnected={sdkConnected}
+                connectedTitle='We received metrics from your application'
+                connectedBody='Your SDK is connected and evaluating flags.'
+                waitingTitle='Waiting for SDK data...'
+                waitingBody='Run your app and evaluate your flag. This step completes on its own.'
                 showTroubleshooting={showTroubleshooting}
+                troubleshootingText='Not seeing evaluations after ~30s? Make sure your app has started and that the client was initialized with the API key from step 2.'
             />
         </StyledSpacedContainer>
     );

--- a/frontend/src/component/onboarding/dialog/SdkEvaluationStatus.story.tsx
+++ b/frontend/src/component/onboarding/dialog/SdkEvaluationStatus.story.tsx
@@ -1,6 +1,6 @@
 import { styled, Typography } from '@mui/material';
 import type { Story, StoryMeta } from 'component/stories/types';
-import { ListeningStatus, SdkConnectionStatus } from './SdkEvaluationStatus';
+import { SdkConnectionStatus } from './SdkEvaluationStatus';
 
 export const meta: StoryMeta = {
     title: 'Onboarding/SdkEvaluationStatus',
@@ -20,37 +20,55 @@ const Section = styled('div')(({ theme }) => ({
     gap: theme.spacing(1),
 }));
 
+const configureProps = {
+    connectedTitle: 'We received metrics from your application',
+    connectedBody: 'Your SDK is connected and evaluating flags.',
+    waitingTitle: 'Waiting for SDK data...',
+    waitingBody:
+        'Run your app and evaluate your flag. This step completes on its own.',
+};
+
+const implementProps = {
+    connectedTitle: 'Got the first evaluation!',
+    connectedBody: 'Your flag is wired up. Finish setup to close this dialog.',
+    waitingTitle: 'Listening for the first evaluation…',
+    waitingBody: 'Run your app and evaluate your flag.',
+};
+
 export const Default: Story = () => (
     <Container>
         <Section>
-            <Typography variant='subtitle2'>
-                ListeningStatus — waiting
-            </Typography>
-            <ListeningStatus evaluated={false} />
+            <Typography variant='subtitle2'>ConfigureSdk — waiting</Typography>
+            <SdkConnectionStatus sdkConnected={false} {...configureProps} />
         </Section>
         <Section>
             <Typography variant='subtitle2'>
-                ListeningStatus — evaluated
+                ConfigureSdk — waiting with troubleshooting
             </Typography>
-            <ListeningStatus evaluated={true} />
+            <SdkConnectionStatus
+                sdkConnected={false}
+                showTroubleshooting
+                troubleshootingText='Not seeing evaluations after ~30s? Make sure your app has started and that the client was initialized with the API key from step 2.'
+                {...configureProps}
+            />
         </Section>
         <Section>
             <Typography variant='subtitle2'>
-                SdkConnectionStatus — waiting
+                ConfigureSdk — connected
             </Typography>
-            <SdkConnectionStatus sdkConnected={false} />
+            <SdkConnectionStatus sdkConnected={true} {...configureProps} />
         </Section>
         <Section>
             <Typography variant='subtitle2'>
-                SdkConnectionStatus — waiting with troubleshooting
+                ImplementFlagDialog — waiting
             </Typography>
-            <SdkConnectionStatus sdkConnected={false} showTroubleshooting />
+            <SdkConnectionStatus sdkConnected={false} {...implementProps} />
         </Section>
         <Section>
             <Typography variant='subtitle2'>
-                SdkConnectionStatus — connected
+                ImplementFlagDialog — evaluated
             </Typography>
-            <SdkConnectionStatus sdkConnected={true} />
+            <SdkConnectionStatus sdkConnected={true} {...implementProps} />
         </Section>
     </Container>
 );

--- a/frontend/src/component/onboarding/dialog/SdkEvaluationStatus.tsx
+++ b/frontend/src/component/onboarding/dialog/SdkEvaluationStatus.tsx
@@ -1,95 +1,7 @@
 import { Alert, alpha, styled, Typography } from '@mui/material';
-import CheckIcon from '@mui/icons-material/Check';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import { PulsingAvatar } from 'component/common/PulsingAvatar/PulsingAvatar.tsx';
-
-// --- ListeningStatus (used by ImplementFlagDialog) ---
-
-const ListeningCard = styled('div')(({ theme }) => ({
-    backgroundColor: theme.palette.secondary.light,
-    border: `1px solid ${theme.palette.secondary.border}`,
-    borderRadius: theme.shape.borderRadiusMedium,
-    padding: theme.spacing(2),
-    display: 'flex',
-    gap: theme.spacing(1),
-    alignItems: 'center',
-}));
-
-const ListeningIcon = styled('div')(({ theme }) => ({
-    width: 44,
-    height: 44,
-    borderRadius: '50%',
-    backgroundColor: theme.palette.primary.main,
-    color: theme.palette.primary.contrastText,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexShrink: 0,
-    gap: 3,
-    '@keyframes bubble': {
-        '0%, 80%, 100%': {
-            transform: 'scale(0.4)',
-            opacity: 0.5,
-        },
-        '40%': {
-            transform: 'scale(1)',
-            opacity: 1,
-        },
-    },
-    '& span': {
-        width: 6,
-        height: 6,
-        borderRadius: '50%',
-        backgroundColor: theme.palette.primary.contrastText,
-        animation: 'bubble 1.4s infinite ease-in-out both',
-    },
-    '& span:nth-of-type(1)': {
-        animationDelay: '-0.32s',
-    },
-    '& span:nth-of-type(2)': {
-        animationDelay: '-0.16s',
-    },
-}));
-
-const ListeningText = styled('div')({
-    display: 'flex',
-    flexDirection: 'column',
-});
-
-export const ListeningStatus = ({ evaluated }: { evaluated: boolean }) => (
-    <ListeningCard>
-        <ListeningIcon>
-            {evaluated ? (
-                <CheckIcon />
-            ) : (
-                <>
-                    <span />
-                    <span />
-                    <span />
-                </>
-            )}
-        </ListeningIcon>
-        <ListeningText>
-            <Typography
-                variant='body2'
-                color='primary'
-                sx={{ fontWeight: 'bold' }}
-            >
-                {evaluated
-                    ? 'Got the first evaluation!'
-                    : 'Listening for the first evaluation…'}
-            </Typography>
-            <Typography variant='caption' color='primary'>
-                {evaluated
-                    ? 'Your flag is wired up. Finish setup to close this dialog.'
-                    : 'Render the code path above anywhere to check that we receive metric evaluations.'}
-            </Typography>
-        </ListeningText>
-    </ListeningCard>
-);
-
-// --- SdkConnectionStatus (used by ConfigureSdk) ---
 
 const ConnectionAlert = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -141,14 +53,26 @@ const TroubleshootingAlert = styled(Alert)(({ theme }) => ({
     },
 }));
 
-interface SdkConnectionStatusProps {
+export type TroubleshootingProps =
+    | { showTroubleshooting: boolean; troubleshootingText: string }
+    | { showTroubleshooting?: never; troubleshootingText?: never };
+
+type SdkConnectionStatusProps = {
     sdkConnected: boolean;
-    showTroubleshooting?: boolean;
-}
+    connectedTitle: string;
+    connectedBody: string;
+    waitingTitle: string;
+    waitingBody: string;
+} & TroubleshootingProps;
 
 export const SdkConnectionStatus = ({
     sdkConnected,
-    showTroubleshooting = false,
+    connectedTitle,
+    connectedBody,
+    waitingTitle,
+    waitingBody,
+    showTroubleshooting,
+    troubleshootingText,
 }: SdkConnectionStatusProps) => {
     if (sdkConnected) {
         return (
@@ -157,9 +81,9 @@ export const SdkConnectionStatus = ({
                     <ConnectedIcon />
                 </div>
                 <div>
-                    <strong>We received metrics from your application</strong>
+                    <strong>{connectedTitle}</strong>
                     <Typography variant='body2' color='textSecondary'>
-                        Your SDK is connected and evaluating flags.
+                        {connectedBody}
                     </Typography>
                 </div>
             </ConnectedAlert>
@@ -174,16 +98,13 @@ export const SdkConnectionStatus = ({
                 </ConnectionPulsingAvatar>
             </div>
             <div>
-                <strong>Waiting for SDK data...</strong>
+                <strong>{waitingTitle}</strong>
                 <Typography variant='body2' color='textSecondary'>
-                    Run your app and evaluate your flag. This step completes on
-                    its own.
+                    {waitingBody}
                 </Typography>
                 {showTroubleshooting && (
                     <TroubleshootingAlert severity='warning'>
-                        Not seeing evaluations after ~30s? Make sure your app
-                        has started and that the client was initialized with the
-                        API key from step 2.
+                        {troubleshootingText}
                     </TroubleshootingAlert>
                 )}
             </div>


### PR DESCRIPTION

<img width="1116" height="636" alt="Screenshot 2026-06-01 at 15 19 13" src="https://github.com/user-attachments/assets/9ab459a6-a19d-4178-82d1-dda26e951fa1" />


And to see that it's consistent - but not sure if the story file as it is makes long term sense: 

<img width="730" height="840" alt="Screenshot 2026-06-01 at 15 18 20" src="https://github.com/user-attachments/assets/8fb4d66f-1a40-4f39-bf18-6dbd16fad618" />


