### PR TITLE
chore: replace feature page impace metrics empty state

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureImpactOverview/FeatureImpactHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureImpactOverview/FeatureImpactHeader.tsx
@@ -1,12 +1,11 @@
 import type { FC } from 'react';
 import { useLocalStorageState } from 'hooks/useLocalStorageState';
 import { Button, Collapse, styled, Typography } from '@mui/material';
-import { Badge } from 'component/common/Badge/Badge';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import Add from '@mui/icons-material/Add';
 import { useFeatureImpactMetrics } from 'hooks/api/getters/useFeatureImpactMetrics/useFeatureImpactMetrics';
-import { PlaceholderChart } from './ImpactDashboard/PlaceholderChart';
+import { ImpactMetricsEmptyState } from './ImpactMetricsEmptyState';
 import { CompactChartCard } from './CompactChartCard';
 import { GroupedChartCard } from './GroupedChartCard';
 import { groupImpactConfigs, multimetricFirst } from './groupImpactConfigs';
@@ -70,12 +69,6 @@ const StyledExpandedContent = styled('div')(({ theme }) => ({
     backgroundColor: theme.palette.background.elevation2,
 }));
 
-const StyledEmptyDescription = styled(Typography)(({ theme }) => ({
-    fontSize: theme.fontSizes.smallBody,
-    color: theme.palette.text.secondary,
-    maxWidth: '100%',
-}));
-
 const StyledChartRow = styled('div')(({ theme }) => ({
     display: 'grid',
     gridTemplateColumns: 'repeat(3, 1fr)',
@@ -87,12 +80,6 @@ const StyledChartRow = styled('div')(({ theme }) => ({
         gridTemplateColumns: '1fr',
     },
 }));
-
-const StyledConnectButton = styled(Button)({
-    textTransform: 'none',
-    whiteSpace: 'nowrap',
-    flexShrink: 0,
-});
 
 const StyledFooter = styled('div')(({ theme }) => ({
     padding: theme.spacing(2, 3, 2),
@@ -119,6 +106,9 @@ export const FeatureImpactHeader: FC<FeatureImpactHeaderProps> = ({
             'impact-metrics-accordion:expanded',
             'closed',
         );
+    const [bannerState, setBannerState] = useLocalStorageState<
+        'open' | 'closed'
+    >('impact-metrics-banner:dismissed', 'open');
     const { trackEvent } = usePlausibleTracker();
     const { trackAccordionOpened, trackAddMetricClicked } =
         useTrackFlagpageImpactMetrics();
@@ -151,71 +141,15 @@ export const FeatureImpactHeader: FC<FeatureImpactHeaderProps> = ({
     };
 
     if (!hasMetrics) {
+        if (bannerState === 'closed') {
+            return null;
+        }
+
         return (
-            <StyledContainer>
-                <StyledHeaderBar
-                    role='button'
-                    tabIndex={0}
-                    aria-expanded={expanded}
-                    aria-label='Toggle impact metrics details'
-                    onClick={toggleExpanded}
-                    onKeyDown={onHeaderKeyDown}
-                >
-                    <StyledImpactLabel>
-                        <StyledImpactTitle>
-                            Measure the impact of this feature
-                        </StyledImpactTitle>
-                        <Badge color='success' sx={{ ml: 1 }}>
-                            New
-                        </Badge>
-                    </StyledImpactLabel>
-                    <StyledRightSection sx={{ marginLeft: 'auto' }}>
-                        <StyledConnectButton
-                            variant='outlined'
-                            startIcon={<Add />}
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                trackEvent('flagpage-impact-metrics', {
-                                    props: {
-                                        eventType: 'add-impact-metric-clicked',
-                                    },
-                                });
-                                trackAddMetricClicked();
-                                onAddChart();
-                            }}
-                        >
-                            Add impact metric
-                        </StyledConnectButton>
-                        {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-                    </StyledRightSection>
-                </StyledHeaderBar>
-                <Collapse in={expanded}>
-                    <StyledExpandedContent>
-                        <StyledEmptyDescription>
-                            Connect your metrics to see how this feature affects
-                            adoption, error counts, latency, and other key
-                            indicators during rollout.
-                        </StyledEmptyDescription>
-                        <StyledChartRow>
-                            <PlaceholderChart
-                                title='Adoption'
-                                change='+1,204'
-                                variant='upward'
-                            />
-                            <PlaceholderChart
-                                title='Errors'
-                                change='3'
-                                variant='downward'
-                            />
-                            <PlaceholderChart
-                                title='Latency (p95)'
-                                change='~230ms'
-                                variant='stable'
-                            />
-                        </StyledChartRow>
-                    </StyledExpandedContent>
-                </Collapse>
-            </StyledContainer>
+            <ImpactMetricsEmptyState
+                onAddChart={onAddChart}
+                onDismiss={() => setBannerState('closed')}
+            />
         );
     }
 

--- a/frontend/src/component/feature/FeatureView/FeatureImpactOverview/ImpactDashboard/PlaceholderChart.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureImpactOverview/ImpactDashboard/PlaceholderChart.tsx
@@ -75,7 +75,7 @@ export const PlaceholderChart: FC<PlaceholderChartProps> = ({
                 borderColor: placeholderColor,
                 backgroundColor: placeholderFill,
                 fill: true,
-                tension: 0.4,
+                tension: 0,
                 pointRadius: 2,
                 pointBackgroundColor: placeholderColor,
                 borderWidth: 2,

--- a/frontend/src/component/feature/FeatureView/FeatureImpactOverview/ImpactMetricsEmptyState.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureImpactOverview/ImpactMetricsEmptyState.tsx
@@ -1,0 +1,82 @@
+import { Button, styled } from '@mui/material';
+import Add from '@mui/icons-material/Add';
+import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
+import { PlaceholderChart } from './ImpactDashboard/PlaceholderChart';
+import { usePlausibleTracker } from 'hooks/usePlausibleTracker';
+import { useTrackFlagpageImpactMetrics } from 'component/impact-metrics/useImpactMetricsFunnel';
+import { FeatureSetupGuideBanner } from '../FeatureOverview/FeatureSetupGuideBanner/FeatureSetupGuideBanner';
+
+const StyledChartRow = styled('div')(({ theme }) => ({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gap: theme.spacing(2),
+    [theme.breakpoints.down('lg')]: {
+        gridTemplateColumns: 'repeat(2, 1fr)',
+    },
+    [theme.breakpoints.down('sm')]: {
+        gridTemplateColumns: '1fr',
+    },
+}));
+
+interface ImpactMetricsEmptyStateProps {
+    onAddChart: () => void;
+    onDismiss: () => void;
+}
+
+export const ImpactMetricsEmptyState = ({
+    onAddChart,
+    onDismiss,
+}: ImpactMetricsEmptyStateProps) => {
+    const { trackEvent } = usePlausibleTracker();
+    const { trackAddMetricClicked } = useTrackFlagpageImpactMetrics();
+
+    return (
+        <FeatureSetupGuideBanner
+            icon={<LightbulbOutlined />}
+            aria-label='Measure the impact of this flag'
+            title='Tip: Measure the impact of this flag'
+            subtitle='Connect your metrics to see how this feature affects adoption, error counts, latency, and other key indicators during rollout.'
+            actions={
+                <>
+                    <Button
+                        variant='outlined'
+                        startIcon={<Add />}
+                        onClick={() => {
+                            trackEvent('flagpage-impact-metrics', {
+                                props: {
+                                    eventType: 'add-impact-metric-clicked',
+                                },
+                            });
+                            trackAddMetricClicked();
+                            onAddChart();
+                        }}
+                        sx={{ textTransform: 'none' }}
+                    >
+                        Add impact metric
+                    </Button>
+                    <Button variant='text' onClick={onDismiss}>
+                        Dismiss
+                    </Button>
+                </>
+            }
+        >
+            <StyledChartRow>
+                <PlaceholderChart
+                    title='Adoption'
+                    change='+1,204'
+                    variant='upward'
+                />
+                <PlaceholderChart
+                    title='Errors'
+                    change='3'
+                    variant='downward'
+                />
+                <PlaceholderChart
+                    title='Latency (p95)'
+                    change='~230ms'
+                    variant='stable'
+                />
+            </StyledChartRow>
+        </FeatureSetupGuideBanner>
+    );
+};

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureSetupGuideBanner/FeatureSetupGuideBanner.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureSetupGuideBanner/FeatureSetupGuideBanner.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react';
+import { Alert, type AlertProps, styled, Typography } from '@mui/material';
+
+const StyledBody = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+}));
+
+const StyledTitle = styled(Typography)(({ theme }) => ({
+    fontWeight: theme.typography.fontWeightBold,
+    fontSize: theme.fontSizes.bodySize,
+    color: theme.palette.text.primary,
+}));
+
+const StyledSubtitle = styled(Typography)(({ theme }) => ({
+    fontSize: theme.fontSizes.smallBody,
+    color: theme.palette.text.secondary,
+}));
+
+const StyledActions = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(3),
+}));
+
+interface FeatureSetupGuideBannerProps
+    extends Omit<AlertProps, 'severity' | 'color' | 'variant'> {
+    subtitle: ReactNode;
+    actions: ReactNode;
+    children?: ReactNode;
+}
+
+export const FeatureSetupGuideBanner = ({
+    icon,
+    title,
+    subtitle,
+    actions,
+    children,
+    ...props
+}: FeatureSetupGuideBannerProps) => (
+    <Alert severity='info' icon={icon} {...props}>
+        <StyledBody>
+            <div>
+                <StyledTitle>{title}</StyledTitle>
+                <StyledSubtitle>{subtitle}</StyledSubtitle>
+            </div>
+            {children}
+            <StyledActions>{actions}</StyledActions>
+        </StyledBody>
+    </Alert>
+);


### PR DESCRIPTION
- Replaces the empty state of `FeatureImpactHeader` with a dismissible banner
- Stores in local storage wether the "Dismiss" button has been clicked
- Adds reusable `FeatureSetupGuideBanner` (which can be reused for the other feature flag set up guidance banners)


https://github.com/user-attachments/assets/bb0e95de-135c-4621-896e-3be5776186d3



