### PR TITLE
chore: project onboarding steps shown simplification

### DIFF
--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.test.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.test.tsx
@@ -261,7 +261,7 @@ test('renders lifecycle quick filters', async () => {
     await screen.findByText(/Cleanup/);
 }, 10000);
 
-test('shows new onboarding steps when flag is enabled and project is not onboarded', async () => {
+test('shows onboarding steps when flag is enabled and project is not onboarded', async () => {
     const projectId = 'default';
     setupApi();
     testServerRoute(server, '/api/admin/ui-config', {
@@ -282,7 +282,7 @@ test('shows new onboarding steps when flag is enabled and project is not onboard
     await screen.findByText('Project setup');
 }, 10000);
 
-test('hides new onboarding when user dismissed the flow', async () => {
+test('hides onboarding when user dismissed the flow', async () => {
     const projectId = 'default';
     setupApi();
     testServerRoute(server, '/api/admin/ui-config', {
@@ -305,56 +305,6 @@ test('hides new onboarding when user dismissed the flow', async () => {
         { route: `/projects/${projectId}` },
     );
     expect(screen.queryByText('Project setup')).not.toBeInTheDocument();
-}, 10000);
-
-test('hides new onboarding when project is onboarded and setup state is hide-setup', async () => {
-    const projectId = 'default';
-    setupApi();
-    testServerRoute(server, '/api/admin/ui-config', {
-        flags: { flagCreator: true },
-    });
-    testServerRoute(server, '/api/admin/projects/default/overview', {
-        onboardingStatus: { status: 'onboarded' },
-    });
-    setLocalStorageItem(
-        ':onboarding-state:v1-default:localStorage:v2',
-        'hide-setup',
-    );
-    render(
-        <Routes>
-            <Route
-                path={'/projects/:projectId'}
-                element={<ProjectFeatureToggles environments={[]} />}
-            />
-        </Routes>,
-        { route: `/projects/${projectId}` },
-    );
-    expect(screen.queryByText('Project setup')).not.toBeInTheDocument();
-}, 10000);
-
-test('keeps onboarding visible for users with old-flow show-setup localStorage state', async () => {
-    const projectId = 'default';
-    setupApi();
-    testServerRoute(server, '/api/admin/ui-config', {
-        flags: { flagCreator: true },
-    });
-    testServerRoute(server, '/api/admin/projects/default/overview', {
-        onboardingStatus: { status: 'onboarded' },
-    });
-    setLocalStorageItem(
-        ':onboarding-state:v1-default:localStorage:v2',
-        'show-setup',
-    );
-    render(
-        <Routes>
-            <Route
-                path={'/projects/:projectId'}
-                element={<ProjectFeatureToggles environments={[]} />}
-            />
-        </Routes>,
-        { route: `/projects/${projectId}` },
-    );
-    await screen.findByText('Project setup');
 }, 10000);
 
 test('clears lifecycle filter when switching to archived view', async () => {

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.test.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.test.tsx
@@ -5,7 +5,6 @@ import { ProjectFeatureToggles } from './ProjectFeatureToggles.tsx';
 import { testServerRoute, testServerSetup } from 'utils/testServer';
 import { fireEvent, screen } from '@testing-library/react';
 import { BATCH_SELECTED_COUNT } from 'utils/testIds';
-import { setLocalStorageItem } from 'utils/storage';
 
 const server = testServerSetup();
 

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.test.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.test.tsx
@@ -282,31 +282,6 @@ test('shows onboarding steps when flag is enabled and project is not onboarded',
     await screen.findByText('Project setup');
 }, 10000);
 
-test('hides onboarding when user dismissed the flow', async () => {
-    const projectId = 'default';
-    setupApi();
-    testServerRoute(server, '/api/admin/ui-config', {
-        flags: { flagCreator: true },
-    });
-    testServerRoute(server, '/api/admin/projects/default/overview', {
-        onboardingStatus: { status: 'onboarding-started' },
-    });
-    setLocalStorageItem(
-        ':onboarding-flow:v1-default:localStorage:v2',
-        'closed',
-    );
-    render(
-        <Routes>
-            <Route
-                path={'/projects/:projectId'}
-                element={<ProjectFeatureToggles environments={[]} />}
-            />
-        </Routes>,
-        { route: `/projects/${projectId}` },
-    );
-    expect(screen.queryByText('Project setup')).not.toBeInTheDocument();
-}, 10000);
-
 test('clears lifecycle filter when switching to archived view', async () => {
     setupApi();
     testServerRoute(server, '/api/admin/ui-config', {

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
@@ -168,18 +168,19 @@ export const ProjectFeatureToggles = ({
 
     const isPlaceholder = Boolean(initialLoad || loading);
 
+    const isOnboarded = project.onboardingStatus.status === 'onboarded';
+
     const [onboardingFlow, setOnboardingFlow] = useLocalStorageState<
         'visible' | 'closed'
-    >(`onboarding-flow:v1-${projectId}`, 'visible');
-    const [setupCompletedState] = useLocalStorageState<
-        'hide-setup' | 'show-setup'
-    >(`onboarding-state:v1-${projectId}`, 'hide-setup');
+    >(`onboarding-flow:v1-${projectId}`, 'closed');
 
-    const isOnboarded = project.onboardingStatus.status === 'onboarded';
-    const userCompletedOldOnboardingFlow =
-        isOnboarded && setupCompletedState === 'hide-setup';
-    const showNewOnboarding =
-        onboardingFlow === 'visible' && !userCompletedOldOnboardingFlow;
+    useEffect(() => {
+        if (!isPlaceholder && !isOnboarded) {
+            setOnboardingFlow('visible');
+        }
+    }, [isPlaceholder, isOnboarded]);
+
+    const showNewOnboarding = onboardingFlow === 'visible';
 
     const showCleanupReminder = !tableState.lastSeenAt && !tableState.lifecycle;
     const showArchived = Boolean(tableState.archived);
@@ -483,17 +484,14 @@ export const ProjectFeatureToggles = ({
 
     return (
         <Container>
-            <ConditionallyRender
-                condition={showNewOnboarding}
-                show={() => (
-                    <ProjectOnboarding
-                        projectId={projectId}
-                        setConnectSdkOpen={setConnectSdkOpen}
-                        setOnboardingFlow={setOnboardingFlow}
-                        refetchFeatures={refetch}
-                    />
-                )}
-            />
+            {showNewOnboarding && (
+                <ProjectOnboarding
+                    projectId={projectId}
+                    setConnectSdkOpen={setConnectSdkOpen}
+                    setOnboardingFlow={setOnboardingFlow}
+                    refetchFeatures={refetch}
+                />
+            )}
             {showCleanupReminder ? (
                 <ProjectCleanupReminder projectId={projectId} />
             ) : null}


### PR DESCRIPTION
addressing feedback from https://github.com/Unleash/unleash/pull/12155

1. If the user lands on the project for the first time (logout resets it) and it's already onboarded then don't show project onboarding to that user
2. If the project is NOT onboarded show the onboarding steps and remember that in localStorage. User will see completed steps until they dismiss them. (or log-out and visit the page with a fresh session -> then it's point 1). 