### PR TITLE
chore: clean up rust example dependencies

### DIFF
--- a/frontend/src/component/onboarding/dialog/snippets/rust.md
+++ b/frontend/src/component/onboarding/dialog/snippets/rust.md
@@ -1,6 +1,6 @@
 1\. Install the SDK
 ```sh
-cargo add unleash-api-client --features async-std,reqwest
+cargo add unleash-api-client --features reqwest
 cargo add serde --features derive
 cargo add reqwest@0.12 --features json
 cargo add tokio --features full


### PR DESCRIPTION
We're using full tokio here already, async std isn't necessary. Pretty sure this is only working because we're not disabling default features on the install. But leaving this in makes reading this example suuuper confusing