### PR TITLE
feat(impact-views): flag-event impact math (PR 2b)

### DIFF
--- a/frontend/src/component/impact-views/views/computeFlagEventImpact.test.ts
+++ b/frontend/src/component/impact-views/views/computeFlagEventImpact.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it } from 'vitest';
+import type { MultimetricStepSeries } from 'component/impact-metrics/MultimetricChart/types';
+import type { VisibleWindow } from 'component/impact-metrics/MultimetricChart/chartConfig';
+import {
+    computeFlagEventImpacts,
+    getDefaultHalfWindowMs,
+} from './computeFlagEventImpact';
+import type { ImpactViewFeatureEvent } from './types';
+
+const HOUR_MS = 60 * 60 * 1000;
+const HOUR_SEC = 60 * 60;
+const DAY_MS = 24 * HOUR_MS;
+const DAY_SEC = 24 * HOUR_SEC;
+
+const makeEvent = (
+    overrides: Partial<ImpactViewFeatureEvent> & {
+        id: number;
+        timestamp: number;
+    },
+): ImpactViewFeatureEvent => ({
+    type: 'feature-environment-enabled',
+    label: 'Enabled',
+    createdBy: 'someone',
+    featureName: 'my-flag',
+    ...overrides,
+});
+
+// `month` view → ±1 day half-window.
+const MONTH_WINDOW: VisibleWindow = {
+    minMs: 0,
+    maxMs: 30 * DAY_MS,
+    rangeMs: 30 * DAY_MS,
+};
+
+// `day` view → ±1 hour half-window.
+const DAY_WINDOW: VisibleWindow = {
+    minMs: 0,
+    maxMs: DAY_MS,
+    rangeMs: DAY_MS,
+};
+
+const seriesAt = (points: [number, number][]): MultimetricStepSeries => ({
+    label: 'goal',
+    data: points,
+});
+
+describe('computeFlagEventImpacts', () => {
+    it('returns empty when there is no goal series', () => {
+        const result = computeFlagEventImpacts({
+            events: [makeEvent({ id: 1, timestamp: DAY_MS })],
+            goalSeries: undefined,
+            aggregationMode: 'avg',
+            visibleWindow: MONTH_WINDOW,
+            timeRange: 'month',
+        });
+        expect(result).toEqual([]);
+    });
+
+    it('returns empty when there are no events', () => {
+        const result = computeFlagEventImpacts({
+            events: [],
+            goalSeries: seriesAt([[0, 1]]),
+            aggregationMode: 'avg',
+            visibleWindow: MONTH_WINDOW,
+            timeRange: 'month',
+        });
+        expect(result).toEqual([]);
+    });
+
+    it('computes pre/post means and Δ% for a latest-mode goal', () => {
+        // Event at day 10. Pre-window samples = [10, 10] → mean 10. Post-window
+        // samples = [20, 20] → mean 20. Δ% = (20-10)/10 * 100 = +100.
+        const eventMs = 10 * DAY_MS;
+        const result = computeFlagEventImpacts({
+            events: [makeEvent({ id: 1, timestamp: eventMs })],
+            goalSeries: seriesAt([
+                [10 * DAY_SEC - 2 * HOUR_SEC, 10],
+                [10 * DAY_SEC - HOUR_SEC, 10],
+                [10 * DAY_SEC + HOUR_SEC, 20],
+                [10 * DAY_SEC + 2 * HOUR_SEC, 20],
+            ]),
+            aggregationMode: 'avg',
+            visibleWindow: MONTH_WINDOW,
+            timeRange: 'month',
+        });
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+            eventId: 1,
+            preValue: 10,
+            postValue: 20,
+            deltaAbs: 10,
+            deltaPct: 100,
+            halfWindowMs: getDefaultHalfWindowMs('month'),
+        });
+    });
+
+    it('sums values per side for cumulative goals', () => {
+        const eventMs = 10 * DAY_MS;
+        const result = computeFlagEventImpacts({
+            events: [makeEvent({ id: 1, timestamp: eventMs })],
+            goalSeries: seriesAt([
+                [10 * DAY_SEC - HOUR_SEC, 3],
+                [10 * DAY_SEC - 30 * 60, 4],
+                [10 * DAY_SEC + 30 * 60, 5],
+                [10 * DAY_SEC + HOUR_SEC, 5],
+            ]),
+            aggregationMode: 'count',
+            visibleWindow: MONTH_WINDOW,
+            timeRange: 'month',
+        });
+        expect(result[0].preValue).toBe(7);
+        expect(result[0].postValue).toBe(10);
+        expect(result[0].deltaPct).toBeCloseTo((3 / 7) * 100);
+    });
+
+    it('returns deltaPct = null when pre is zero', () => {
+        const eventMs = 10 * DAY_MS;
+        const result = computeFlagEventImpacts({
+            events: [makeEvent({ id: 1, timestamp: eventMs })],
+            goalSeries: seriesAt([
+                [10 * DAY_SEC - HOUR_SEC, 0],
+                [10 * DAY_SEC + HOUR_SEC, 5],
+            ]),
+            aggregationMode: 'avg',
+            visibleWindow: MONTH_WINDOW,
+            timeRange: 'month',
+        });
+        expect(result[0].preValue).toBe(0);
+        expect(result[0].postValue).toBe(5);
+        expect(result[0].deltaAbs).toBe(5);
+        expect(result[0].deltaPct).toBeNull();
+    });
+
+    it('returns nulls and ranks the event last when one side has no data', () => {
+        // Event right at the start of the window — no pre-window data exists.
+        const eventMs = HOUR_MS;
+        const result = computeFlagEventImpacts({
+            events: [
+                makeEvent({ id: 1, timestamp: 12 * HOUR_MS }),
+                makeEvent({ id: 2, timestamp: eventMs }),
+            ],
+            goalSeries: seriesAt([
+                // No pre-window points exist before event 2.
+                [HOUR_SEC + 30 * 60, 5],
+                [HOUR_SEC + 60 * 60, 5],
+                [12 * HOUR_SEC - 30 * 60, 5],
+                [12 * HOUR_SEC + 30 * 60, 10],
+            ]),
+            aggregationMode: 'avg',
+            visibleWindow: DAY_WINDOW,
+            timeRange: 'day',
+        });
+        // The event with measurable Δ% (event 1) should rank first; the
+        // event with null Δ% (event 2) ranks last.
+        expect(result.map((impact) => impact.eventId)).toEqual([1, 2]);
+        const eventTwo = result.find((impact) => impact.eventId === 2)!;
+        expect(eventTwo.preValue).toBeNull();
+        expect(eventTwo.postValue).not.toBeNull();
+        expect(eventTwo.deltaPct).toBeNull();
+    });
+
+    it('drops an event with no pre and no post data', () => {
+        const eventMs = 10 * DAY_MS;
+        const result = computeFlagEventImpacts({
+            events: [makeEvent({ id: 1, timestamp: eventMs })],
+            // All series points fall far outside the half-window.
+            goalSeries: seriesAt([
+                [1 * DAY_SEC, 5],
+                [2 * DAY_SEC, 5],
+            ]),
+            aggregationMode: 'avg',
+            visibleWindow: MONTH_WINDOW,
+            timeRange: 'month',
+        });
+        expect(result).toEqual([]);
+    });
+
+    it('records the requested half-window and clamp reason on each impact', () => {
+        const firstMs = 10 * DAY_MS;
+        const secondMs = firstMs + 6 * HOUR_MS;
+        const result = computeFlagEventImpacts({
+            events: [
+                makeEvent({ id: 1, timestamp: firstMs }),
+                makeEvent({ id: 2, timestamp: secondMs }),
+            ],
+            goalSeries: seriesAt([
+                [10 * DAY_SEC - 60, 1],
+                [10 * DAY_SEC + 6 * HOUR_SEC + 60, 1],
+            ]),
+            aggregationMode: 'avg',
+            visibleWindow: MONTH_WINDOW,
+            timeRange: 'month',
+            // 1 day requested; neighbour is 6h away so each event's window
+            // clamps to 3h.
+            halfWindowMs: DAY_MS,
+        });
+        const first = result.find((impact) => impact.eventId === 1)!;
+        expect(first.requestedHalfWindowMs).toBe(DAY_MS);
+        expect(first.halfWindowMs).toBe(3 * HOUR_MS);
+        expect(first.clampReason).toBe('next-event');
+        const second = result.find((impact) => impact.eventId === 2)!;
+        expect(second.clampReason).toBe('previous-event');
+    });
+
+    it('leaves clampReason null when the effective window equals the requested one', () => {
+        const eventMs = 10 * DAY_MS;
+        const result = computeFlagEventImpacts({
+            events: [makeEvent({ id: 1, timestamp: eventMs })],
+            goalSeries: seriesAt([
+                [10 * DAY_SEC - HOUR_SEC, 5],
+                [10 * DAY_SEC + HOUR_SEC, 10],
+            ]),
+            aggregationMode: 'avg',
+            visibleWindow: MONTH_WINDOW,
+            timeRange: 'month',
+            halfWindowMs: 2 * HOUR_MS,
+        });
+        expect(result[0].requestedHalfWindowMs).toBe(2 * HOUR_MS);
+        expect(result[0].halfWindowMs).toBe(2 * HOUR_MS);
+        expect(result[0].clampReason).toBeNull();
+    });
+
+    it('clamps the half-window to half the distance between neighbouring events', () => {
+        // Two events 30 minutes apart inside a `month` view: default half-window
+        // is 1 day but should shrink to 15 minutes for both.
+        const firstMs = 10 * DAY_MS;
+        const secondMs = firstMs + 30 * 60 * 1000;
+        const result = computeFlagEventImpacts({
+            events: [
+                makeEvent({ id: 1, timestamp: firstMs }),
+                makeEvent({ id: 2, timestamp: secondMs }),
+            ],
+            goalSeries: seriesAt([
+                // Far enough away that they don't fall inside the (clamped) windows.
+                [10 * DAY_SEC - 60, 1],
+                [10 * DAY_SEC + 30 * 60 + 60, 1],
+            ]),
+            aggregationMode: 'avg',
+            visibleWindow: MONTH_WINDOW,
+            timeRange: 'month',
+        });
+        for (const impact of result) {
+            expect(impact.halfWindowMs).toBe(15 * 60 * 1000);
+        }
+    });
+
+    it('ranks impacts by |Δ%| descending', () => {
+        // Three events with Δ% of +200, -100, +20 respectively.
+        const events: ImpactViewFeatureEvent[] = [
+            makeEvent({ id: 1, timestamp: 5 * DAY_MS }),
+            makeEvent({ id: 2, timestamp: 15 * DAY_MS }),
+            makeEvent({ id: 3, timestamp: 25 * DAY_MS }),
+        ];
+        const goalSeries = seriesAt([
+            // event 1: pre = 10, post = 30 → +200%
+            [5 * DAY_SEC - HOUR_SEC, 10],
+            [5 * DAY_SEC + HOUR_SEC, 30],
+            // event 2: pre = 10, post = 0 → -100%
+            [15 * DAY_SEC - HOUR_SEC, 10],
+            [15 * DAY_SEC + HOUR_SEC, 0],
+            // event 3: pre = 10, post = 12 → +20%
+            [25 * DAY_SEC - HOUR_SEC, 10],
+            [25 * DAY_SEC + HOUR_SEC, 12],
+        ]);
+        const result = computeFlagEventImpacts({
+            events,
+            goalSeries,
+            aggregationMode: 'avg',
+            visibleWindow: MONTH_WINDOW,
+            timeRange: 'month',
+        });
+        expect(result.map((impact) => impact.eventId)).toEqual([1, 2, 3]);
+    });
+
+    it('exposes the raw pre/post points used in the aggregates', () => {
+        const eventMs = 10 * DAY_MS;
+        const result = computeFlagEventImpacts({
+            events: [makeEvent({ id: 1, timestamp: eventMs })],
+            goalSeries: seriesAt([
+                // pre — both inside the ±1d default
+                [10 * DAY_SEC - 2 * HOUR_SEC, 5],
+                [10 * DAY_SEC - HOUR_SEC, 7],
+                // post — both inside the ±1d default
+                [10 * DAY_SEC + HOUR_SEC, 9],
+                [10 * DAY_SEC + 2 * HOUR_SEC, 11],
+                // out-of-window — neither side should pick this up
+                [10 * DAY_SEC + 3 * DAY_SEC, 99],
+            ]),
+            aggregationMode: 'avg',
+            visibleWindow: MONTH_WINDOW,
+            timeRange: 'month',
+        });
+        expect(result[0].preSeries).toEqual([
+            [10 * DAY_SEC - 2 * HOUR_SEC, 5],
+            [10 * DAY_SEC - HOUR_SEC, 7],
+        ]);
+        expect(result[0].postSeries).toEqual([
+            [10 * DAY_SEC + HOUR_SEC, 9],
+            [10 * DAY_SEC + 2 * HOUR_SEC, 11],
+        ]);
+    });
+
+    it('drops non-finite values from the raw pre/post points', () => {
+        const eventMs = 10 * DAY_MS;
+        const result = computeFlagEventImpacts({
+            events: [makeEvent({ id: 1, timestamp: eventMs })],
+            goalSeries: seriesAt([
+                [10 * DAY_SEC - HOUR_SEC, Number.NaN],
+                [10 * DAY_SEC - 30 * 60, 10],
+                [10 * DAY_SEC + 30 * 60, 20],
+                [10 * DAY_SEC + HOUR_SEC, Number.POSITIVE_INFINITY],
+            ]),
+            aggregationMode: 'avg',
+            visibleWindow: MONTH_WINDOW,
+            timeRange: 'month',
+        });
+        expect(result[0].preSeries).toEqual([[10 * DAY_SEC - 30 * 60, 10]]);
+        expect(result[0].postSeries).toEqual([[10 * DAY_SEC + 30 * 60, 20]]);
+    });
+
+    it('respects an explicit halfWindowMs override', () => {
+        // Default for `month` is ±1 day. Override to ±2 hours and confirm the
+        // event picks up the shorter window in its `halfWindowMs` field.
+        const eventMs = 10 * DAY_MS;
+        const result = computeFlagEventImpacts({
+            events: [makeEvent({ id: 1, timestamp: eventMs })],
+            goalSeries: seriesAt([
+                [10 * DAY_SEC - HOUR_SEC, 5],
+                [10 * DAY_SEC + HOUR_SEC, 15],
+            ]),
+            aggregationMode: 'avg',
+            visibleWindow: MONTH_WINDOW,
+            timeRange: 'month',
+            halfWindowMs: 2 * HOUR_MS,
+        });
+        expect(result[0].halfWindowMs).toBe(2 * HOUR_MS);
+    });
+
+    it('skips non-finite series values', () => {
+        const eventMs = 10 * DAY_MS;
+        const result = computeFlagEventImpacts({
+            events: [makeEvent({ id: 1, timestamp: eventMs })],
+            goalSeries: seriesAt([
+                [10 * DAY_SEC - HOUR_SEC, Number.NaN],
+                [10 * DAY_SEC - 30 * 60, 10],
+                [10 * DAY_SEC + 30 * 60, 20],
+                [10 * DAY_SEC + HOUR_SEC, Number.POSITIVE_INFINITY],
+            ]),
+            aggregationMode: 'avg',
+            visibleWindow: MONTH_WINDOW,
+            timeRange: 'month',
+        });
+        expect(result[0].preValue).toBe(10);
+        expect(result[0].postValue).toBe(20);
+    });
+});

