### PR TITLE
add kebab menu options

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureHeaderActionsKebab.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureHeaderActionsKebab.tsx
@@ -1,0 +1,149 @@
+import { useId, useState, type FC, type MouseEvent } from 'react';
+import MoreVert from '@mui/icons-material/MoreVert';
+import ArchiveOutlined from '@mui/icons-material/ArchiveOutlined';
+import WatchLaterOutlined from '@mui/icons-material/WatchLaterOutlined';
+import LibraryAddOutlined from '@mui/icons-material/LibraryAddOutlined';
+import Star from '@mui/icons-material/Star';
+import StarBorder from '@mui/icons-material/StarBorder';
+import {
+    IconButton,
+    ListItemIcon,
+    ListItemText,
+    Menu,
+    MenuItem,
+    Typography,
+} from '@mui/material';
+import { Link } from 'react-router-dom';
+import {
+    CREATE_FEATURE,
+    DELETE_FEATURE,
+    UPDATE_FEATURE,
+} from 'component/providers/AccessProvider/permissions';
+import { useCheckProjectPermissions } from 'hooks/useHasAccess';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import type { IFeatureToggle } from 'interfaces/featureToggle';
+
+type FeatureHeaderActionsKebabProps = {
+    feature: IFeatureToggle;
+    onFavorite: () => void;
+    openStaleDialog: () => void;
+    openDeleteDialog: () => void;
+};
+
+export const FeatureHeaderActionsKebab: FC<FeatureHeaderActionsKebabProps> = ({
+    feature,
+    onFavorite,
+    openStaleDialog,
+    openDeleteDialog,
+}) => {
+    const projectId = useRequiredPathParam('projectId');
+    const featureId = useRequiredPathParam('featureId');
+    const checkAccess = useCheckProjectPermissions(projectId);
+    const canClone = checkAccess(CREATE_FEATURE);
+    const canArchive = checkAccess(DELETE_FEATURE);
+    const canToggleStale = checkAccess(UPDATE_FEATURE);
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const open = Boolean(anchorEl);
+    const buttonId = useId();
+    const menuId = useId();
+
+    const handleClick = (event: MouseEvent<HTMLElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    return (
+        <>
+            <IconButton
+                aria-label='Feature flag actions'
+                id={buttonId}
+                aria-controls={open ? menuId : undefined}
+                aria-expanded={open}
+                aria-haspopup='true'
+                onClick={handleClick}
+                data-loading
+            >
+                <MoreVert />
+            </IconButton>
+            <Menu
+                id={menuId}
+                anchorEl={anchorEl}
+                open={open}
+                onClose={handleClose}
+                anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+                transformOrigin={{ horizontal: 'right', vertical: 'top' }}
+                slotProps={{
+                    list: {
+                        'aria-labelledby': buttonId,
+                    },
+                }}
+            >
+                <MenuItem
+                    onClick={() => {
+                        onFavorite();
+                        handleClose();
+                    }}
+                >
+                    <ListItemIcon>
+                        {feature.favorite ? <Star /> : <StarBorder />}
+                    </ListItemIcon>
+                    <ListItemText>
+                        <Typography variant='body2'>
+                            {feature.favorite
+                                ? 'Remove from favorites'
+                                : 'Add to favorites'}
+                        </Typography>
+                    </ListItemText>
+                </MenuItem>
+                <MenuItem
+                    component={Link}
+                    nativeButton={false}
+                    disabled={!canClone}
+                    to={`/projects/${projectId}/features/${featureId}/copy`}
+                    onClick={handleClose}
+                >
+                    <ListItemIcon>
+                        <LibraryAddOutlined />
+                    </ListItemIcon>
+                    <ListItemText>
+                        <Typography variant='body2'>Clone</Typography>
+                    </ListItemText>
+                </MenuItem>
+                <MenuItem
+                    disabled={!canArchive}
+                    onClick={() => {
+                        openDeleteDialog();
+                        handleClose();
+                    }}
+                >
+                    <ListItemIcon>
+                        <ArchiveOutlined />
+                    </ListItemIcon>
+                    <ListItemText>
+                        <Typography variant='body2'>
+                            Archive feature flag
+                        </Typography>
+                    </ListItemText>
+                </MenuItem>
+                <MenuItem
+                    disabled={!canToggleStale}
+                    onClick={() => {
+                        openStaleDialog();
+                        handleClose();
+                    }}
+                >
+                    <ListItemIcon>
+                        <WatchLaterOutlined />
+                    </ListItemIcon>
+                    <ListItemText>
+                        <Typography variant='body2'>
+                            Toggle stale state
+                        </Typography>
+                    </ListItemText>
+                </MenuItem>
+            </Menu>
+        </>
+    );
+};

--- a/frontend/src/component/feature/FeatureView/FeatureHeaderActionsKebab.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureHeaderActionsKebab.tsx
@@ -20,11 +20,10 @@ import {
     UPDATE_FEATURE,
 } from 'component/providers/AccessProvider/permissions';
 import { useCheckProjectPermissions } from 'hooks/useHasAccess';
-import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
-import type { IFeatureToggle } from 'interfaces/featureToggle';
+import type { FeatureSchema } from 'openapi';
 
 type FeatureHeaderActionsKebabProps = {
-    feature: IFeatureToggle;
+    feature: Pick<FeatureSchema, 'project' | 'name' | 'favorite'>;
     onFavorite: () => void;
     openStaleDialog: () => void;
     openDeleteDialog: () => void;
@@ -36,9 +35,7 @@ export const FeatureHeaderActionsKebab: FC<FeatureHeaderActionsKebabProps> = ({
     openStaleDialog,
     openDeleteDialog,
 }) => {
-    const projectId = useRequiredPathParam('projectId');
-    const featureId = useRequiredPathParam('featureId');
-    const checkAccess = useCheckProjectPermissions(projectId);
+    const checkAccess = useCheckProjectPermissions(feature.project);
     const canClone = checkAccess(CREATE_FEATURE);
     const canArchive = checkAccess(DELETE_FEATURE);
     const canToggleStale = checkAccess(UPDATE_FEATURE);
@@ -63,7 +60,6 @@ export const FeatureHeaderActionsKebab: FC<FeatureHeaderActionsKebabProps> = ({
                 aria-expanded={open}
                 aria-haspopup='true'
                 onClick={handleClick}
-                data-loading
             >
                 <MoreVert />
             </IconButton>
@@ -101,8 +97,7 @@ export const FeatureHeaderActionsKebab: FC<FeatureHeaderActionsKebabProps> = ({
                     component={Link}
                     nativeButton={false}
                     disabled={!canClone}
-                    to={`/projects/${projectId}/features/${featureId}/copy`}
-                    onClick={handleClose}
+                    to={`/projects/${feature.project}/features/${feature.name}/copy`}
                 >
                     <ListItemIcon>
                         <LibraryAddOutlined />

--- a/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx
@@ -232,7 +232,7 @@ export const FeatureViewHeader: FC<Props> = ({ feature }) => {
     const basePath = `/projects/${projectId}/features/${featureId}`;
 
     const showLegacyVariants = useLegacyVariants(feature.environments);
-    const useKebabActions = useMinimumUnleashVersion('8.0.0');
+    const useKebabActions = !useMinimumUnleashVersion('8.0.0');
 
     const tabData = [
         {

--- a/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx
@@ -32,6 +32,8 @@ import { FeatureStaleDialog } from 'component/common/FeatureStaleDialog/FeatureS
 import { FeatureArchiveDialog } from 'component/common/FeatureArchiveDialog/FeatureArchiveDialog';
 import { FeatureArchiveNotAllowedDialog } from 'component/common/FeatureArchiveDialog/FeatureArchiveNotAllowedDialog';
 import { FeatureCopyName } from './FeatureCopyName/FeatureCopyName.tsx';
+import { useMinimumUnleashVersion } from 'hooks/useMinimumUnleashVersion';
+import { FeatureHeaderActionsKebab } from './FeatureHeaderActionsKebab';
 
 const StyledHeader = styled('div')(({ theme }) => ({
     backgroundColor: 'none',
@@ -65,6 +67,10 @@ const LowerHeaderRow = styled(UpperHeaderRow)(({ theme }) => ({
     columnGap: 0,
     flexFlow: 'column nowrap',
     alignItems: 'flex-start',
+    '&[data-reflow-on-narrow="false"]': {
+        alignItems: 'center',
+        flexFlow: 'row nowrap',
+    },
     ...onWideHeader(theme, {
         alignItems: 'center',
         flexFlow: 'row nowrap',
@@ -226,6 +232,7 @@ export const FeatureViewHeader: FC<Props> = ({ feature }) => {
     const basePath = `/projects/${projectId}/features/${featureId}`;
 
     const showLegacyVariants = useLegacyVariants(feature.environments);
+    const useKebabActions = useMinimumUnleashVersion('8.0.0');
 
     const tabData = [
         {
@@ -295,8 +302,10 @@ export const FeatureViewHeader: FC<Props> = ({ feature }) => {
                     </StyledTitle>
                     {feature.stale ? <FeatureStatusChip stale={true} /> : null}
                 </UpperHeaderRow>
-                <LowerHeaderRow>
-                    <HeaderActionsInner showOnNarrowScreens />
+                <LowerHeaderRow data-reflow-on-narrow={!useKebabActions}>
+                    {!useKebabActions && (
+                        <HeaderActionsInner showOnNarrowScreens />
+                    )}
                     <StyledTabs
                         value={activeTab.path}
                         indicatorColor='primary'
@@ -314,7 +323,16 @@ export const FeatureViewHeader: FC<Props> = ({ feature }) => {
                             />
                         ))}
                     </StyledTabs>
-                    <HeaderActionsInner />
+                    {useKebabActions ? (
+                        <FeatureHeaderActionsKebab
+                            feature={feature}
+                            onFavorite={onFavorite}
+                            openStaleDialog={() => setOpenStaleDialog(true)}
+                            openDeleteDialog={() => setShowDelDialog(true)}
+                        />
+                    ) : (
+                        <HeaderActionsInner />
+                    )}
                 </LowerHeaderRow>
             </StyledHeader>
             {feature.children.length > 0 ? (


### PR DESCRIPTION
Moves all the feature flag actions into a kebab menu and makes it so that it doesn't flow into a separate row on narrow screens 🍢

Because we're reimplementing and slightly changing all the options, I've added a brand new file with the same actions.

Before:
<img width="949" height="174" alt="image" src="https://github.com/user-attachments/assets/532fa1ea-7f60-4d83-bad2-6b38915c9734" />
<img width="533" height="198" alt="image" src="https://github.com/user-attachments/assets/d18ca8d4-378a-4c6f-ad88-4639c078f363" />

After:
<img width="1027" height="155" alt="image" src="https://github.com/user-attachments/assets/4157be89-6da2-416d-8424-b2b0f8bedb37" />
<img width="532" height="150" alt="image" src="https://github.com/user-attachments/assets/99f7033d-cd0a-4050-8342-74d1ab5470d8" />
<img width="248" height="220" alt="image" src="https://github.com/user-attachments/assets/89b35bc3-73ff-490e-8e10-68e5c9260008" />


Closes DX-4655