### PR TITLE
feat: add Sunset feature flag type

### DIFF
--- a/frontend/src/component/feature/FeatureToggleList/FeaturesOverviewLifecycleFilters/FeaturesOverviewToggleFilters.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeaturesOverviewLifecycleFilters/FeaturesOverviewToggleFilters.tsx
@@ -128,6 +128,7 @@ export const FeaturesOverviewToggleFilters: FC<
                     { label: 'Operational', value: 'operational' },
                     { label: 'Kill switch', value: 'kill-switch' },
                     { label: 'Permission', value: 'permission' },
+                    { label: 'Sunset', value: 'sunset' },
                 ],
                 filterKey: 'type',
                 singularOperators: ['IS', 'IS_NOT'],

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectOverviewFilters.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectOverviewFilters.tsx
@@ -117,6 +117,7 @@ export const ProjectOverviewFilters: FC<ProjectOverviewFiltersProps> = ({
                     { label: 'Operational', value: 'operational' },
                     { label: 'Kill switch', value: 'kill-switch' },
                     { label: 'Permission', value: 'permission' },
+                    { label: 'Sunset', value: 'sunset' },
                 ],
                 filterKey: 'type',
                 singularOperators: ['IS', 'IS_NOT'],

--- a/frontend/src/constants/featureToggleTypes.ts
+++ b/frontend/src/constants/featureToggleTypes.ts
@@ -3,3 +3,4 @@ export const RELEASE = 'release';
 export const OPERATIONAL = 'operational';
 export const KILLSWITCH = 'kill-switch';
 export const PERMISSION = 'permission';
+export const SUNSET = 'sunset';

--- a/frontend/src/openapi/models/createFeatureSchemaType.ts
+++ b/frontend/src/openapi/models/createFeatureSchemaType.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * The feature flag's [type](https://docs.getunleash.io/concepts/feature-flags#feature-flag-types). One of experiment, kill-switch, release, operational, or permission
+ * The feature flag's [type](https://docs.getunleash.io/concepts/feature-flags#feature-flag-types). One of experiment, kill-switch, release, operational, permission, or sunset
  */
 export type CreateFeatureSchemaType =
     (typeof CreateFeatureSchemaType)[keyof typeof CreateFeatureSchemaType];
@@ -17,4 +17,5 @@ export const CreateFeatureSchemaType = {
     release: 'release',
     operational: 'operational',
     permission: 'permission',
+    sunset: 'sunset',
 } as const;

--- a/frontend/src/openapi/models/updateFeatureSchemaType.ts
+++ b/frontend/src/openapi/models/updateFeatureSchemaType.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * Type of the flag e.g. experiment, kill-switch, release, operational, permission
+ * Type of the flag e.g. experiment, kill-switch, release, operational, permission, sunset
  */
 export type UpdateFeatureSchemaType =
     (typeof UpdateFeatureSchemaType)[keyof typeof UpdateFeatureSchemaType];
@@ -17,4 +17,5 @@ export const UpdateFeatureSchemaType = {
     release: 'release',
     operational: 'operational',
     permission: 'permission',
+    sunset: 'sunset',
 } as const;

--- a/frontend/src/utils/getFeatureTypeIcons.ts
+++ b/frontend/src/utils/getFeatureTypeIcons.ts
@@ -4,6 +4,7 @@ import {
     KILLSWITCH,
     OPERATIONAL,
     PERMISSION,
+    SUNSET,
 } from '../constants/featureToggleTypes.js';
 
 import LoopIcon from '@mui/icons-material/Loop';
@@ -11,6 +12,7 @@ import TimelineIcon from '@mui/icons-material/Timeline';
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
 import PanToolIcon from '@mui/icons-material/PanTool';
 import BuildIcon from '@mui/icons-material/Build';
+import TrendingDownIcon from '@mui/icons-material/TrendingDown';
 
 export const getFeatureTypeIcons = (type?: string) => {
     switch (type) {
@@ -24,6 +26,8 @@ export const getFeatureTypeIcons = (type?: string) => {
             return BuildIcon;
         case PERMISSION:
             return PanToolIcon;
+        case SUNSET:
+            return TrendingDownIcon;
         default:
             return LoopIcon;
     }

--- a/src/lib/openapi/spec/create-feature-schema.ts
+++ b/src/lib/openapi/spec/create-feature-schema.ts
@@ -19,10 +19,11 @@ export const createFeatureSchema = {
                 'release',
                 'operational',
                 'permission',
+                'sunset',
             ],
             example: 'release',
             description:
-                "The feature flag's [type](https://docs.getunleash.io/concepts/feature-flags#feature-flag-types). One of experiment, kill-switch, release, operational, or permission",
+                "The feature flag's [type](https://docs.getunleash.io/concepts/feature-flags#feature-flag-types). One of experiment, kill-switch, release, operational, permission, or sunset",
         },
         description: {
             type: 'string',

--- a/src/lib/openapi/spec/update-feature-schema.ts
+++ b/src/lib/openapi/spec/update-feature-schema.ts
@@ -19,10 +19,11 @@ export const updateFeatureSchema = {
                 'release',
                 'operational',
                 'permission',
+                'sunset',
             ],
             example: 'kill-switch',
             description:
-                'Type of the flag e.g. experiment, kill-switch, release, operational, permission',
+                'Type of the flag e.g. experiment, kill-switch, release, operational, permission, sunset',
         },
         stale: {
             type: 'boolean',

--- a/src/migrations/20260601105104-add-sunset-feature-type.js
+++ b/src/migrations/20260601105104-add-sunset-feature-type.js
@@ -1,0 +1,20 @@
+'use strict';
+
+exports.up = function (db, cb) {
+    db.runSql(
+        `
+        INSERT INTO feature_types(id, name, description, lifetime_days)
+        VALUES('sunset', 'Sunset', 'Used to gradually reduce exposure and remove a feature from the code.', 90);
+        `,
+        cb,
+    );
+};
+
+exports.down = function (db, cb) {
+    db.runSql(
+        `
+        DELETE FROM feature_types WHERE id = 'sunset';
+        `,
+        cb,
+    );
+};

--- a/src/test/arbitraries.test.ts
+++ b/src/test/arbitraries.test.ts
@@ -173,6 +173,7 @@ export const clientFeature = (name?: string): Arbitrary<ClientFeatureSchema> =>
                 'experiment',
                 'operational',
                 'permission',
+                'sunset',
             ),
             description: fc.lorem(),
             project: urlFriendlyString(),

--- a/src/test/e2e/api/admin/feature-type.test.ts
+++ b/src/test/e2e/api/admin/feature-type.test.ts
@@ -53,12 +53,25 @@ test('Should get all defined feature types', async () => {
         .expect((res) => {
             const { version, types } = res.body;
             expect(version).toBe(1);
-            expect(types.length).toBe(5);
+            expect(types.length).toBe(6);
             expect(types[0].name).toBe('Release');
             expect(
                 validateSchema(featureTypesSchema.$id, res.body),
             ).toBeUndefined();
         });
+});
+
+test('Sunset flag type exists with a 90 day default lifetime', async () => {
+    const { body } = await app.request
+        .get('/api/admin/feature-types')
+        .expect(200);
+
+    const sunset = body.types.find((type) => type.id === 'sunset');
+    expect(sunset).toMatchObject({
+        id: 'sunset',
+        name: 'Sunset',
+        lifetimeDays: 90,
+    });
 });
 
 describe('updating lifetimes', () => {

--- a/src/test/e2e/stores/feature-type-store.e2e.test.ts
+++ b/src/test/e2e/stores/feature-type-store.e2e.test.ts
@@ -17,9 +17,9 @@ afterAll(async () => {
     await db.destroy();
 });
 
-test('should have 5 default types', async () => {
+test('should have 6 default types', async () => {
     const types = await featureTypeStore.getAll();
-    expect(types.length).toBe(5);
+    expect(types.length).toBe(6);
     expect(types[0].name).toBe('Release');
 });
 
@@ -38,7 +38,7 @@ test('should be possible to delete by id', async () => {
     const deleteType = types.pop()!;
     await featureTypeStore.delete(deleteType.id);
     const typesAfterDelete = await featureTypeStore.getAll();
-    expect(typesAfterDelete.length).toBe(4);
+    expect(typesAfterDelete.length).toBe(5);
 });
 
 describe('update lifetimes', () => {


### PR DESCRIPTION
## About the changes
Adds a new "Sunset" feature flag type to help teams gradually reduce a feature's exposure and remove it from the codebase. It has a **default lifetime of 90 days**, after which flags of this type are marked potentially stale to prompt cleanup.

[Screencast from 2026-06-02 12-40-44.webm](https://github.com/user-attachments/assets/bd576004-3572-4e0e-a9d9-733cfc6c0515)

### Changes made
Backend:
- Migration seeds the `sunset` type into `feature_types` (90-day lifetime). The existing potentially-stale logic picks up the lifetime automatically, so no service changes are needed.
- Add `sunset` to the `type` enum in create/update feature request schemas; without this, creating a sunset flag failed OpenAPI validation ("must be equal to one of the allowed values").

Frontend:
- Add the `SUNSET` constant and map it to `TrendingDownIcon` in getFeatureTypeIcons.
- Add `sunset` to the generated create/update feature schema models to keep them in sync with the spec.

Tests:
- New e2e assertion verifying the Sunset type exists with a 90-day lifetime, plus updated flag-type count assertions and the property-based flag-type generator.

### Discussion points
90 days might not be the right lifetime for a sunset flag. In some cases it will probably need to stay around longer, and other times you might want to remove a feature more aggressivly. 