### PR TITLE
fix: Profile tab navigation with React Router `v7_startTransition`

### DIFF
--- a/frontend/src/component/user/Profile/Profile.tsx
+++ b/frontend/src/component/user/Profile/Profile.tsx
@@ -41,10 +41,11 @@ export const Profile = () => {
         });
     };
 
-    const foundTab = tabs.find(
+    const visibleTabs = tabs.filter((tab) => !tab.hidden);
+    const foundTab = visibleTabs.find(
         ({ path }) => path && location.pathname.includes(path),
     );
-    const tab = (foundTab || tabs[0]).id;
+    const tab = (foundTab || visibleTabs[0] || tabs[0]).id;
 
     if (loading) return null;
 

--- a/frontend/src/component/user/Profile/Profile.tsx
+++ b/frontend/src/component/user/Profile/Profile.tsx
@@ -5,7 +5,6 @@ import {
 } from 'component/common/VerticalTabs/VerticalTabs';
 import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
 import useAuthSettings from 'hooks/api/getters/useAuthSettings/useAuthSettings';
-import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { PasswordTab } from './PasswordTab/PasswordTab.tsx';
 import { PersonalAPITokensTab } from './PersonalAPITokensTab/PersonalAPITokensTab.tsx';
@@ -40,20 +39,12 @@ export const Profile = () => {
         navigate(tab.path ? `/profile/${tab.path}` : '/profile', {
             replace: true,
         });
-        setTab(tab.id);
     };
 
-    const tabFromUrl = () => {
-        const url = location.pathname;
-        const foundTab = tabs.find(({ path }) => path && url.includes(path));
-        return (foundTab || tabs[0]).id;
-    };
-
-    const [tab, setTab] = useState(tabFromUrl());
-
-    useEffect(() => {
-        setTab(tabFromUrl());
-    }, [location]);
+    const foundTab = tabs.find(
+        ({ path }) => path && location.pathname.includes(path),
+    );
+    const tab = (foundTab || tabs[0]).id;
 
     if (loading) return null;
 


### PR DESCRIPTION
### What

Make the URL the single source of truth for the active Profile tab: drop the redundant `setTab` in `onChange` and derive the tab from `location.pathname` during render (removing the `useState`/`useEffect` mirror).

### Why it was broken

`v7_startTransition` wraps navigation in `React.startTransition`, so it becomes a deferred update. But `onChange` also called `setTab` — an urgent update — which mounted the new tab's content *before* the URL changed. The Personal API tokens tab writes `setSearchParams(..., { replace: true })` on mount, so it replaced the still-pending navigation using the *old* pathname, collapsing the URL back to the previous tab and snapping the UI back. PAT was the only affected tab because it's the only one that writes search params on mount.
### The fix

Removing the urgent `setTab` means nothing front-runs the deferred navigation, and deriving the tab from the URL each render keeps a single source of truth. The PAT tab now mounts only after the URL has settled, so its `setSearchParams` writes against the correct path and navigation works for all tabs.
