### PR TITLE
fix: modal improvements

### DIFF
--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/DropdownList.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/DropdownList.styles.tsx
@@ -1,5 +1,32 @@
 import { Checkbox, ListItem, styled } from '@mui/material';
 
+export const StyledHeader = styled('div')(({ theme }) => ({
+    paddingInline: theme.spacing(2),
+    paddingBottom: theme.spacing(1),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+}));
+
+export const StyledHeaderTitle = styled('p')(({ theme }) => ({
+    margin: 0,
+    fontWeight: theme.fontWeight.bold,
+    fontSize: theme.typography.body2.fontSize,
+}));
+
+export const StyledHeaderDescription = styled('p')(({ theme }) => ({
+    margin: 0,
+    color: theme.palette.text.secondary,
+    fontSize: theme.fontSizes.smallBody,
+}));
+
+export const StyledOptionDescription = styled('span')(({ theme }) => ({
+    display: 'block',
+    color: theme.palette.text.secondary,
+    fontSize: theme.fontSizes.smallBody,
+    whiteSpace: 'normal',
+}));
+
 export const StyledListItem = styled(ListItem)(({ theme }) => ({
     paddingLeft: theme.spacing(2),
     paddingBlock: theme.spacing(1),

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/DropdownList.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/DropdownList.tsx
@@ -2,7 +2,14 @@ import Search from '@mui/icons-material/Search';
 import { useRef, useState } from 'react';
 import { InputAdornment, List, ListItemText } from '@mui/material';
 import { StyledDropdownSearch } from './shared.styles';
-import { StyledCheckbox, StyledListItem } from './DropdownList.styles';
+import {
+    StyledCheckbox,
+    StyledHeader,
+    StyledHeaderDescription,
+    StyledHeaderTitle,
+    StyledListItem,
+    StyledOptionDescription,
+} from './DropdownList.styles';
 
 function useSelectionManagement<T>(handleToggle: (value: T) => () => void) {
     const listRefs = useRef<Array<HTMLInputElement | HTMLLIElement | null>>([]);
@@ -46,12 +53,13 @@ function useSelectionManagement<T>(handleToggle: (value: T) => () => void) {
 }
 
 export type DropdownListProps<T> = {
-    options: Array<{ label: string; value: T }>;
+    options: Array<{ label: string; value: T; description?: string }>;
     onChange: (value: T) => void;
     search: {
         label: string;
         placeholder: string;
     };
+    header?: { header: string; description: string };
     multiselect?: { selectedOptions: Set<T> };
 };
 
@@ -59,6 +67,7 @@ export function DropdownList<T = string>({
     options,
     onChange,
     search,
+    header,
     multiselect,
 }: DropdownListProps<T>) {
     const [searchText, setSearchText] = useState('');
@@ -77,6 +86,14 @@ export function DropdownList<T = string>({
 
     return (
         <>
+            {header ? (
+                <StyledHeader>
+                    <StyledHeaderTitle>{header.header}</StyledHeaderTitle>
+                    <StyledHeaderDescription>
+                        {header.description}
+                    </StyledHeaderDescription>
+                </StyledHeader>
+            ) : null}
             <StyledDropdownSearch
                 variant='outlined'
                 size='small'
@@ -143,7 +160,24 @@ export function DropdownList<T = string>({
                                     disableRipple
                                 />
                             ) : null}
-                            <ListItemText id={labelId} primary={option.label} />
+                            <ListItemText
+                                id={labelId}
+                                primary={option.label}
+                                title={option.label}
+                                secondary={
+                                    option.description ? (
+                                        <StyledOptionDescription>
+                                            {option.description}
+                                        </StyledOptionDescription>
+                                    ) : undefined
+                                }
+                                sx={{ minWidth: 0 }}
+                                slotProps={{
+                                    primary: {
+                                        noWrap: !option.description,
+                                    },
+                                }}
+                            />
                         </StyledListItem>
                     );
                 })}

--- a/frontend/src/component/common/DialogFormTemplate/ConfigButtons/shared.styles.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/ConfigButtons/shared.styles.tsx
@@ -23,6 +23,8 @@ export const StyledPopover = styled(Popover)(({ theme }) => ({
         flexDirection: 'column',
         gap: theme.spacing(1),
         maxHeight: '70vh',
+        width: theme.spacing(40),
+        maxWidth: '90vw',
     },
 }));
 

--- a/frontend/src/component/common/DialogFormTemplate/NewDialogFormTemplate.tsx
+++ b/frontend/src/component/common/DialogFormTemplate/NewDialogFormTemplate.tsx
@@ -18,8 +18,6 @@ import type { CreateFeatureNamingPatternSchema } from 'openapi';
 import { HeaderBreadcrumb } from './HeaderBreadcrumb.tsx';
 import { DropdownList } from './ConfigButtons/DropdownList.tsx';
 import { StyledPopover } from './ConfigButtons/shared.styles';
-import { StyledTooltipContent } from './ConfigButtons/ConfigButton.styles';
-import { TooltipResolver } from 'component/common/TooltipResolver/TooltipResolver';
 
 export type ProjectOption = { label: string; value: string };
 
@@ -117,41 +115,29 @@ export const PillButton = styled(Button)(({ theme }) => ({
     },
 }));
 
-type DropdownOption<T> = { label: string; value: T };
+type DropdownOption<T> = { label: string; value: T; description?: string };
 
 export type PillTooltip = { header: string; description: string };
 type Tooltip = PillTooltip;
 
 export const PillTrigger = ({
     label,
-    tooltip,
     onClick,
     buttonRef,
 }: {
     label: string;
-    tooltip: Tooltip;
     onClick: () => void;
     buttonRef: React.RefObject<HTMLButtonElement | null>;
 }) => (
-    <TooltipResolver
-        titleComponent={
-            <StyledTooltipContent>
-                <h3>{tooltip.header}</h3>
-                <p>{tooltip.description}</p>
-            </StyledTooltipContent>
-        }
-        variant='custom'
+    <PillButton
+        ref={buttonRef}
+        variant='outlined'
+        color='inherit'
+        onClick={onClick}
     >
-        <PillButton
-            ref={buttonRef}
-            variant='outlined'
-            color='inherit'
-            onClick={onClick}
-        >
-            <span>{label}</span>
-            <ArrowDropDownIcon />
-        </PillButton>
-    </TooltipResolver>
+        <span>{label}</span>
+        <ArrowDropDownIcon />
+    </PillButton>
 );
 
 type SinglePillProps<T> = {
@@ -177,7 +163,6 @@ export function SinglePillDropdown<T = string>({
         <>
             <PillTrigger
                 label={label}
-                tooltip={tooltip}
                 buttonRef={ref}
                 onClick={() => setAnchorEl(ref.current)}
             />
@@ -189,6 +174,7 @@ export function SinglePillDropdown<T = string>({
                 transformOrigin={{ vertical: 'top', horizontal: 'left' }}
             >
                 <DropdownList<T>
+                    header={tooltip}
                     options={options}
                     onChange={(value) => {
                         onChange(value);
@@ -235,7 +221,6 @@ export function MultiPillDropdown<T = string>({
         <>
             <PillTrigger
                 label={label}
-                tooltip={tooltip}
                 buttonRef={ref}
                 onClick={() => setAnchorEl(ref.current)}
             />
@@ -247,6 +232,7 @@ export function MultiPillDropdown<T = string>({
                 transformOrigin={{ vertical: 'top', horizontal: 'left' }}
             >
                 <DropdownList<T>
+                    header={tooltip}
                     options={options}
                     multiselect={{ selectedOptions }}
                     onChange={toggle}
@@ -343,7 +329,13 @@ export const NewDialogFormTemplate: React.FC<Props> = ({
             </Section>
 
             <Section
-                sx={{ display: 'flex', gap: 2, flexFlow: 'row wrap', pb: 3 }}
+                sx={{
+                    display: 'flex',
+                    gap: 2,
+                    flexFlow: 'row wrap',
+                    pt: 2,
+                    pb: 3,
+                }}
             >
                 {configButtons}
             </Section>

--- a/frontend/src/component/project/Project/CreateProject/CreateProjectForm/CreateProjectDialog.tsx
+++ b/frontend/src/component/project/Project/CreateProject/CreateProjectForm/CreateProjectDialog.tsx
@@ -131,9 +131,24 @@ const Section = styled(Box)(({ theme }) => ({
 }));
 
 const projectModeOptions = [
-    { value: 'open', label: 'open' },
-    { value: 'protected', label: 'protected' },
-    { value: 'private', label: 'private' },
+    {
+        value: 'open',
+        label: 'Open project',
+        description:
+            'Anyone can see the project and anyone can create change requests.',
+    },
+    {
+        value: 'protected',
+        label: 'Protected project',
+        description:
+            'Anyone can see the project, but only admins and project members can submit change requests.',
+    },
+    {
+        value: 'private',
+        label: 'Private project',
+        description:
+            'Hides the project from users with the "viewer" root role who are not members of the project. Only project members and admins can submit change requests.',
+    },
 ];
 
 const useProjectLimit = () => {
@@ -439,9 +454,7 @@ export const CreateProjectDialog: FC<Props> = ({ open, onClose }) => {
 
     const stickinessLabel = projectStickiness;
 
-    const projectModeLabel =
-        projectModeOptions.find((option) => option.value === projectMode)
-            ?.label ?? projectMode;
+    const projectModeLabel = projectMode;
 
     const sidebar: ReactNode = (
         <>
@@ -526,6 +539,7 @@ export const CreateProjectDialog: FC<Props> = ({ open, onClose }) => {
                             display: 'flex',
                             gap: 2,
                             flexFlow: 'row wrap',
+                            pt: 2,
                             pb: 3,
                         }}
                     >

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx
@@ -53,7 +53,7 @@ interface ICreateFeatureDialogProps {
 const StyledDialog = styled(Dialog)(({ theme }) => ({
     '& .MuiDialog-paper': {
         borderRadius: theme.shape.borderRadiusLarge,
-        maxWidth: theme.spacing(170),
+        maxWidth: theme.spacing(128),
         width: '100%',
         backgroundColor: 'transparent',
     },


### PR DESCRIPTION
<img width="1028" height="701" alt="Skjermbilde 2026-06-02 kl  10 07 14" src="https://github.com/user-attachments/assets/4cd099f4-98a7-4548-88f3-c7dfe084a5a8" />

- Make feature flag modal less wide
- Remove tooltips and add inline guidance in dropdowns
- Restrict project dropdown width