--- a/frontend/src/component/impact-views/views/computeFlagEventImpact.ts
+++ b/frontend/src/component/impact-views/views/computeFlagEventImpact.ts
@@ -1,0 +1,276 @@
+import type { MultimetricStepSeries } from 'component/impact-metrics/MultimetricChart/types';
+import type { AggregationMode } from 'component/impact-metrics/types';
+import type { VisibleWindow } from 'component/impact-metrics/MultimetricChart/chartConfig';
+import type { ImpactViewFeatureEvent } from './types';
+
+// Goal metric aggregation modes whose visible value is a running sum vs. a
+// "current" rate/percentile. We compare windows by summing for the first and
+// averaging for the second, matching the split in `computeGoalSummary`.
+const SUM_MODES: ReadonlySet<AggregationMode> = new Set(['count', 'sum']);
+
+// Default half-window length around a flag event when the caller doesn't
+// specify one. Sized per chart time range so we compare like-for-like buckets.
+const HALF_WINDOW_MS_BY_TIME_RANGE = {
+    hour: 5 * 60 * 1000,
+    day: 60 * 60 * 1000,
+    week: 6 * 60 * 60 * 1000,
+    month: 24 * 60 * 60 * 1000,
+} as const;
+
+export type FlagEventImpactTimeRange =
+    keyof typeof HALF_WINDOW_MS_BY_TIME_RANGE;
+
+// Named options the goal-tracking UI exposes in the baseline picker. Each
+// option is a fixed half-window length — picking `1d` means "compare goal Δ
+// over the day before vs. the day after each flip". Visible-window and
+// neighbouring-event clamps still apply so the math stays honest at edges.
+export const BASELINE_OPTIONS = [
+    { id: '15m', label: '\u00B115 minutes', halfWindowMs: 15 * 60 * 1000 },
+    { id: '1h', label: '\u00B11 hour', halfWindowMs: 60 * 60 * 1000 },
+    { id: '6h', label: '\u00B16 hours', halfWindowMs: 6 * 60 * 60 * 1000 },
+    { id: '1d', label: '\u00B11 day', halfWindowMs: 24 * 60 * 60 * 1000 },
+    { id: '3d', label: '\u00B13 days', halfWindowMs: 3 * 24 * 60 * 60 * 1000 },
+    { id: '7d', label: '\u00B17 days', halfWindowMs: 7 * 24 * 60 * 60 * 1000 },
+] as const;
+
+export type BaselineOptionId = (typeof BASELINE_OPTIONS)[number]['id'];
+
+// Default picker selection for each chart time range — wide enough to absorb
+// short-term noise but narrow enough not to drown a real movement.
+export const DEFAULT_BASELINE_BY_TIME_RANGE: Record<
+    FlagEventImpactTimeRange,
+    BaselineOptionId
+> = {
+    hour: '15m',
+    day: '1h',
+    week: '6h',
+    month: '1d',
+};
+
+export type ClampReason = 'previous-event' | 'next-event' | 'visible-window';
+
+export type FlagEventImpact = {
+    eventId: number;
+    event: ImpactViewFeatureEvent;
+    // The half-window actually used after clamping to neighbouring events and
+    // the visible window. Exposed so the row can label "Δ measured over ±Xh".
+    halfWindowMs: number;
+    // The half-window the caller asked for, before clamps. Equal to
+    // `halfWindowMs` when no clamp applied. Exposed so the UI can call out
+    // "you picked ±7d but we measured ±2d because the next flip was nearby".
+    requestedHalfWindowMs: number;
+    // When the effective window is smaller than the requested one, this names
+    // the tightest constraint. `null` means no clamp applied.
+    clampReason: ClampReason | null;
+    // Mean (latest modes) or sum (cumulative modes) of finite values in each
+    // half-window. `null` when no finite points fell into that side.
+    preValue: number | null;
+    postValue: number | null;
+    deltaAbs: number | null;
+    // `null` when `preValue` is null or zero — matches `computeGoalSummary`.
+    deltaPct: number | null;
+    // The raw goal-series points that went into each half-window aggregate.
+    // Useful for drilling down into the Δ — e.g. drawing a sub-chart around
+    // the flip. Timestamps are in seconds, matching `MultimetricStepSeries`.
+    preSeries: [number, number][];
+    postSeries: [number, number][];
+};
+
+export const getDefaultHalfWindowMs = (
+    timeRange: FlagEventImpactTimeRange,
+): number => HALF_WINDOW_MS_BY_TIME_RANGE[timeRange];
+
+const seriesPointsBetween = (
+    series: MultimetricStepSeries,
+    fromSec: number,
+    toSec: number,
+): [number, number][] => {
+    const points: [number, number][] = [];
+    for (const [tsSec, value] of series.data) {
+        if (tsSec < fromSec || tsSec >= toSec) continue;
+        if (!Number.isFinite(value)) continue;
+        points.push([tsSec, value]);
+    }
+    return points;
+};
+
+const valuesOf = (points: readonly [number, number][]): number[] =>
+    points.map(([, value]) => value);
+
+const mean = (values: number[]): number | null => {
+    if (values.length === 0) return null;
+    let total = 0;
+    for (const value of values) total += value;
+    return total / values.length;
+};
+
+const sum = (values: number[]): number | null => {
+    if (values.length === 0) return null;
+    let total = 0;
+    for (const value of values) total += value;
+    return total;
+};
+
+const aggregate = (values: number[], isSumMode: boolean): number | null =>
+    isSumMode ? sum(values) : mean(values);
+
+// Half-window for an event = caller-requested length, then shrunk to half
+// the gap to any neighbouring event, then clamped so neither side spills out
+// of the visible chart window. Returns the effective half-window plus the
+// tightest constraint that applied (so the UI can explain "you picked ±7d but
+// we measured ±2d because the next flip was nearby"). Effective = 0 when
+// there's no room on at least one side — callers treat that as "can't
+// compute".
+type PickedHalfWindow = {
+    effectiveMs: number;
+    clampReason: ClampReason | null;
+};
+
+const pickHalfWindowMs = (
+    eventMs: number,
+    sortedEventMs: readonly number[],
+    eventIndex: number,
+    visibleWindow: VisibleWindow,
+    requestedHalfWindowMs: number,
+): PickedHalfWindow => {
+    let halfWindowMs = requestedHalfWindowMs;
+    let clampReason: ClampReason | null = null;
+
+    const prevEventMs = sortedEventMs[eventIndex - 1];
+    if (prevEventMs !== undefined) {
+        const halfGap = (eventMs - prevEventMs) / 2;
+        if (halfGap < halfWindowMs) {
+            halfWindowMs = halfGap;
+            clampReason = 'previous-event';
+        }
+    }
+    const nextEventMs = sortedEventMs[eventIndex + 1];
+    if (nextEventMs !== undefined) {
+        const halfGap = (nextEventMs - eventMs) / 2;
+        if (halfGap < halfWindowMs) {
+            halfWindowMs = halfGap;
+            clampReason = 'next-event';
+        }
+    }
+
+    const roomBefore = eventMs - visibleWindow.minMs;
+    if (roomBefore < halfWindowMs) {
+        halfWindowMs = roomBefore;
+        clampReason = 'visible-window';
+    }
+    const roomAfter = visibleWindow.maxMs - eventMs;
+    if (roomAfter < halfWindowMs) {
+        halfWindowMs = roomAfter;
+        clampReason = 'visible-window';
+    }
+
+    return {
+        effectiveMs: Math.max(0, Math.floor(halfWindowMs)),
+        clampReason: halfWindowMs < requestedHalfWindowMs ? clampReason : null,
+    };
+};
+
+export type ComputeFlagEventImpactsInput = {
+    events: readonly ImpactViewFeatureEvent[];
+    goalSeries: MultimetricStepSeries | undefined;
+    aggregationMode: AggregationMode;
+    visibleWindow: VisibleWindow;
+    timeRange: FlagEventImpactTimeRange;
+    // Caller-requested baseline half-window. When omitted, the per-time-range
+    // default is used. The effective value per event may still be smaller due
+    // to neighbouring-event and visible-window clamps.
+    halfWindowMs?: number;
+};
+
+// Returns one `FlagEventImpact` per event that has at least one of pre/post
+// data available, ranked by absolute Δ% descending (events with `null` Δ%
+// rank below all measurable ones, in chronological order). Events whose
+// half-window collapses to zero on both sides are dropped entirely — they
+// would carry no information.
+export const computeFlagEventImpacts = ({
+    events,
+    goalSeries,
+    aggregationMode,
+    visibleWindow,
+    timeRange,
+    halfWindowMs: requestedHalfWindowMs,
+}: ComputeFlagEventImpactsInput): FlagEventImpact[] => {
+    if (!goalSeries || goalSeries.data.length === 0) return [];
+    if (events.length === 0) return [];
+
+    const isSumMode = SUM_MODES.has(aggregationMode);
+    const baselineHalfWindowMs =
+        requestedHalfWindowMs ?? HALF_WINDOW_MS_BY_TIME_RANGE[timeRange];
+
+    const sortedEvents = [...events].sort(
+        (left, right) => left.timestamp - right.timestamp,
+    );
+    const sortedEventMs = sortedEvents.map((event) => event.timestamp);
+
+    const impacts: FlagEventImpact[] = [];
+    for (let index = 0; index < sortedEvents.length; index += 1) {
+        const event = sortedEvents[index];
+        const { effectiveMs: halfWindowMs, clampReason } = pickHalfWindowMs(
+            event.timestamp,
+            sortedEventMs,
+            index,
+            visibleWindow,
+            baselineHalfWindowMs,
+        );
+        if (halfWindowMs === 0) continue;
+
+        // Series timestamps are seconds, event timestamps are milliseconds.
+        const eventSec = event.timestamp / 1000;
+        const halfWindowSec = halfWindowMs / 1000;
+        const preSeries = seriesPointsBetween(
+            goalSeries,
+            eventSec - halfWindowSec,
+            eventSec,
+        );
+        const postSeries = seriesPointsBetween(
+            goalSeries,
+            eventSec,
+            eventSec + halfWindowSec,
+        );
+        const preValue = aggregate(valuesOf(preSeries), isSumMode);
+        const postValue = aggregate(valuesOf(postSeries), isSumMode);
+
+        if (preValue === null && postValue === null) continue;
+
+        const deltaAbs =
+            preValue !== null && postValue !== null
+                ? postValue - preValue
+                : null;
+        const deltaPct =
+            deltaAbs !== null && preValue !== null && preValue !== 0
+                ? (deltaAbs / preValue) * 100
+                : null;
+
+        impacts.push({
+            eventId: event.id,
+            event,
+            halfWindowMs,
+            requestedHalfWindowMs: baselineHalfWindowMs,
+            clampReason,
+            preValue,
+            postValue,
+            deltaAbs,
+            deltaPct,
+            preSeries,
+            postSeries,
+        });
+    }
+
+    impacts.sort((left, right) => {
+        const leftMagnitude =
+            left.deltaPct === null ? -1 : Math.abs(left.deltaPct);
+        const rightMagnitude =
+            right.deltaPct === null ? -1 : Math.abs(right.deltaPct);
+        if (leftMagnitude !== rightMagnitude)
+            return rightMagnitude - leftMagnitude;
+        // Tie-breaker: chronological so the list is stable.
+        return left.event.timestamp - right.event.timestamp;
+    });
+
+    return impacts;
+};

