### PR TITLE
fix: invalid button nesting in segment accordion headers

### DIFF
--- a/frontend/src/component/common/SegmentItem/SegmentItem.tsx
+++ b/frontend/src/component/common/SegmentItem/SegmentItem.tsx
@@ -44,7 +44,7 @@ const StyledAccordionSummary = styled(AccordionSummary)(({ theme }) => ({
     ':focus-within': {
         backgroundColor: 'inherit',
     },
-}));
+})) as typeof AccordionSummary;
 
 const StyledAccordionDetails = styled(AccordionDetails)(({ theme }) => ({
     padding: theme.spacing(0.5, 3, 2.5),
@@ -120,6 +120,13 @@ export const SegmentItem: FC<SegmentItemProps> = ({
                     id={`segment-accordion-${segment.id}`}
                     tabIndex={-1}
                     aria-controls={segmentDetailsId}
+                    sx={{
+                        '&&&': {
+                            cursor: 'default',
+                        },
+                    }}
+                    component={'div'}
+                    role={'none'}
                 >
                     <StrategyEvaluationItem type='Segment'>
                         <StyledLink to={`/segments/edit/${segment.id}`}>


### PR DESCRIPTION
The segment accordion headers are intentionally made non-interactive, but they were still being rendered as buttons. This caused an error in the console because we also render our own button within. Buttons can not be descendants of buttons.

This PR changes the accordion headers to use a `div` instead of a `button` and explicitly gives it a `role="none"` and cursor as default.

No visual change (except for the cursor which I don't know how to screenshot), but you don't get this error in the console anymore:
<img width="1786" height="1131" alt="image" src="https://github.com/user-attachments/assets/72c93d61-5939-423c-b78e-54134e362f99" />
