### PR TITLE
feat: add a new useMinimumUnleashVersion hook

### DIFF
--- a/frontend/src/hooks/useMinimumUnleashVersion.test.ts
+++ b/frontend/src/hooks/useMinimumUnleashVersion.test.ts
@@ -1,0 +1,23 @@
+import { expect, it } from 'vitest';
+import { isVersionGreaterThanOrEqual } from './useMinimumUnleashVersion.ts';
+
+it('treats a bare major as the .0.0 release of that major', () => {
+    expect(isVersionGreaterThanOrEqual('8.0.0', '8')).toBe(true);
+    expect(isVersionGreaterThanOrEqual('8.4.2', '8')).toBe(true);
+    expect(isVersionGreaterThanOrEqual('7.6.5', '8')).toBe(false);
+});
+
+it('supports partial minimum versions down to the patch level', () => {
+    expect(isVersionGreaterThanOrEqual('8.2.0', '8.2')).toBe(true);
+    expect(isVersionGreaterThanOrEqual('8.1.0', '8.2')).toBe(false);
+    expect(isVersionGreaterThanOrEqual('8.2.1', '8.2.1')).toBe(true);
+});
+
+it('counts a pre-release as lower than its release', () => {
+    expect(isVersionGreaterThanOrEqual('8.0.0-beta.1', '8')).toBe(false);
+});
+
+it('returns false when either version is unparseable', () => {
+    expect(isVersionGreaterThanOrEqual('not-a-version', '8')).toBe(false);
+    expect(isVersionGreaterThanOrEqual('8.0.0', 'not-a-version')).toBe(false);
+});

--- a/frontend/src/hooks/useMinimumUnleashVersion.test.ts
+++ b/frontend/src/hooks/useMinimumUnleashVersion.test.ts
@@ -17,6 +17,15 @@ it('counts a pre-release as lower than its release', () => {
     expect(isVersionGreaterThanOrEqual('8.0.0-beta.1', '8')).toBe(false);
 });
 
+it('supports pre-release minimum versions when fully specified', () => {
+    expect(isVersionGreaterThanOrEqual('8.0.0-beta.2', '8.0.0-beta.1')).toBe(
+        true,
+    );
+    expect(isVersionGreaterThanOrEqual('8.0.0-beta.1', '8.0.0-beta.2')).toBe(
+        false,
+    );
+    expect(isVersionGreaterThanOrEqual('8.0.0', '8.0.0-beta.2')).toBe(true);
+});
 it('returns false when either version is unparseable', () => {
     expect(isVersionGreaterThanOrEqual('not-a-version', '8')).toBe(false);
     expect(isVersionGreaterThanOrEqual('8.0.0', 'not-a-version')).toBe(false);

--- a/frontend/src/hooks/useMinimumUnleashVersion.ts
+++ b/frontend/src/hooks/useMinimumUnleashVersion.ts
@@ -3,15 +3,25 @@ import semverCoerce from 'semver/functions/coerce';
 import semverValid from 'semver/functions/valid';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 
+const validOrCoerced = (version: string): string | undefined => {
+    return (
+        semverValid(version) ??
+        semverCoerce(version, { includePrerelease: true })?.version
+    );
+};
+
 export const isVersionGreaterThanOrEqual = (
     currentVersion: string,
     minimumVersion: string,
 ): boolean => {
-    const minimum = semverCoerce(minimumVersion);
-    if (!minimum || !semverValid(currentVersion)) {
-        return false;
+    const minimum = validOrCoerced(minimumVersion);
+    const current = validOrCoerced(currentVersion);
+
+    if (minimum && current) {
+        return semverGte(current, minimum);
     }
-    return semverGte(currentVersion, minimum.version);
+
+    return false;
 };
 
 export const useMinimumUnleashVersion = (minimumVersion: string): boolean => {

--- a/frontend/src/hooks/useMinimumUnleashVersion.ts
+++ b/frontend/src/hooks/useMinimumUnleashVersion.ts
@@ -17,11 +17,11 @@ export const isVersionGreaterThanOrEqual = (
     const minimum = validOrCoerced(minimumVersion);
     const current = validOrCoerced(currentVersion);
 
-    if (minimum && current) {
-        return semverGte(current, minimum);
+    if (!minimum || !current) {
+        return false;
     }
 
-    return false;
+    return semverGte(current, minimum);
 };
 
 export const useMinimumUnleashVersion = (minimumVersion: string): boolean => {

--- a/frontend/src/hooks/useMinimumUnleashVersion.ts
+++ b/frontend/src/hooks/useMinimumUnleashVersion.ts
@@ -1,0 +1,20 @@
+import semverGte from 'semver/functions/gte';
+import semverCoerce from 'semver/functions/coerce';
+import semverValid from 'semver/functions/valid';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+
+export const isVersionGreaterThanOrEqual = (
+    currentVersion: string,
+    minimumVersion: string,
+): boolean => {
+    const minimum = semverCoerce(minimumVersion);
+    if (!minimum || !semverValid(currentVersion)) {
+        return false;
+    }
+    return semverGte(currentVersion, minimum.version);
+};
+
+export const useMinimumUnleashVersion = (minimumVersion: string): boolean => {
+    const { uiConfig } = useUiConfig();
+    return isVersionGreaterThanOrEqual(uiConfig.version, minimumVersion);
+};


### PR DESCRIPTION
The hook compares the provided version against the current Unleash version (as judged from the `version` field in the UI config).

The hook allows partial semver version strings via semver coercion (using the built-in coercion function in the library).

This is useful for gating parts of the UI until specific Unleash versions without depending on external feature flags (e.g. it'll work in oss and self-hosted enterprise deployments too).