### PR TITLE
feat(impact-views): followed-features list + dummy goal view

### DIFF
--- a/frontend/src/component/impact-views/ImpactViewsPage.tsx
+++ b/frontend/src/component/impact-views/ImpactViewsPage.tsx
@@ -1,12 +1,13 @@
 import type { FC } from 'react';
 import { styled } from '@mui/material';
-import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { GoalSummaryPanel } from './views/GoalSummaryPanel/GoalSummaryPanel';
 import { MultimetricChartCard } from './views/MultimetricChartCard/MultimetricChartCard';
+import { FollowedFeaturesList } from './views/FollowedFeaturesList/FollowedFeaturesList';
 import {
     DUMMY_END,
     DUMMY_FEATURE_EVENTS,
+    DUMMY_FOLLOWED_FEATURES,
     DUMMY_GOAL_METRIC_LABEL,
     DUMMY_GOAL_SERIES,
     DUMMY_GOAL_SUMMARY,
@@ -27,33 +28,39 @@ const StyledCardPreview = styled('div')(({ theme }) => ({
     marginTop: theme.spacing(3),
 }));
 
+const StyledFeaturesPreview = styled('div')(({ theme }) => ({
+    marginTop: theme.spacing(3),
+}));
+
 export const ImpactViewsPage: FC = () => (
     <StyledWrapper>
-        <PageContent header={<PageHeader title='Impact views' />}>
-            <StyledCardPreview>
-                <MultimetricChartCard
-                    title={DUMMY_GOAL_METRIC_LABEL}
-                    subtitle={`Goal · ${DUMMY_GOAL_TIME_LABEL}`}
-                    timeRange='month'
-                    aggregationMode='avg'
-                    stepSeries={DUMMY_STEP_SERIES}
-                    stepTotals={DUMMY_STEP_TOTALS}
-                    featureEvents={DUMMY_FEATURE_EVENTS}
-                    start={DUMMY_START}
-                    end={DUMMY_END}
-                    loading={false}
-                    chartHeightSpacing={{ base: 48, lg: 40, sm: 32 }}
-                    totalsLabel='Goal'
-                    totalsHeaderSlot={
-                        <GoalSummaryPanel
-                            goalMetricLabel={DUMMY_GOAL_METRIC_LABEL}
-                            summary={DUMMY_GOAL_SUMMARY}
-                            series={DUMMY_GOAL_SERIES}
-                            timeLabel={DUMMY_GOAL_TIME_LABEL}
-                        />
-                    }
-                />
-            </StyledCardPreview>
-        </PageContent>
+        <PageHeader title='Impact views' />
+        <StyledCardPreview>
+            <MultimetricChartCard
+                title={DUMMY_GOAL_METRIC_LABEL}
+                subtitle={`Goal · ${DUMMY_GOAL_TIME_LABEL}`}
+                timeRange='month'
+                aggregationMode='avg'
+                stepSeries={DUMMY_STEP_SERIES}
+                stepTotals={DUMMY_STEP_TOTALS}
+                featureEvents={DUMMY_FEATURE_EVENTS}
+                start={DUMMY_START}
+                end={DUMMY_END}
+                loading={false}
+                chartHeightSpacing={{ base: 48, lg: 40, sm: 32 }}
+                totalsLabel='Goal'
+                totalsHeaderSlot={
+                    <GoalSummaryPanel
+                        goalMetricLabel={DUMMY_GOAL_METRIC_LABEL}
+                        summary={DUMMY_GOAL_SUMMARY}
+                        series={DUMMY_GOAL_SERIES}
+                        timeLabel={DUMMY_GOAL_TIME_LABEL}
+                    />
+                }
+            />
+        </StyledCardPreview>
+        <StyledFeaturesPreview>
+            <FollowedFeaturesList features={DUMMY_FOLLOWED_FEATURES} />
+        </StyledFeaturesPreview>
     </StyledWrapper>
 );

--- a/frontend/src/component/impact-views/README.md
+++ b/frontend/src/component/impact-views/README.md
@@ -59,8 +59,8 @@ generators, the view editor, localStorage CRUD, and real-data wiring.
 | **2** | Goal-view types + goal summary (no components, no API calls): `views/types.ts`, `computeGoalSummary(+test)`. |
 | **3** | Goal summary panel (render-only): `GoalSummaryPanel`. (`FollowedFeaturesStrip` dropped — dead code, nothing imports it.) |
 | **4** | Chart card (render-only layout): `views/MultimetricChartCard/MultimetricChartCard.tsx`. (Getter `useGroupedImpactMetricsData` deferred to the real-data PR — not needed for dummy data.) |
-| **5** | Goal chart + lists: `GoalTrackingViewChart` (Top Movers / Flag Impact / dev simulation stripped), `FollowedFeaturesList`, `useMergedFeatureEvents`. |
-| **6** | Wire the dummy goal view: `fixtures/dummyGoalView.ts` (hardcoded `MetricView` + static series/events) rendered from `ImpactViewsPage` — no API calls. |
+| **5** | Followed-features list (render-only): `views/FollowedFeaturesList/FollowedFeaturesList.tsx`, rendered below the card on the page with dummy feature names. (The `GoalTrackingViewChart` orchestrator and `useMergedFeatureEvents` stay with the deferred real-data wiring — they exist to fetch live data the dummy view doesn't need.) |
+| **(later)** | Replace the per-piece dummy wiring on `ImpactViewsPage` with a single cohesive dummy goal view / `GoalTrackingViewChart` if desired — optional polish, no new components. |
 | **Deferred** | **Top Movers / Flag Impact** (`computeFlagEventImpact`, `flagImpactFormatting`, `TopFlagMoversPanel`, `FlagImpactDialog`); real-data wiring; view editor + localStorage CRUD (`ViewEditorDialog`, `useImpactMetricViews`, `FeaturePicker`, `TemplatePickerDialog`, `ViewSwitcher`, `ImpactMetricViews`); system-health view (`SystemHealthViewChart`, `ViewChart` template router, `useAutoFollowedFeatureNames`, `useEnvironmentEvents`, `normalizeSeriesToBaseline`); the synthetic generator `simulateFlagContribution`. |
 
 ## Status
@@ -71,13 +71,26 @@ generators, the view editor, localStorage CRUD, and real-data wiring.
   + a temporary dummy preview (`fixtures/dummyGoalSummary.ts` rendered from
   `ImpactViewsPage`). The preview is throwaway — `ImpactViewsPage` is replaced by the full
   `GoalTrackingViewChart` later.
-- **PR 4** — in progress. `views/MultimetricChartCard/MultimetricChartCard.tsx` (render-only
-  layout card). **Note:** the branch version passed `highlightedEventId` / `eventImpactById`
-  to `<MultimetricChart>` and exported `FeatureEventImpactSummary` — but those `MultimetricChart`
-  props are **branch-only additions** (part of the deferred Top Movers / event-tooltip work)
-  and are NOT on `main`. They were stripped from the co-located card to keep it compiling
-  against `main`. When Top Movers lands, re-add them to both `MultimetricChart` and this card.
-- **PR 5+** — not started.
+- **PR 4** — merged. `views/MultimetricChartCard/MultimetricChartCard.tsx` (render-only layout
+  card, prop interface tightened to what the goal view needs). The page now renders the card
+  with dummy data and the `GoalSummaryPanel` in its `totalsHeaderSlot`. **Note:** the branch
+  version passed `highlightedEventId` / `eventImpactById` to `<MultimetricChart>` and exported
+  `FeatureEventImpactSummary` — those `MultimetricChart` props are **branch-only additions**
+  (deferred Top Movers / event-tooltip work), NOT on `main`, so they were stripped from the
+  co-located card. When Top Movers lands, re-add them to both `MultimetricChart` and this card.
+- **PR 5** — in progress. `views/FollowedFeaturesList/FollowedFeaturesList.tsx` rendered below
+  the chart card on the page. **Made presentational:** the branch version resolved each name
+  via a real `useFeatureSearch` call internally; that data fetching is **deferred to the
+  real-data phase**. The component now takes `features: ResolvedFeature[]` (name / project /
+  type / lifecycleStage / found) and only groups + renders them. The page passes
+  `DUMMY_FOLLOWED_FEATURES` with varied lifecycle stages, so the whole dummy view makes **no
+  API calls**. (Removed `SingleFeatureLoader`, the resolve state machine, and the loading
+  group → 550 → ~399 LOC.) When real data lands, add a small resolver that maps
+  `featureNames` → `ResolvedFeature[]` via `useFeatureSearch` and feeds this component.
+  Also removed the `PageContent` wrapper from `ImpactViewsPage`. After this the basic goal
+  view is visually complete (chart + goal panel + followed list).
+- **PR 6+** — deferred phase (real data incl. the followed-features resolver, editor +
+  localStorage, system-health, Top Movers).
 
 ## Decisions & context (for picking this up later)
 

--- a/frontend/src/component/impact-views/fixtures/dummyGoalSummary.ts
+++ b/frontend/src/component/impact-views/fixtures/dummyGoalSummary.ts
@@ -4,6 +4,7 @@ import type {
 } from 'component/impact-metrics/MultimetricChart/types';
 import type { MultimetricStep } from 'component/impact-metrics/MultimetricChart/MultimetricTotals';
 import { computeGoalSummary } from '../views/computeGoalSummary';
+import type { ResolvedFeature } from '../views/FollowedFeaturesList/FollowedFeaturesList';
 
 // Temporary dummy data so the chart card (with the goal summary panel in its
 // header slot) can be previewed on the page before real data / the full goal
@@ -12,6 +13,37 @@ import { computeGoalSummary } from '../views/computeGoalSummary';
 
 export const DUMMY_GOAL_METRIC_LABEL = 'checkout_completed_total';
 export const DUMMY_GOAL_TIME_LABEL = 'Last 30 days';
+
+export const DUMMY_FOLLOWED_FEATURES: ResolvedFeature[] = [
+    {
+        name: 'new-checkout-flow',
+        project: 'default',
+        type: 'release',
+        lifecycleStage: 'live',
+        found: true,
+    },
+    {
+        name: 'express-checkout',
+        project: 'default',
+        type: 'experiment',
+        lifecycleStage: 'pre-live',
+        found: true,
+    },
+    {
+        name: 'one-click-purchase',
+        project: 'payments',
+        type: 'release',
+        lifecycleStage: 'completed',
+        found: true,
+    },
+    {
+        name: 'legacy-cart',
+        project: 'default',
+        type: 'kill-switch',
+        lifecycleStage: 'archived',
+        found: true,
+    },
+];
 
 const HOUR_SEC = 60 * 60;
 const POINTS = 48;

--- a/frontend/src/component/impact-views/fixtures/dummyGoalSummary.ts
+++ b/frontend/src/component/impact-views/fixtures/dummyGoalSummary.ts
@@ -20,28 +20,24 @@ export const DUMMY_FOLLOWED_FEATURES: ResolvedFeature[] = [
         project: 'default',
         type: 'release',
         lifecycleStage: 'live',
-        found: true,
     },
     {
         name: 'express-checkout',
         project: 'default',
         type: 'experiment',
         lifecycleStage: 'pre-live',
-        found: true,
     },
     {
         name: 'one-click-purchase',
         project: 'payments',
         type: 'release',
         lifecycleStage: 'completed',
-        found: true,
     },
     {
         name: 'legacy-cart',
         project: 'default',
         type: 'kill-switch',
         lifecycleStage: 'archived',
-        found: true,
     },
 ];
 

--- a/frontend/src/component/impact-views/views/FollowedFeaturesList/FollowedFeaturesList.tsx
+++ b/frontend/src/component/impact-views/views/FollowedFeaturesList/FollowedFeaturesList.tsx
@@ -146,8 +146,72 @@ const StyledDash = styled('span')(({ theme }) => ({
     color: theme.palette.text.disabled,
 }));
 
-const groupLabel = (key: GroupKey): string =>
-    key === 'unknown' ? 'Not found' : getFeatureLifecycleName(key);
+const StageBadge: FC<{ stage: LifecycleStageName }> = ({ stage }) => (
+    <StyledStageWrapper>
+        <StyledStageIcon>
+            <FeatureLifecycleStageIcon stage={{ name: stage }} />
+        </StyledStageIcon>
+        <span>{getFeatureLifecycleName(stage)}</span>
+    </StyledStageWrapper>
+);
+
+const GroupHeaderRow: FC<{
+    groupKey: GroupKey;
+    count: number;
+    collapsed: boolean;
+    onToggle: () => void;
+}> = ({ groupKey, count, collapsed, onToggle }) => (
+    <StyledGroupRow>
+        <StyledGroupCell colSpan={4}>
+            <StyledGroupButton
+                type='button'
+                aria-expanded={!collapsed}
+                onClick={onToggle}
+            >
+                <StyledChevron>
+                    {collapsed ? <ChevronRightIcon /> : <ExpandMoreIcon />}
+                </StyledChevron>
+                {groupKey === 'unknown' ? (
+                    <span>Not found</span>
+                ) : (
+                    <>
+                        <StyledStageIcon>
+                            <FeatureLifecycleStageIcon
+                                stage={{ name: groupKey }}
+                            />
+                        </StyledStageIcon>
+                        <span>{getFeatureLifecycleName(groupKey)}</span>
+                    </>
+                )}
+                <StyledGroupCount>{count}</StyledGroupCount>
+            </StyledGroupButton>
+        </StyledGroupCell>
+    </StyledGroupRow>
+);
+
+const FeatureRow: FC<{ feature: ResolvedFeature }> = ({ feature }) => (
+    <TableRow>
+        <TableCell>
+            <StyledNameWrapper>
+                <StyledNameIcon>
+                    <FlagOutlinedIcon />
+                </StyledNameIcon>
+                <span>{feature.name}</span>
+            </StyledNameWrapper>
+        </TableCell>
+        <TableCell>{feature.project}</TableCell>
+        <TableCell sx={{ textTransform: 'capitalize' }}>
+            {feature.type}
+        </TableCell>
+        <TableCell>
+            {feature.lifecycleStage ? (
+                <StageBadge stage={feature.lifecycleStage} />
+            ) : (
+                <StyledDash>—</StyledDash>
+            )}
+        </TableCell>
+    </TableRow>
+);
 
 export type FollowedFeaturesListProps = {
     features: ResolvedFeature[];
@@ -193,94 +257,24 @@ export const FollowedFeaturesList: FC<FollowedFeaturesListProps> = ({
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        {groups.map(({ key, entries }) => {
-                            const isCollapsed = Boolean(collapsed[key]);
-                            const isStage = key !== 'unknown';
-
-                            return (
-                                <Fragment key={key}>
-                                    <StyledGroupRow>
-                                        <StyledGroupCell colSpan={4}>
-                                            <StyledGroupButton
-                                                type='button'
-                                                aria-expanded={!isCollapsed}
-                                                onClick={() => toggleGroup(key)}
-                                            >
-                                                <StyledChevron>
-                                                    {isCollapsed ? (
-                                                        <ChevronRightIcon />
-                                                    ) : (
-                                                        <ExpandMoreIcon />
-                                                    )}
-                                                </StyledChevron>
-                                                {isStage ? (
-                                                    <StyledStageIcon>
-                                                        <FeatureLifecycleStageIcon
-                                                            stage={{
-                                                                name: key,
-                                                            }}
-                                                        />
-                                                    </StyledStageIcon>
-                                                ) : null}
-                                                <span>{groupLabel(key)}</span>
-                                                <StyledGroupCount>
-                                                    {entries.length}
-                                                </StyledGroupCount>
-                                            </StyledGroupButton>
-                                        </StyledGroupCell>
-                                    </StyledGroupRow>
-                                    {!isCollapsed
-                                        ? entries.map((entry) => (
-                                              <TableRow key={entry.name}>
-                                                  <TableCell>
-                                                      <StyledNameWrapper>
-                                                          <StyledNameIcon>
-                                                              <FlagOutlinedIcon />
-                                                          </StyledNameIcon>
-                                                          <span>
-                                                              {entry.name}
-                                                          </span>
-                                                      </StyledNameWrapper>
-                                                  </TableCell>
-                                                  <TableCell>
-                                                      {entry.project}
-                                                  </TableCell>
-                                                  <TableCell
-                                                      sx={{
-                                                          textTransform:
-                                                              'capitalize',
-                                                      }}
-                                                  >
-                                                      {entry.type}
-                                                  </TableCell>
-                                                  <TableCell>
-                                                      {entry.lifecycleStage ? (
-                                                          <StyledStageWrapper>
-                                                              <StyledStageIcon>
-                                                                  <FeatureLifecycleStageIcon
-                                                                      stage={{
-                                                                          name: entry.lifecycleStage,
-                                                                      }}
-                                                                  />
-                                                              </StyledStageIcon>
-                                                              <span>
-                                                                  {getFeatureLifecycleName(
-                                                                      entry.lifecycleStage,
-                                                                  )}
-                                                              </span>
-                                                          </StyledStageWrapper>
-                                                      ) : (
-                                                          <StyledDash>
-                                                              —
-                                                          </StyledDash>
-                                                      )}
-                                                  </TableCell>
-                                              </TableRow>
-                                          ))
-                                        : null}
-                                </Fragment>
-                            );
-                        })}
+                        {groups.map(({ key, entries }) => (
+                            <Fragment key={key}>
+                                <GroupHeaderRow
+                                    groupKey={key}
+                                    count={entries.length}
+                                    collapsed={Boolean(collapsed[key])}
+                                    onToggle={() => toggleGroup(key)}
+                                />
+                                {!collapsed[key]
+                                    ? entries.map((entry) => (
+                                          <FeatureRow
+                                              key={entry.name}
+                                              feature={entry}
+                                          />
+                                      ))
+                                    : null}
+                            </Fragment>
+                        ))}
                     </TableBody>
                 </Table>
             </StyledSurface>

--- a/frontend/src/component/impact-views/views/FollowedFeaturesList/FollowedFeaturesList.tsx
+++ b/frontend/src/component/impact-views/views/FollowedFeaturesList/FollowedFeaturesList.tsx
@@ -25,21 +25,25 @@ export type LifecycleStageName =
 
 export type ResolvedFeature = {
     name: string;
-    project: string | null;
+    project: string;
+    type: string;
     lifecycleStage: LifecycleStageName | null;
-    type: string | null;
-    found: boolean;
 };
 
 type GroupKey = LifecycleStageName | 'unknown';
 
-const STAGE_ORDER: LifecycleStageName[] = [
+// Render order; 'unknown' (no resolvable lifecycle) always sits last.
+const GROUP_ORDER: GroupKey[] = [
     'initial',
     'pre-live',
     'live',
     'completed',
     'archived',
+    'unknown',
 ];
+
+const groupKeyOf = (feature: ResolvedFeature): GroupKey =>
+    feature.lifecycleStage ?? 'unknown';
 
 const StyledSectionHeader = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -154,25 +158,20 @@ export const FollowedFeaturesList: FC<FollowedFeaturesListProps> = ({
 }) => {
     const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
 
-    const groups = useMemo(() => {
-        const byKey: Record<string, ResolvedFeature[]> = {};
-        for (const feature of features) {
-            const key =
-                feature.found && feature.lifecycleStage
-                    ? feature.lifecycleStage
-                    : 'unknown';
-            if (!byKey[key]) byKey[key] = [];
-            byKey[key].push(feature);
-        }
-        return byKey;
-    }, [features]);
+    // Each lifecycle stage (then 'unknown'), in render order, with the
+    // features that belong to it. Empty groups are dropped.
+    const groups = useMemo(
+        () =>
+            GROUP_ORDER.map((key) => ({
+                key,
+                entries: features.filter(
+                    (feature) => groupKeyOf(feature) === key,
+                ),
+            })).filter((group) => group.entries.length > 0),
+        [features],
+    );
 
     if (features.length === 0) return null;
-
-    const orderedKeys: GroupKey[] = [
-        ...STAGE_ORDER.filter((key) => (groups[key] ?? []).length > 0),
-        ...(groups.unknown?.length ? (['unknown'] as const) : []),
-    ];
 
     const toggleGroup = (key: GroupKey) =>
         setCollapsed((prev) => ({ ...prev, [key]: !prev[key] }));
@@ -194,8 +193,7 @@ export const FollowedFeaturesList: FC<FollowedFeaturesListProps> = ({
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        {orderedKeys.map((key) => {
-                            const entries = groups[key] ?? [];
+                        {groups.map(({ key, entries }) => {
                             const isCollapsed = Boolean(collapsed[key]);
                             const isStage = key !== 'unknown';
 
@@ -245,11 +243,7 @@ export const FollowedFeaturesList: FC<FollowedFeaturesListProps> = ({
                                                       </StyledNameWrapper>
                                                   </TableCell>
                                                   <TableCell>
-                                                      {entry.project ?? (
-                                                          <StyledDash>
-                                                              —
-                                                          </StyledDash>
-                                                      )}
+                                                      {entry.project}
                                                   </TableCell>
                                                   <TableCell
                                                       sx={{
@@ -257,11 +251,7 @@ export const FollowedFeaturesList: FC<FollowedFeaturesListProps> = ({
                                                               'capitalize',
                                                       }}
                                                   >
-                                                      {entry.type ?? (
-                                                          <StyledDash>
-                                                              —
-                                                          </StyledDash>
-                                                      )}
+                                                      {entry.type}
                                                   </TableCell>
                                                   <TableCell>
                                                       {entry.lifecycleStage ? (

--- a/frontend/src/component/impact-views/views/FollowedFeaturesList/FollowedFeaturesList.tsx
+++ b/frontend/src/component/impact-views/views/FollowedFeaturesList/FollowedFeaturesList.tsx
@@ -1,0 +1,299 @@
+import { Fragment, useMemo, useState, type FC } from 'react';
+import {
+    Box,
+    Paper,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableRow,
+    Typography,
+    styled,
+} from '@mui/material';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import FlagOutlinedIcon from '@mui/icons-material/FlagOutlined';
+import { FeatureLifecycleStageIcon } from 'component/common/FeatureLifecycle/FeatureLifecycleStageIcon';
+import { getFeatureLifecycleName } from 'component/common/FeatureLifecycle/getFeatureLifecycleName';
+
+export type LifecycleStageName =
+    | 'initial'
+    | 'pre-live'
+    | 'live'
+    | 'completed'
+    | 'archived';
+
+export type ResolvedFeature = {
+    name: string;
+    project: string | null;
+    lifecycleStage: LifecycleStageName | null;
+    type: string | null;
+    found: boolean;
+};
+
+type GroupKey = LifecycleStageName | 'unknown';
+
+const STAGE_ORDER: LifecycleStageName[] = [
+    'initial',
+    'pre-live',
+    'live',
+    'completed',
+    'archived',
+];
+
+const StyledSectionHeader = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: theme.spacing(1),
+    marginBottom: theme.spacing(1.5),
+}));
+
+const StyledSectionTitle = styled(Typography)(({ theme }) => ({
+    fontSize: theme.fontSizes.bodySize,
+    fontWeight: theme.typography.fontWeightBold,
+    color: theme.palette.text.primary,
+}));
+
+const StyledSectionMeta = styled(Typography)(({ theme }) => ({
+    fontSize: theme.fontSizes.smallerBody,
+    color: theme.palette.text.secondary,
+}));
+
+const StyledSurface = styled(Paper)(({ theme }) => ({
+    borderRadius: theme.shape.borderRadiusLarge,
+    boxShadow: 'none',
+    border: `1px solid ${theme.palette.divider}`,
+    overflow: 'hidden',
+}));
+
+const StyledGroupRow = styled(TableRow)(({ theme }) => ({
+    backgroundColor: theme.palette.background.elevation1,
+}));
+
+const StyledGroupCell = styled(TableCell)(({ theme }) => ({
+    padding: theme.spacing(0.75, 2),
+    color: theme.palette.text.secondary,
+    fontSize: theme.fontSizes.smallerBody,
+    fontWeight: theme.typography.fontWeightBold,
+    letterSpacing: '0.04em',
+    textTransform: 'uppercase',
+}));
+
+const StyledGroupButton = styled('button')(({ theme }) => ({
+    all: 'unset',
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.75),
+    cursor: 'pointer',
+    '&:focus-visible': {
+        outline: `2px solid ${theme.palette.primary.main}`,
+        outlineOffset: 2,
+        borderRadius: theme.shape.borderRadius,
+    },
+}));
+
+const StyledChevron = styled(Box)(({ theme }) => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    color: theme.palette.text.disabled,
+    '& svg': { fontSize: 16 },
+}));
+
+const StyledStageIcon = styled(Box)({
+    display: 'inline-flex',
+    alignItems: 'center',
+    '& svg': {
+        height: 18,
+        width: 'auto',
+        display: 'block',
+    },
+});
+
+const StyledGroupCount = styled('span')(({ theme }) => ({
+    color: theme.palette.text.disabled,
+    fontWeight: theme.typography.fontWeightRegular,
+    textTransform: 'none',
+    letterSpacing: 0,
+    marginLeft: theme.spacing(0.25),
+}));
+
+const StyledNameWrapper = styled(Box)(({ theme }) => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    color: theme.palette.text.primary,
+    fontWeight: theme.typography.fontWeightMedium,
+}));
+
+const StyledNameIcon = styled(Box)(({ theme }) => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    color: theme.palette.text.disabled,
+    '& svg': { fontSize: 16 },
+}));
+
+const StyledStageWrapper = styled(Box)(({ theme }) => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.75),
+}));
+
+const StyledDash = styled('span')(({ theme }) => ({
+    color: theme.palette.text.disabled,
+}));
+
+const groupLabel = (key: GroupKey): string =>
+    key === 'unknown' ? 'Not found' : getFeatureLifecycleName(key);
+
+export type FollowedFeaturesListProps = {
+    features: ResolvedFeature[];
+};
+
+export const FollowedFeaturesList: FC<FollowedFeaturesListProps> = ({
+    features,
+}) => {
+    const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+
+    const groups = useMemo(() => {
+        const byKey: Record<string, ResolvedFeature[]> = {};
+        for (const feature of features) {
+            const key =
+                feature.found && feature.lifecycleStage
+                    ? feature.lifecycleStage
+                    : 'unknown';
+            if (!byKey[key]) byKey[key] = [];
+            byKey[key].push(feature);
+        }
+        return byKey;
+    }, [features]);
+
+    if (features.length === 0) return null;
+
+    const orderedKeys: GroupKey[] = [
+        ...STAGE_ORDER.filter((key) => (groups[key] ?? []).length > 0),
+        ...(groups.unknown?.length ? (['unknown'] as const) : []),
+    ];
+
+    const toggleGroup = (key: GroupKey) =>
+        setCollapsed((prev) => ({ ...prev, [key]: !prev[key] }));
+
+    return (
+        <Box>
+            <StyledSectionHeader>
+                <StyledSectionTitle>Followed features</StyledSectionTitle>
+                <StyledSectionMeta>{`${features.length} total`}</StyledSectionMeta>
+            </StyledSectionHeader>
+            <StyledSurface>
+                <Table>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell>Name</TableCell>
+                            <TableCell>Project</TableCell>
+                            <TableCell>Type</TableCell>
+                            <TableCell>Lifecycle stage</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {orderedKeys.map((key) => {
+                            const entries = groups[key] ?? [];
+                            const isCollapsed = Boolean(collapsed[key]);
+                            const isStage = key !== 'unknown';
+
+                            return (
+                                <Fragment key={key}>
+                                    <StyledGroupRow>
+                                        <StyledGroupCell colSpan={4}>
+                                            <StyledGroupButton
+                                                type='button'
+                                                aria-expanded={!isCollapsed}
+                                                onClick={() => toggleGroup(key)}
+                                            >
+                                                <StyledChevron>
+                                                    {isCollapsed ? (
+                                                        <ChevronRightIcon />
+                                                    ) : (
+                                                        <ExpandMoreIcon />
+                                                    )}
+                                                </StyledChevron>
+                                                {isStage ? (
+                                                    <StyledStageIcon>
+                                                        <FeatureLifecycleStageIcon
+                                                            stage={{
+                                                                name: key,
+                                                            }}
+                                                        />
+                                                    </StyledStageIcon>
+                                                ) : null}
+                                                <span>{groupLabel(key)}</span>
+                                                <StyledGroupCount>
+                                                    {entries.length}
+                                                </StyledGroupCount>
+                                            </StyledGroupButton>
+                                        </StyledGroupCell>
+                                    </StyledGroupRow>
+                                    {!isCollapsed
+                                        ? entries.map((entry) => (
+                                              <TableRow key={entry.name}>
+                                                  <TableCell>
+                                                      <StyledNameWrapper>
+                                                          <StyledNameIcon>
+                                                              <FlagOutlinedIcon />
+                                                          </StyledNameIcon>
+                                                          <span>
+                                                              {entry.name}
+                                                          </span>
+                                                      </StyledNameWrapper>
+                                                  </TableCell>
+                                                  <TableCell>
+                                                      {entry.project ?? (
+                                                          <StyledDash>
+                                                              —
+                                                          </StyledDash>
+                                                      )}
+                                                  </TableCell>
+                                                  <TableCell
+                                                      sx={{
+                                                          textTransform:
+                                                              'capitalize',
+                                                      }}
+                                                  >
+                                                      {entry.type ?? (
+                                                          <StyledDash>
+                                                              —
+                                                          </StyledDash>
+                                                      )}
+                                                  </TableCell>
+                                                  <TableCell>
+                                                      {entry.lifecycleStage ? (
+                                                          <StyledStageWrapper>
+                                                              <StyledStageIcon>
+                                                                  <FeatureLifecycleStageIcon
+                                                                      stage={{
+                                                                          name: entry.lifecycleStage,
+                                                                      }}
+                                                                  />
+                                                              </StyledStageIcon>
+                                                              <span>
+                                                                  {getFeatureLifecycleName(
+                                                                      entry.lifecycleStage,
+                                                                  )}
+                                                              </span>
+                                                          </StyledStageWrapper>
+                                                      ) : (
+                                                          <StyledDash>
+                                                              —
+                                                          </StyledDash>
+                                                      )}
+                                                  </TableCell>
+                                              </TableRow>
+                                          ))
+                                        : null}
+                                </Fragment>
+                            );
+                        })}
+                    </TableBody>
+                </Table>
+            </StyledSurface>
+        </Box>
+    );
+};


### PR DESCRIPTION
## About the changes

Adds the **followed-features list** — the last display piece of the basic goal-tracking view — and wires the full dummy view on `/impact-views`. After this, the basic goal view is visually complete: chart card (chart + goal summary panel) on top, followed-features list below, all from dummy data with **no API calls**.

## Table implementation tradeoff — discussion point

This list is built with **raw MUI `<Table>`** + a hand-rolled collapsible grouping, which **diverges from the codebase-standard table approach** (`@tanstack/react-table` via the shared `PaginatedTable` / `VirtualizedTable`, with `useConditionallyHiddenColumns` for responsive hiding).

**Why it's raw MUI here:** the list groups rows by lifecycle stage into **collapsible sections**. That grouping/collapse doesn't map cleanly onto the shared table components, which are built for flat, sortable, paginated lists. Forcing it into react-table would be a larger rewrite for arguably worse ergonomics on the grouping.