--- a/frontend/src/component/impact-views/views/flagImpactFormatting.ts
+++ b/frontend/src/component/impact-views/views/flagImpactFormatting.ts
@@ -1,0 +1,41 @@
+import type { FlagEventImpact } from './computeFlagEventImpact';
+
+// Anything below this magnitude is rounded down to "flat" — used for both the
+// row tone and the small-change disclosure in Top Movers. Centralised so the
+// row, dialog, and pill tooltip all agree on what counts as movement.
+export const SMALL_CHANGE_THRESHOLD_PCT = 1;
+
+export type Tone = 'up' | 'down' | 'flat';
+
+// Maps a Δ% to a directional tone, treating sub-threshold magnitudes as flat
+// regardless of sign. Null Δ% → flat (nothing measurable to colour).
+export const toneOf = (impact: FlagEventImpact): Tone => {
+    if (
+        impact.deltaPct === null ||
+        Math.abs(impact.deltaPct) < SMALL_CHANGE_THRESHOLD_PCT
+    ) {
+        return 'flat';
+    }
+    return impact.deltaAbs! > 0 ? 'up' : 'down';
+};
+
+// "+85%" or "−12%" — unicode minus so it lines up with the formatAbs sign.
+export const formatPct = (pct: number): string => {
+    const sign = pct > 0 ? '+' : '\u2212';
+    const abs = Math.abs(pct);
+    const formatted =
+        abs >= 10 || Number.isInteger(abs)
+            ? `${Math.round(abs)}`
+            : abs.toFixed(1);
+    return `${sign}${formatted}%`;
+};
+
+// Human-readable rendering of the half-window length used in the comparison.
+export const formatHalfWindow = (halfWindowMs: number): string => {
+    const minutes = Math.round(halfWindowMs / (60 * 1000));
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.round(halfWindowMs / (60 * 60 * 1000));
+    if (hours < 24) return `${hours}h`;
+    const days = Math.round(halfWindowMs / (24 * 60 * 60 * 1000));
+    return `${days}d`;
+};


