### PR TITLE
chore: include CLA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,9 @@ Closes #
 
 ## Discussion points
 
-## OSS CLA checklist
+## OSS PR checklist
 
 - [ ] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
 - [ ] I have added tests or explained why tests are not needed.
+- [ ] I have updated documentation where relevant.
 - [ ] I have updated documentation where relevant.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## About the changes
+
+Closes #
+
+### Important files
+
+## Discussion points
+
+## OSS CLA checklist
+
+- [ ] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
+- [ ] I have added tests or explained why tests are not needed.
+- [ ] I have updated documentation where relevant.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,62 @@
+# Unleash Contributor License Agreement
+
+Thank you for your interest in contributing to Unleash.
+
+This Contributor License Agreement ("Agreement") documents the terms under which you may submit contributions to Unleash. It is intended to clarify the intellectual property rights granted with contributions, while preserving your ownership of your own work.
+
+By accepting this Agreement, you agree to the following terms for your present and future contributions to Unleash.
+
+## 1. Definitions
+
+"You" means the copyright owner or legal entity authorized by the copyright owner that is accepting this Agreement. If you accept this Agreement on behalf of an organization, "You" includes that organization and any entities that control, are controlled by, or are under common control with that organization.
+
+"Unleash" means the legal entity that owns or manages the Unleash project and the repositories to which you submit contributions.
+
+"Contribution" means any original work of authorship, including any modification or addition to an existing work, that you intentionally submit to Unleash for inclusion in, or documentation of, any Unleash project. "Submit" includes sending work through GitHub, issue trackers, source code control systems, mailing lists, chat, or other channels used by Unleash to discuss and improve the project. Work that you clearly mark in writing as "Not a Contribution" is not a Contribution.
+
+## 2. Copyright license
+
+Subject to the terms of this Agreement, you grant Unleash a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, relicense, and distribute your Contributions and derivative works.
+
+Recipients of software distributed by Unleash receive the rights granted by the license under which Unleash distributes that software.
+
+## 3. Patent license
+
+Subject to the terms of this Agreement, you grant Unleash and recipients of software distributed by Unleash a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer your Contributions. This license applies only to patent claims that you can license and that are necessarily infringed by your Contributions alone or by combining your Contributions with the project to which they were submitted.
+
+If any entity institutes patent litigation against you or another entity alleging that your Contribution, or the project to which you contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or project terminate as of the date such litigation is filed.
+
+## 4. Your representations
+
+You represent that:
+
+- You are legally entitled to grant the licenses described in this Agreement.
+- If your employer or another organization has rights to intellectual property that you create, you have received permission to make the Contribution, the organization has waived those rights for the Contribution, or the organization has accepted this Agreement.
+- Each Contribution is your original creation, except for work submitted under section 5.
+- You are not aware of any third-party license, restriction, or obligation that would prevent Unleash from using your Contribution under this Agreement.
+
+## 5. Third-party work
+
+If you submit work that is not your original creation, you must identify the complete details of its source and any license or other restriction that you are aware of. Mark that work clearly as:
+
+```text
+Submitted on behalf of a third party: [name]
+```
+
+## 6. No support obligation
+
+You are not expected to provide support for your Contributions unless you choose to do so. You may provide support for free, for a fee, or not at all.
+
+## 7. No warranty
+
+Unless required by applicable law or agreed to in writing, you provide your Contributions on an "AS IS" basis, without warranties or conditions of any kind, either express or implied, including warranties or conditions of title, non-infringement, merchantability, or fitness for a particular purpose.
+
+## 8. Ownership
+
+You retain ownership of your Contributions. This Agreement does not prevent you from using your Contributions for any other purpose.
+
+The licenses you grant to Unleash under this Agreement are irrevocable and survive any later withdrawal request, so Unleash may continue to use, distribute, sublicense, and relicense Contributions that were submitted under this Agreement.
+
+## 9. Acceptance
+
+Unleash uses a pull request CLA check to record acceptance of this Agreement. When requested, provide your full name, email address, GitHub username, and whether you are signing on your own behalf or on behalf of an organization.

--- a/CLA.md
+++ b/CLA.md
@@ -59,4 +59,4 @@ The licenses you grant to Unleash under this Agreement are irrevocable and survi
 
 ## 9. Acceptance
 
-Unleash uses a pull request CLA check to record acceptance of this Agreement. When requested, provide your full name, email address, GitHub username, and whether you are signing on your own behalf or on behalf of an organization.
+Unleash records acceptance of this Agreement via a pull request CLA check. When prompted by that check, provide the requested details through the check UI (do not post personal information in the pull request discussion).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <br/>
 <br/>
 
