### PR TITLE
chore: onboarding python snippet update

### DIFF
--- a/frontend/src/component/onboarding/dialog/snippets/python.md
+++ b/frontend/src/component/onboarding/dialog/snippets/python.md
@@ -6,7 +6,7 @@ pip install UnleashClient
 2\. Run Unleash
 ```python
 from UnleashClient import UnleashClient
-import asyncio
+import time
 
 client = UnleashClient(
     url="<YOUR_API_URL>",
@@ -16,19 +16,24 @@ client = UnleashClient(
 client.initialize_client()
 
 while True:
-    print(client.is_enabled("<YOUR_FLAG>"))
-    asyncio.run(asyncio.sleep(1))
+    if client.is_enabled("<YOUR_FLAG>"):
+        print("<YOUR_FLAG> is enabled")
+    else:
+        print("<YOUR_FLAG> is disabled")
+    time.sleep(2)
 ```
 ---
 ```python
 from UnleashClient import UnleashClient
-import asyncio
 import os
 
 client = UnleashClient(
     url="<YOUR_API_URL>",
     app_name="unleash-onboarding-python",
-    custom_headers={'Authorization': os.getenv('UNLEASH_API_TOKEN')}
+    custom_headers={'Authorization': os.getenv('UNLEASH_API_TOKEN')})
+
+client.initialize_client()
+
 ```
 
 ---


### PR DESCRIPTION
https://docs.getunleash.io/sdks/python

https://github.com/Unleash/unleash-sdk-examples/pull/90

I decided to replace asyncio with a simpler time.sleep - it's a silly test example anyway and both are here only for the testing/setup loop. 

> asyncio.run(asyncio.sleep(2)) creates and tears down an event loop on every iteration just to sleep. That overhead makes sense only if you have a running event loop you need to yield back to, or if the rest of the code is async.
> 
> Since the UnleashClient runs its polling on a background thread and main.py is fully synchronous, time.sleep is the right call — simpler and no wasted overhead.
