### PR TITLE
feat: impact-views foundation (flag + route + stub)

### DIFF
--- a/frontend/src/component/impact-views/ImpactViewsPage.tsx
+++ b/frontend/src/component/impact-views/ImpactViewsPage.tsx
@@ -1,0 +1,39 @@
+import type { FC } from 'react';
+import { Typography, styled } from '@mui/material';
+import { PageContent } from 'component/common/PageContent/PageContent';
+import { PageHeader } from 'component/common/PageHeader/PageHeader';
+
+const StyledWrapper = styled('div')(({ theme }) => ({
+    paddingTop: theme.spacing(2),
+}));
+
+const StyledContent = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    padding: theme.spacing(6, 4),
+    textAlign: 'center',
+}));
+
+/**
+ * Stub page for the Impact Views feature. The full implementation (view
+ * switcher, goal-tracking / system-health charts, editor) is introduced in
+ * later PRs — see ./README.md for the rollout plan. Gated behind the
+ * `impactViews` flag via the `/impact-views` route.
+ */
+export const ImpactViewsPage: FC = () => (
+    <StyledWrapper>
+        <PageContent header={<PageHeader title='Impact views' />}>
+            <StyledContent>
+                <Typography variant='h3' component='h2' sx={{ mb: 1.5 }}>
+                    Impact views are on the way
+                </Typography>
+                <Typography sx={{ color: 'text.secondary', maxWidth: 480 }}>
+                    Follow a set of features and their impact metrics together
+                    on a single chart. This experimental feature is still being
+                    put together.
+                </Typography>
+            </StyledContent>
+        </PageContent>
+    </StyledWrapper>
+);

--- a/frontend/src/component/impact-views/LazyImpactViewsPage.tsx
+++ b/frontend/src/component/impact-views/LazyImpactViewsPage.tsx
@@ -1,0 +1,7 @@
+import { lazy } from 'react';
+
+export const LazyImpactViewsPage = lazy(() =>
+    import('./ImpactViewsPage.tsx').then((module) => ({
+        default: module.ImpactViewsPage,
+    })),
+);

