### PR TITLE
chore: move flag details sidebar from the left to the right

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
@@ -20,6 +20,7 @@ import { CleanupReminder } from '../CleanupReminder/CleanupReminder.tsx';
 import { useFeature } from '../../../../hooks/api/getters/useFeature/useFeature.ts';
 import { FeatureConnectSdkBanner } from './FeatureConnectSdkBanner.tsx';
 import { FeatureImplementFlagBanner } from './FeatureImplementFlagBanner.tsx';
+import { useMinimumUnleashVersion } from 'hooks/useMinimumUnleashVersion.ts';
 
 const StyledContainer = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -46,6 +47,7 @@ interface FeatureOverviewProps {
 }
 
 export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
+    const flipMainContentOrder = useMinimumUnleashVersion('8.0.0');
     const navigate = useNavigate();
     const projectId = useRequiredPathParam('projectId');
     const featureId = useRequiredPathParam('featureId');
@@ -82,6 +84,20 @@ export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
         <div>
             <CleanupReminder feature={feature} onChange={refetchFeature} />
             <StyledContainer>
+                {!flipMainContentOrder && (
+                    <div>
+                        {!loading ? (
+                            <FeatureOverviewMetaData
+                                hiddenEnvironments={hiddenEnvironments}
+                                onEnvironmentVisibilityChange={
+                                    onEnvironmentVisibilityChange
+                                }
+                                feature={feature}
+                                onChange={refetchFeature}
+                            />
+                        ) : null}
+                    </div>
+                )}
                 <StyledMainContent>
                     {!loading && (
                         <>
@@ -101,18 +117,20 @@ export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
                         hiddenEnvironments={hiddenEnvironments}
                     />
                 </StyledMainContent>
-                <div>
-                    {!loading ? (
-                        <FeatureOverviewMetaData
-                            hiddenEnvironments={hiddenEnvironments}
-                            onEnvironmentVisibilityChange={
-                                onEnvironmentVisibilityChange
-                            }
-                            feature={feature}
-                            onChange={refetchFeature}
-                        />
-                    ) : null}
-                </div>
+                {flipMainContentOrder && (
+                    <div>
+                        {!loading ? (
+                            <FeatureOverviewMetaData
+                                hiddenEnvironments={hiddenEnvironments}
+                                onEnvironmentVisibilityChange={
+                                    onEnvironmentVisibilityChange
+                                }
+                                feature={feature}
+                                onChange={refetchFeature}
+                            />
+                        ) : null}
+                    </div>
+                )}
                 <Routes>
                     <Route
                         path='strategies/create'

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
@@ -82,18 +82,6 @@ export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
         <div>
             <CleanupReminder feature={feature} onChange={refetchFeature} />
             <StyledContainer>
-                <div>
-                    {!loading ? (
-                        <FeatureOverviewMetaData
-                            hiddenEnvironments={hiddenEnvironments}
-                            onEnvironmentVisibilityChange={
-                                onEnvironmentVisibilityChange
-                            }
-                            feature={feature}
-                            onChange={refetchFeature}
-                        />
-                    ) : null}
-                </div>
                 <StyledMainContent>
                     {!loading && (
                         <>
@@ -113,6 +101,18 @@ export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
                         hiddenEnvironments={hiddenEnvironments}
                     />
                 </StyledMainContent>
+                <div>
+                    {!loading ? (
+                        <FeatureOverviewMetaData
+                            hiddenEnvironments={hiddenEnvironments}
+                            onEnvironmentVisibilityChange={
+                                onEnvironmentVisibilityChange
+                            }
+                            feature={feature}
+                            onChange={refetchFeature}
+                        />
+                    ) : null}
+                </div>
                 <Routes>
                     <Route
                         path='strategies/create'


### PR DESCRIPTION
Renders the flag environments to the left and the links + metadata section to the right.

The container is a flex container, so this should just continue to work.

Before:
<img width="1571" height="896" alt="image" src="https://github.com/user-attachments/assets/7bd8f419-222f-4c5a-81c3-3e601a7659b0" />


After:
<img width="1559" height="871" alt="image" src="https://github.com/user-attachments/assets/68540dd5-3dc5-4460-936d-41aa4c86dddd" />