### PR DESCRIPTION
## About the changes

**Stacked on #12177 (PR 2)** — please review/merge that first. Base branch is `feat/impact-views-pr2-utils`, so this diff shows only the 3 new files.

Adds the flag-event impact layer of the goal-tracking view, extracted from `feat/exp-views` into the co-located `impact-views/views/` dir.

### What's in this PR (3 files)

- `computeFlagEventImpact.ts` (+ tests) — attributes goal-metric deltas to flag toggle events (baseline / half-window logic, ranking by |Δ%|).
- `flagImpactFormatting.ts` — Δ% / tone formatting helpers. Depends on `computeFlagEventImpact`'s `FlagEventImpact` type, so it's grouped here rather than in PR 2.

Pure functions, no components, no API calls. Imports the local `ImpactViewFeatureEvent` type from PR 2's `types.ts`; otherwise only already-on-`main` modules.

### Why split from PR 2

PR 2 reviewer feedback was to keep each PR as small as possible. `computeFlagEventImpact` + its 356-line test are the bulk, so they live here. `flagImpactFormatting` comes along because it imports a type from `computeFlagEventImpact`.

## Verification

- `pnpm exec tsc` passes.
- Biome lint clean.
- `pnpm exec vitest run` — 15 unit tests pass (`computeFlagEventImpact`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)