-[![Build and Tests](https://img.shields.io/github/actions/workflow/status/Unleash/unleash/build.yaml?branch=main)](https://github.com/Unleash/unleash/actions/workflows/build.yaml) [![Coverage Report](https://img.shields.io/badge/coverage-vitest-green)](https://github.com/Unleash/unleash/actions/workflows/build_coverage.yaml) [![Docker Pulls](https://img.shields.io/docker/pulls/unleashorg/unleash-server)](https://hub.docker.com/r/unleashorg/unleash-server) [![Apache-2.0 license](https://img.shields.io/github/license/unleash/unleash)](https://github.com/Unleash/unleash/blob/main/LICENSE) [![Join Unleash on Slack](https://img.shields.io/badge/slack-join-635dc5?logo=slack)](https://slack.unleash.run)
+[![Build and Tests](https://img.shields.io/github/actions/workflow/status/Unleash/unleash/build.yaml?branch=main)](https://github.com/Unleash/unleash/actions/workflows/build.yaml) [![Coverage Report](https://img.shields.io/badge/coverage-vitest-green)](https://github.com/Unleash/unleash/actions/workflows/build_coverage.yaml) [![Docker Pulls](https://img.shields.io/docker/pulls/unleashorg/unleash-server)](https://hub.docker.com/r/unleashorg/unleash-server) [![AGPL-3.0-or-later license](https://img.shields.io/github/license/unleash/unleash)](https://github.com/Unleash/unleash/blob/main/LICENSE) [![Join Unleash on Slack](https://img.shields.io/badge/slack-join-635dc5?logo=slack)](https://slack.unleash.run)
 
 [Launch the live demo](https://www.getunleash.io/interactive-demo?utm_source=readme&utm_medium=oss&utm_content=top-cta) | [Try Unleash Enterprise for free](https://www.getunleash.io/plans/enterprise-payg?utm_source=readme&utm_medium=oss&utm_content=top-cta)
 
@@ -130,7 +130,7 @@ We know that learning a new tool can be hard and time-consuming. We have a growi
 
 Unleash is the largest [open-source feature flag solution](https://www.getunleash.io/) on GitHub. Building Unleash is a collaborative effort, and we owe a lot of gratitude to many smart and talented individuals. Building it together with the community ensures that we build a product that solves real problems for real people. We'd love to have your help too: Please feel free to open issues or provide pull requests.
 
-Check out [the CONTRIBUTING.md file](./contributing/CONTRIBUTING.md) for contribution guidelines and the [Unleash developer guide](https://docs.getunleash.io/contribute) for tips on environment setup, running the tests, and running Unleash from source.
+Check out [the CONTRIBUTING.md file](./contributing/CONTRIBUTING.md) for contribution guidelines and the [Unleash developer guide](https://docs.getunleash.io/contribute) for tips on environment setup, running the tests, and running Unleash from source. Before a pull request can be merged, contributors must read and agree to the [Unleash Contributor License Agreement](./CLA.md).
 
 ### Contributors
 

--- a/contributing/CONTRIBUTING.md
+++ b/contributing/CONTRIBUTING.md
@@ -5,11 +5,22 @@
 Before you begin:
 
 - Have you read the [code of conduct](../CODE_OF_CONDUCT.md)?
+- Have you read and agreed to the [Unleash Contributor License Agreement](../CLA.md)?
 - Check out the [existing issues](https://github.com/unleash/Unleash/issues)
 - Browse the [developer-guide](https://docs.getunleash.io/contribute) for tips on environment setup, running the tests, and running Unleash from source.
 - You need
   - Node 22
   - corepack enabled `corepack enable`
+
+### Contributor License Agreement
+
+Before we can merge a pull request, every human contributor must read and agree to the [Unleash Contributor License Agreement](../CLA.md). The CLA keeps ownership of your contribution with you while giving Unleash the rights needed to use, distribute, sublicense, and relicense contributions.
+
+When you open a pull request, the CLA check will ask you to confirm the agreement with your GitHub account. If you are contributing on behalf of your employer or another organization, make sure you are authorized to do so before signing.
+
+Please do not add new individual copyright headers to files. Git history and pull request history record contribution attribution. Preserve existing third-party copyright and license notices when they are already present or when you are explicitly importing third-party work.
+
+If your contribution includes AI-generated code, documentation, or other content, disclose that in the pull request, review the generated content carefully, and make sure the tool terms allow you to contribute it under the CLA and repository license.
 
 ### Don't see your issue? Open one
 


### PR DESCRIPTION
## About the changes

This introduces a lightweight Contributor License Agreement process for the OSS repository after the move to AGPL.

The goal is to make contribution rights explicit without adding unnecessary friction for community contributors. Contributors keep ownership of their work, while Unleash receives the permissions needed to continue developing, distributing, and, when needed, relicensing accepted contributions.

The process is intentionally simple: contributors acknowledge the agreement as part of the pull request flow, and automated dependency updates can continue through the existing bot workflow. This gives the project a clearer long-term governance trail while keeping day-to-day contributions familiar.

## Discussion points

- Legal should review the final CLA wording before the signing flow is treated as authoritative.
- Maintainers will still need to configure the external CLA check and branch protection after this lands.
- The policy avoids adding individual copyright headers to source files; attribution remains based on the project history and review trail.