--- a/frontend/src/component/impact-views/README.md
+++ b/frontend/src/component/impact-views/README.md
@@ -1,0 +1,66 @@
+# Impact Views (experimental)
+
+Impact views let a user follow a set of feature flags and their impact metrics
+together on a single chart — goal-tracking and system-health templates, a
+"top flag movers" panel, a flag-impact dialog, and a view editor.
+
+This feature is **experimental and intentionally not production-hardened**:
+
+- **Storage is browser `localStorage`** — there is no backend persistence, no
+  new database tables, and no new API endpoints. The getters used here hit
+  existing endpoints only (e.g. `api/admin/search/events`).
+- It is **gated behind the `impactViews` feature flag** and served from the
+  self-contained `/impact-views` route.
+- Everything is **co-located under this directory** so the feature can be
+  removed cleanly (see "Deletion contract" below).
+
+## Layout
+
+```
+component/impact-views/
+  README.md                  # this file (rollout plan + context)
+  ImpactViewsPage.tsx        # page shell / container (currently a stub)
+  LazyImpactViewsPage.tsx    # lazy wrapper used by the route
+  hooks/                     # NEW co-located getter hooks + chart card (PR 3)
+  views/                     # view components & utilities (PR 2+)
+```
+
+**Reused from `main` (imported, not copied):** the `MultimetricChart` suite
+(`chartConfig`, `types`, `FeatureEventOverlay/eventTheme`, `MultimetricTotals`),
+`metricsFormatters`, `useFeatureEnvironmentEvents`, `useImpactMetricsMetadata`
+(`useImpactMetricsOptions`), `useEnvironments`, `useFeatureSearch`,
+`useLocalStorageState`, `createUuid`, `PageHeader`, `PageContent`, `LineChart`,
+`FeatureLifecycleStageIcon`.
+
+## Rollout plan (small, independently-mergeable PRs)
+
+Source of the view files: the `feat/exp-views` branch under
+`frontend/src/component/impact-metrics/views/`. Extract file contents (not
+commits — the branch carries unrelated churn) and adjust import paths to the
+co-located locations.
+
+| PR | Contents |
+|----|----------|
+| **1 (this PR)** | `impactViews` flag (backend `experimental.ts` + frontend `UiFlags`), `/impact-views` route, gated nav item, stub page + this README. |
+| **2** | Types & pure utilities: `views/types.ts`, `flagImpactFormatting`, `normalizeSeriesToBaseline(+test)`, `computeGoalSummary(+test)`, `computeFlagEventImpact(+test)`, `simulateFlagContribution`. |
+| **3** | New co-located getters + chart card: `hooks/useEnvironmentEvents`, `hooks/useGroupedImpactMetricsData` + `sumSeriesByTimestamp(+test)`, `hooks/MultimetricChartCard`. |
+| **4** | View-local hooks: `views/useImpactMetricViews(+test)` (the localStorage CRUD core), `useAutoFollowedFeatureNames`, `useMergedFeatureEvents`. |
+| **5** | Simple UI: `FeaturePicker`, `ImpactMetricViewsEmptyState`, `FollowedFeaturesStrip`, `TemplatePickerDialog`, `ViewSwitcher`. |
+| **6** | Data-display panels: `GoalSummaryPanel`, `TopFlagMoversPanel(+test)`, `FlagImpactDialog(+test)`, `FollowedFeaturesList` (split if too large). |
+| **7** | Chart views: `ViewChart`, `GoalTrackingViewChart`, `SystemHealthViewChart`. |
+| **8** | Editor + wire live: `ViewEditorDialog` (split if needed), and replace this stub `ImpactViewsPage` with the full container driven by `useImpactMetricViews`. |
+
+## Flag wiring
+
+- Backend: `impactViews` in `src/lib/types/experimental.ts`
+  (env var `UNLEASH_EXPERIMENTAL_IMPACT_VIEWS`, default `false`).
+- Frontend: `impactViews` in `frontend/src/interfaces/uiConfig.ts` (`UiFlags`).
+- Route: `/impact-views` in `frontend/src/component/menu/routes.ts` (`flag: 'impactViews'`).
+- Nav: gated `PrimaryListItem` in
+  `frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationList.tsx`.
+
+## Deletion contract
+
+Removing the feature is: delete this `component/impact-views/` directory, the one
+`/impact-views` entry in `routes.ts`, the gated nav line in `NavigationList.tsx`,
+and the two `impactViews` flag declarations (backend + frontend).

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationList.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationList.tsx
@@ -75,6 +75,7 @@ export const PrimaryNavigationList: FC<{
 
     const { isOss, isEnterprise } = useUiConfig();
     const impactMetricsEnabled = useUiFlag('impactMetrics');
+    const impactViewsEnabled = useUiFlag('impactViews');
     const showChangeRequestList = isEnterprise();
 
     return (
@@ -94,6 +95,9 @@ export const PrimaryNavigationList: FC<{
             ) : null}
             {!isOss() && impactMetricsEnabled ? (
                 <PrimaryListItem href='/impact-metrics' text='Impact Metrics' />
+            ) : null}
+            {!isOss() && impactViewsEnabled ? (
+                <PrimaryListItem href='/impact-views' text='Impact views' />
             ) : null}
             <ConfigurationAccordion
                 mode={mode}

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -115,6 +115,16 @@ exports[`returns all baseRoutes 1`] = `
     "type": "protected",
   },
   {
+    "enterprise": true,
+    "flag": "impactViews",
+    "menu": {
+      "primary": true,
+    },
+    "path": "/impact-views",
+    "title": "Impact views",
+    "type": "protected",
+  },
+  {
     "menu": {},
     "parent": "/applications",
     "path": "/applications/:name/*",

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -45,6 +45,7 @@ import { PaginatedApplicationList } from '../application/ApplicationList/Paginat
 import { AddonRedirect } from 'component/integrations/AddonRedirect/AddonRedirect';
 import { Insights } from '../insights/Insights.jsx';
 import { LazyImpactMetricsPage } from '../impact-metrics/LazyImpactMetricsPage.tsx';
+import { LazyImpactViewsPage } from '../impact-views/LazyImpactViewsPage.tsx';
 import { FeedbackList } from '../feedbackNew/FeedbackList.jsx';
 import { Application } from 'component/application/Application';
 import { Signals } from 'component/signals/Signals';
@@ -184,6 +185,17 @@ export const routes: IRoute[] = [
         menu: { primary: true },
         enterprise: true,
         flag: 'impactMetrics',
+    },
+
+    // Impact Views
+    {
+        path: '/impact-views',
+        title: 'Impact views',
+        component: LazyImpactViewsPage,
+        type: 'protected',
+        menu: { primary: true },
+        enterprise: true,
+        flag: 'impactViews',
     },
 
     // Applications

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -78,6 +78,7 @@ export type UiFlags = {
     consumptionModelUI?: boolean;
     customMetrics?: boolean;
     impactMetrics?: boolean;
+    impactViews?: boolean;
     registerImpactMetrics?: boolean;
     plausibleMetrics?: boolean;
     milestoneProgression?: boolean;

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -57,6 +57,7 @@ export type IFlagKey =
     | 'consumptionModelUI'
     | 'customMetrics'
     | 'impactMetrics'
+    | 'impactViews'
     | 'registerImpactMetrics'
     | 'etagByEnv'
     | 'fetchMode'
@@ -263,6 +264,10 @@ const flags: IFlags = {
     ),
     impactMetrics: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_IMPACT_METRICS,
+        false,
+    ),
+    impactViews: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_IMPACT_VIEWS,
         false,
     ),
     registerImpactMetrics: parseEnvVarBoolean(


### PR DESCRIPTION
## About the changes

First PR in the rollout of the experimental **Custom views** feature (impact-metric goals & views). This PR lays the **foundation only** — no functionality yet, just the flag, the route, and a stub page.