### PR TITLE
chore: remove impact metrics flag

### DIFF
--- a/frontend/src/component/admin/adminRoutes.ts
+++ b/frontend/src/component/admin/adminRoutes.ts
@@ -171,7 +171,7 @@ export const adminRoutes: INavigationMenuItem[] = [
         path: '/admin/impact-metrics',
         title: 'Impact Metrics',
         menu: { adminSettings: true },
-        flag: 'impactMetrics',
+        notFlag: 'disableImpactMetrics',
     },
 
     // Instance configuration

--- a/frontend/src/component/admin/adminRoutes.ts
+++ b/frontend/src/component/admin/adminRoutes.ts
@@ -170,7 +170,7 @@ export const adminRoutes: INavigationMenuItem[] = [
     {
         path: '/admin/impact-metrics',
         title: 'Impact Metrics',
-        menu: { adminSettings: true },
+        menu: { adminSettings: true, mode: ['enterprise'] },
         notFlag: 'disableImpactMetrics',
     },
 

--- a/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.test.tsx
+++ b/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.test.tsx
@@ -10,6 +10,8 @@ const server = testServerSetup();
 beforeEach(() => {
     testServerRoute(server, '/api/admin/ui-config', {
         flags: { disableImpactMetrics: false },
+        versionInfo: { current: { enterprise: 'version' } },
+        environment: 'Enterprise',
     });
     testServerRoute(server, '/api/admin/impact-metrics/external-source', {
         enabled: false,

--- a/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.test.tsx
+++ b/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.test.tsx
@@ -9,7 +9,7 @@ const server = testServerSetup();
 
 beforeEach(() => {
     testServerRoute(server, '/api/admin/ui-config', {
-        flags: { impactMetrics: true },
+        flags: {},
     });
     testServerRoute(server, '/api/admin/impact-metrics/external-source', {
         enabled: false,

--- a/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.test.tsx
+++ b/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.test.tsx
@@ -9,7 +9,7 @@ const server = testServerSetup();
 
 beforeEach(() => {
     testServerRoute(server, '/api/admin/ui-config', {
-        flags: {},
+        flags: { disableImpactMetrics: false },
     });
     testServerRoute(server, '/api/admin/impact-metrics/external-source', {
         enabled: false,

--- a/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.tsx
+++ b/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.tsx
@@ -74,7 +74,7 @@ const DOCS_URL =
     'https://docs.getunleash.io/concepts/impact-metrics#enable-external-metrics';
 
 export const ImpactMetricsAdmin = () => {
-    const impactMetricsEnabled = useUiFlag('impactMetrics');
+    const impactMetricsEnabled = !useUiFlag('disableImpactMetrics');
 
     if (!impactMetricsEnabled) {
         return <NotFound />;

--- a/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.tsx
+++ b/frontend/src/component/admin/impact-metrics/ImpactMetricsAdmin.tsx
@@ -19,7 +19,7 @@ import { PermissionGuard } from 'component/common/PermissionGuard/PermissionGuar
 import { ADMIN } from 'component/providers/AccessProvider/permissions';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
-import { useUiFlag } from 'hooks/useUiFlag';
+import { useImpactMetricsEnabled } from 'component/impact-metrics/hooks/useImpactMetricsEnabled';
 import NotFound from 'component/common/NotFound/NotFound';
 import { useExternalImpactMetricsSource } from 'hooks/api/getters/useExternalImpactMetricsSource/useExternalImpactMetricsSource';
 import { useExternalImpactMetricsSourceApi } from 'hooks/api/actions/useExternalImpactMetricsSourceApi/useExternalImpactMetricsSourceApi';
@@ -74,7 +74,7 @@ const DOCS_URL =
     'https://docs.getunleash.io/concepts/impact-metrics#enable-external-metrics';
 
 export const ImpactMetricsAdmin = () => {
-    const impactMetricsEnabled = !useUiFlag('disableImpactMetrics');
+    const impactMetricsEnabled = useImpactMetricsEnabled();
 
     if (!impactMetricsEnabled) {
         return <NotFound />;

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsOverview.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsOverview.tsx
@@ -1,10 +1,10 @@
 import { FeatureExposureMetrics } from './FeatureExposureMetrics.tsx';
 import { FeatureImpactMetrics } from './FeatureImpactMetrics.tsx';
-import { useUiFlag } from 'hooks/useUiFlag.ts';
+import { useImpactMetricsEnabled } from 'component/impact-metrics/hooks/useImpactMetricsEnabled.ts';
 import { Stack } from '@mui/material';
 
 export const FeatureMetricsOverview = () => {
-    const impactMetricsEnabled = !useUiFlag('disableImpactMetrics');
+    const impactMetricsEnabled = useImpactMetricsEnabled();
 
     return (
         <Stack spacing={2}>

--- a/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsOverview.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureMetrics/FeatureMetricsOverview.tsx
@@ -4,7 +4,7 @@ import { useUiFlag } from 'hooks/useUiFlag.ts';
 import { Stack } from '@mui/material';
 
 export const FeatureMetricsOverview = () => {
-    const impactMetricsEnabled = useUiFlag('impactMetrics');
+    const impactMetricsEnabled = !useUiFlag('disableImpactMetrics');
 
     return (
         <Stack spacing={2}>

--- a/frontend/src/component/impact-metrics/ImpactMetricsPage.tsx
+++ b/frontend/src/component/impact-metrics/ImpactMetricsPage.tsx
@@ -1,6 +1,8 @@
 import type { FC } from 'react';
 import { styled } from '@mui/material';
 import { ImpactMetrics } from './ImpactMetrics.tsx';
+import { useImpactMetricsEnabled } from './hooks/useImpactMetricsEnabled.ts';
+import NotFound from 'component/common/NotFound/NotFound';
 
 const StyledWrapper = styled('div')(({ theme }) => ({
     paddingTop: theme.spacing(2),
@@ -13,10 +15,18 @@ const StyledContainer = styled('div')(({ theme }) => ({
     paddingBottom: theme.spacing(4),
 }));
 
-export const ImpactMetricsPage: FC = () => (
-    <StyledWrapper>
-        <StyledContainer>
-            <ImpactMetrics />
-        </StyledContainer>
-    </StyledWrapper>
-);
+export const ImpactMetricsPage: FC = () => {
+    const impactMetricsEnabled = useImpactMetricsEnabled();
+
+    if (!impactMetricsEnabled) {
+        return <NotFound />;
+    }
+
+    return (
+        <StyledWrapper>
+            <StyledContainer>
+                <ImpactMetrics />
+            </StyledContainer>
+        </StyledWrapper>
+    );
+};

--- a/frontend/src/component/impact-metrics/hooks/useImpactMetricsEnabled.ts
+++ b/frontend/src/component/impact-metrics/hooks/useImpactMetricsEnabled.ts
@@ -1,11 +1,6 @@
 import { useUiFlag } from 'hooks/useUiFlag.ts';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 
-/**
- * Impact metrics is an enterprise feature, guarded by the
- * `disableImpactMetrics` killswitch. It is available only when the instance is
- * enterprise and the killswitch is not turned on.
- */
 export const useImpactMetricsEnabled = (): boolean => {
     const { isEnterprise } = useUiConfig();
     const disableImpactMetrics = useUiFlag('disableImpactMetrics');

--- a/frontend/src/component/impact-metrics/hooks/useImpactMetricsEnabled.ts
+++ b/frontend/src/component/impact-metrics/hooks/useImpactMetricsEnabled.ts
@@ -1,0 +1,14 @@
+import { useUiFlag } from 'hooks/useUiFlag.ts';
+import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+
+/**
+ * Impact metrics is an enterprise feature, guarded by the
+ * `disableImpactMetrics` killswitch. It is available only when the instance is
+ * enterprise and the killswitch is not turned on.
+ */
+export const useImpactMetricsEnabled = (): boolean => {
+    const { isEnterprise } = useUiConfig();
+    const disableImpactMetrics = useUiFlag('disableImpactMetrics');
+
+    return isEnterprise() && !disableImpactMetrics;
+};

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationList.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationList.tsx
@@ -12,7 +12,7 @@ import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { useNewAdminMenu } from 'hooks/useNewAdminMenu';
 import { AdminMenuNavigation } from '../AdminMenu/AdminNavigationItems.tsx';
 import { ConfigurationAccordion } from './ConfigurationAccordion.tsx';
-import { useUiFlag } from 'hooks/useUiFlag.ts';
+import { useImpactMetricsEnabled } from 'component/impact-metrics/hooks/useImpactMetricsEnabled.ts';
 import { NewFeatureBadge } from 'component/layout/components/NewFeatureBadge/NewFeatureBadge.tsx';
 import { useRoutes } from './useRoutes.ts';
 
@@ -74,7 +74,7 @@ export const PrimaryNavigationList: FC<{
     );
 
     const { isOss, isEnterprise } = useUiConfig();
-    const impactMetricsEnabled = !useUiFlag('disableImpactMetrics');
+    const impactMetricsEnabled = useImpactMetricsEnabled();
     const showChangeRequestList = isEnterprise();
 
     return (
@@ -92,7 +92,7 @@ export const PrimaryNavigationList: FC<{
             {!isOss() ? (
                 <PrimaryListItem href='/insights' text='Analytics' />
             ) : null}
-            {!isOss() && impactMetricsEnabled ? (
+            {impactMetricsEnabled ? (
                 <PrimaryListItem href='/impact-metrics' text='Impact Metrics' />
             ) : null}
             <ConfigurationAccordion

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationList.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationList.tsx
@@ -74,7 +74,7 @@ export const PrimaryNavigationList: FC<{
     );
 
     const { isOss, isEnterprise } = useUiConfig();
-    const impactMetricsEnabled = useUiFlag('impactMetrics');
+    const impactMetricsEnabled = !useUiFlag('disableImpactMetrics');
     const showChangeRequestList = isEnterprise();
 
     return (

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.test.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.test.tsx
@@ -98,6 +98,7 @@ describe('order of items in navigation', () => {
                 current: { enterprise: 'version' },
             },
             environment: 'Pro',
+            flags: { disableImpactMetrics: true },
         });
 
         render(<NavigationSidebar />);
@@ -111,6 +112,7 @@ describe('order of items in navigation', () => {
                 current: { enterprise: 'version' },
             },
             environment: 'Enterprise',
+            flags: { disableImpactMetrics: true },
         });
         render(<NavigationSidebar />);
 

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -106,10 +106,10 @@ exports[`returns all baseRoutes 1`] = `
   },
   {
     "enterprise": true,
-    "flag": "impactMetrics",
     "menu": {
       "primary": true,
     },
+    "notFlag": "disableImpactMetrics",
     "path": "/impact-metrics",
     "title": "Impact metrics",
     "type": "protected",

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -183,7 +183,7 @@ export const routes: IRoute[] = [
         type: 'protected',
         menu: { primary: true },
         enterprise: true,
-        flag: 'impactMetrics',
+        notFlag: 'disableImpactMetrics',
     },
 
     // Applications

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -77,7 +77,7 @@ export type UiFlags = {
     consumptionModel?: boolean;
     consumptionModelUI?: boolean;
     customMetrics?: boolean;
-    impactMetrics?: boolean;
+    disableImpactMetrics?: boolean;
     registerImpactMetrics?: boolean;
     plausibleMetrics?: boolean;
     milestoneProgression?: boolean;

--- a/src/lib/features/frontend-api/frontend-api-service.ts
+++ b/src/lib/features/frontend-api/frontend-api-service.ts
@@ -151,10 +151,7 @@ export class FrontendApiService {
             impactMetrics?: Metric[];
         };
 
-        if (
-            this.config.flagResolver.isEnabled('impactMetrics') &&
-            impactMetrics
-        ) {
+        if (impactMetrics) {
             await this.services.clientMetricsServiceV2.registerImpactMetrics(
                 impactMetrics as Metric[],
             );

--- a/src/lib/features/frontend-api/frontend-api.e2e.test.ts
+++ b/src/lib/features/frontend-api/frontend-api.e2e.test.ts
@@ -1297,6 +1297,11 @@ test('should accept impact metrics in frontend API metrics endpoint', async () =
         db.stores,
         {
             frontendApiOrigins: ['https://example.com'],
+            experimental: {
+                flags: {
+                    disableImpactMetrics: false,
+                },
+            },
         },
         db.rawDatabase,
     );

--- a/src/lib/features/frontend-api/frontend-api.e2e.test.ts
+++ b/src/lib/features/frontend-api/frontend-api.e2e.test.ts
@@ -1297,11 +1297,6 @@ test('should accept impact metrics in frontend API metrics endpoint', async () =
         db.stores,
         {
             frontendApiOrigins: ['https://example.com'],
-            experimental: {
-                flags: {
-                    impactMetrics: true,
-                },
-            },
         },
         db.rawDatabase,
     );

--- a/src/lib/features/frontend-api/frontend-api.middleware.e2e.test.ts
+++ b/src/lib/features/frontend-api/frontend-api.middleware.e2e.test.ts
@@ -1109,11 +1109,6 @@ test('should accept impact metrics in frontend API metrics endpoint', async () =
         db.stores,
         {
             frontendApiOrigins: ['https://example.com'],
-            experimental: {
-                flags: {
-                    impactMetrics: true,
-                },
-            },
         },
         db.rawDatabase,
     );

--- a/src/lib/features/frontend-api/frontend-api.middleware.e2e.test.ts
+++ b/src/lib/features/frontend-api/frontend-api.middleware.e2e.test.ts
@@ -1109,6 +1109,11 @@ test('should accept impact metrics in frontend API metrics endpoint', async () =
         db.stores,
         {
             frontendApiOrigins: ['https://example.com'],
+            experimental: {
+                flags: {
+                    disableImpactMetrics: false,
+                },
+            },
         },
         db.rawDatabase,
     );

--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -253,6 +253,9 @@ export default class ClientMetricsServiceV2 {
     }
 
     async registerImpactMetrics(impactMetrics: Metric[]) {
+        if (this.flagResolver.isEnabled('disableImpactMetrics')) {
+            return;
+        }
         try {
             const value =
                 await impactMetricsSchema.validateAsync(impactMetrics);

--- a/src/lib/features/metrics/impact/impact-metrics.e2e.test.ts
+++ b/src/lib/features/metrics/impact/impact-metrics.e2e.test.ts
@@ -50,7 +50,13 @@ const sendBulkMetricsWithImpact = async (
 
 beforeAll(async () => {
     db = await dbInit('impact_metrics', getLogger);
-    app = await setupAppWithCustomConfig(db.stores, {});
+    app = await setupAppWithCustomConfig(db.stores, {
+        experimental: {
+            flags: {
+                disableImpactMetrics: false,
+            },
+        },
+    });
 });
 
 afterAll(async () => {

--- a/src/lib/features/metrics/impact/impact-metrics.e2e.test.ts
+++ b/src/lib/features/metrics/impact/impact-metrics.e2e.test.ts
@@ -50,13 +50,7 @@ const sendBulkMetricsWithImpact = async (
 
 beforeAll(async () => {
     db = await dbInit('impact_metrics', getLogger);
-    app = await setupAppWithCustomConfig(db.stores, {
-        experimental: {
-            flags: {
-                impactMetrics: true,
-            },
-        },
-    });
+    app = await setupAppWithCustomConfig(db.stores, {});
 });
 
 afterAll(async () => {

--- a/src/lib/features/metrics/instance/metrics.ts
+++ b/src/lib/features/metrics/instance/metrics.ts
@@ -190,10 +190,7 @@ export default class ClientMetricsController extends Controller {
                     metricsData,
                     clientIp,
                 );
-                if (
-                    this.flagResolver.isEnabled('impactMetrics') &&
-                    impactMetrics
-                ) {
+                if (impactMetrics) {
                     await this.metricsV2.registerImpactMetrics(
                         impactMetrics as Metric[],
                     );
@@ -298,11 +295,7 @@ export default class ClientMetricsController extends Controller {
                     );
                 }
 
-                if (
-                    this.flagResolver.isEnabled('impactMetrics') &&
-                    impactMetrics &&
-                    impactMetrics.length > 0
-                ) {
+                if (impactMetrics && impactMetrics.length > 0) {
                     promises.push(
                         this.metricsV2.registerImpactMetrics(impactMetrics),
                     );

--- a/src/lib/middleware/request-logger.ts
+++ b/src/lib/middleware/request-logger.ts
@@ -11,11 +11,8 @@ const requestLogger: (config: IUnleashConfig) => RequestHandler = (config) => {
     const requestLoggerEnabled = config.server.enableRequestLogger;
     const impactMetrics = config.flagResolver.impactMetrics;
     return (req, res, next) => {
-        const impactMetricsEnabled =
-            config.flagResolver.isEnabled('impactMetrics');
-
         res.on('finish', () => {
-            if (impactMetricsEnabled && impactMetrics) {
+            if (impactMetrics) {
                 if (res.statusCode >= 400 && res.statusCode < 500) {
                     impactMetrics.incrementCounter(CLIENT_ERROR_COUNT);
                 }

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -265,7 +265,7 @@ const flags: IFlags = {
     ),
     disableImpactMetrics: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_DISABLE_IMPACT_METRICS,
-        false,
+        true,
     ),
     streaming: {
         name: 'disabled',

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -56,7 +56,6 @@ export type IFlagKey =
     | 'consumptionModel'
     | 'consumptionModelUI'
     | 'customMetrics'
-    | 'impactMetrics'
     | 'registerImpactMetrics'
     | 'disableImpactMetrics'
     | 'etagByEnv'
@@ -258,10 +257,6 @@ const flags: IFlags = {
     ),
     consumptionModelUI: parseEnvVarBoolean(
         process.env.EXPERIMENTAL_CONSUMPTION_MODEL_UI,
-        false,
-    ),
-    impactMetrics: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_IMPACT_METRICS,
         false,
     ),
     registerImpactMetrics: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -50,6 +50,7 @@ process.nextTick(async () => {
                         uniqueSdkTracking: true,
                         strictSchemaValidation: true,
                         customMetrics: true,
+                        disableImpactMetrics: false,
                         registerImpactMetrics: true,
                         milestoneProgression: true,
                         safeguards: true,

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -50,7 +50,6 @@ process.nextTick(async () => {
                         uniqueSdkTracking: true,
                         strictSchemaValidation: true,
                         customMetrics: true,
-                        impactMetrics: true,
                         registerImpactMetrics: true,
                         milestoneProgression: true,
                         safeguards: true,


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Removing impact metrics release flag. Keeping disable impact metrics killswitch in most critical spots

For self-hosted UNLEASH_EXPERIMENTAL_DISABLE_IMPACT_METRICS is set to true by default for now. Devs willing to try impact metrics locally have to change it to false. After this they will have self-service UI. I think we need to document it. One followup action is to always show the UI for external prom config and based on that show impact metrics for self hosted. But it's more work and I'd like to avoid making this change now. 

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
