### PR TITLE
chore: remove deltaDiff parity logic

### DIFF
--- a/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
@@ -3,11 +3,7 @@ import type { Response } from 'express';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import hashSum from 'hash-sum';
 import Controller from '../../routes/controller.js';
-import type {
-    IClientSegment,
-    IFlagResolver,
-    IUnleashConfig,
-} from '../../types/index.js';
+import type { IClientSegment, IUnleashConfig } from '../../types/index.js';
 import type { FeatureToggleService } from '../feature-toggle/feature-toggle-service.js';
 import type { Logger } from '../../logger.js';
 import { querySchema } from '../../schema/feature-schema.js';
@@ -38,8 +34,6 @@ import {
     CLIENT_METRICS_PROJECT,
     CLIENT_METRICS_TAGS,
 } from '../../internals.js';
-import isEqual from 'lodash.isequal';
-import { diff } from 'json-diff';
 import type { IUnleashServices } from '../../services/index.js';
 
 const version = 2;
@@ -67,8 +61,6 @@ export default class FeatureController extends Controller {
     private configurationRevisionService: ConfigurationRevisionService;
 
     private featureToggleService: FeatureToggleService;
-
-    private flagResolver: IFlagResolver;
 
     private eventBus: EventEmitter;
 
@@ -101,7 +93,6 @@ export default class FeatureController extends Controller {
         this.openApiService = openApiService;
         this.configurationRevisionService = configurationRevisionService;
         this.featureToggleService = featureToggleService;
-        this.flagResolver = config.flagResolver;
         this.eventBus = config.eventBus;
         this.logger = config.getLogger('client-api/feature.js');
 
@@ -163,55 +154,6 @@ export default class FeatureController extends Controller {
     private async resolveFeaturesAndSegments(
         query?: IFeatureToggleQuery,
     ): Promise<[FeatureConfigurationClient[], IClientSegment[]]> {
-        if (this.flagResolver.isEnabled('deltaDiff')) {
-            const features =
-                await this.clientFeatureToggleService.getClientFeatures(query);
-
-            const segments =
-                await this.clientFeatureToggleService.getActiveSegmentsForClient();
-
-            try {
-                const delta =
-                    await this.clientFeatureToggleService.getClientDelta(
-                        undefined,
-                        query!,
-                    );
-
-                const sortedToggles = features.sort((a, b) =>
-                    a.name.localeCompare(b.name),
-                );
-                if (delta?.events[0].type === 'hydration') {
-                    const hydrationEvent = delta?.events[0];
-                    const sortedNewToggles = hydrationEvent.features.sort(
-                        (a, b) => a.name.localeCompare(b.name),
-                    );
-
-                    if (
-                        !this.deepEqualIgnoreOrder(
-                            sortedToggles,
-                            sortedNewToggles,
-                        )
-                    ) {
-                        this.logger.warn(
-                            `old features and new features are different. Old count ${
-                                features.length
-                            }, new count ${hydrationEvent.features.length}, query ${JSON.stringify(query)},
-                        diff ${JSON.stringify(
-                            diff(sortedToggles, sortedNewToggles),
-                        )}`,
-                        );
-                    }
-                } else {
-                    this.logger.warn(
-                        `Delta diff should have only hydration event, query ${JSON.stringify(query)}`,
-                    );
-                }
-            } catch (e) {
-                this.logger.error('Delta diff failed', e);
-            }
-
-            return [features, segments];
-        }
         return Promise.all([
             this.clientFeatureToggleService.getClientFeatures(query),
             this.clientFeatureToggleService.getActiveSegmentsForClient(),
@@ -384,14 +326,4 @@ export default class FeatureController extends Controller {
             },
         );
     }
-
-    deepEqualIgnoreOrder = (obj1, obj2) => {
-        const sortedObj1 = JSON.parse(
-            JSON.stringify(obj1, Object.keys(obj1).sort()),
-        );
-        const sortedObj2 = JSON.parse(
-            JSON.stringify(obj2, Object.keys(obj2).sort()),
-        );
-        return isEqual(sortedObj1, sortedObj2);
-    };
 }

--- a/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
@@ -34,7 +34,6 @@ import {
 import type ConfigurationRevisionService from '../feature-toggle/configuration-revision-service.js';
 import type { ClientFeatureToggleService } from './client-feature-toggle-service.js';
 import {
-    CLIENT_FEATURES_MEMORY,
     CLIENT_METRICS_NAMEPREFIX,
     CLIENT_METRICS_PROJECT,
     CLIENT_METRICS_TAGS,
@@ -72,8 +71,6 @@ export default class FeatureController extends Controller {
     private flagResolver: IFlagResolver;
 
     private eventBus: EventEmitter;
-
-    private clientFeaturesCacheMap = new Map<string, number>();
 
     private featuresAndSegments: (
         query: IFeatureToggleQuery,
@@ -174,13 +171,6 @@ export default class FeatureController extends Controller {
                 await this.clientFeatureToggleService.getActiveSegmentsForClient();
 
             try {
-                const featuresSize = this.getCacheSizeInBytes(features);
-                const segmentsSize = this.getCacheSizeInBytes(segments);
-                this.clientFeaturesCacheMap.set(
-                    JSON.stringify(query),
-                    featuresSize + segmentsSize,
-                );
-
                 const delta =
                     await this.clientFeatureToggleService.getClientDelta(
                         undefined,
@@ -216,8 +206,6 @@ export default class FeatureController extends Controller {
                         `Delta diff should have only hydration event, query ${JSON.stringify(query)}`,
                     );
                 }
-
-                this.storeFootprint();
             } catch (e) {
                 this.logger.error('Delta diff failed', e);
             }
@@ -395,19 +383,6 @@ export default class FeatureController extends Controller {
                 ...toggle,
             },
         );
-    }
-
-    storeFootprint() {
-        let memory = 0;
-        for (const value of this.clientFeaturesCacheMap.values()) {
-            memory += value;
-        }
-        this.eventBus.emit(CLIENT_FEATURES_MEMORY, { memory });
-    }
-
-    getCacheSizeInBytes(value: any): number {
-        const jsonString = JSON.stringify(value);
-        return Buffer.byteLength(jsonString, 'utf8');
     }
 
     deepEqualIgnoreOrder = (obj1, obj2) => {

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -178,8 +178,6 @@ export class ClientFeatureToggleDelta extends EventEmitter {
 
     private readonly segmentReadModel: ISegmentReadModel;
 
-    private eventBus: EventEmitter;
-
     private readonly logger: Logger;
 
     constructor(
@@ -196,7 +194,6 @@ export class ClientFeatureToggleDelta extends EventEmitter {
             clientFeatureToggleDeltaReadModel;
         this.flagResolver = flagResolver;
         this.segmentReadModel = segmentReadModel;
-        this.eventBus = config.eventBus;
         this.logger = config.getLogger('delta/client-feature-toggle-delta.js');
         this.onUpdateRevisionEvent = this.onUpdateRevisionEvent.bind(this);
         this.delta = {};

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta.ts
@@ -13,7 +13,6 @@ import type {
     FeatureConfigurationDeltaClient,
     IClientFeatureToggleDeltaReadModel,
 } from './client-feature-toggle-delta-read-model-type.js';
-import { CLIENT_DELTA_MEMORY } from '../../../metric-events.js';
 import EventEmitter from 'events';
 import type { Logger } from '../../../logger.js';
 import type { ClientFeaturesDeltaSchema } from '../../../openapi/index.js';
@@ -308,7 +307,6 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         if (this.flagResolver.isEnabled('deltaApi')) {
             try {
                 await this.updateFeaturesDelta();
-                this.storeFootprint();
                 this.emit(UPDATE_DELTA);
             } catch (e) {
                 if (e instanceof BadDataError) {
@@ -583,7 +581,6 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         this.lastDeltaProcessedRevisionId = maxRevision;
         this.visibleRevisions[environment] = revisionState;
         deltaRevisionIdMetric.labels({ environment }).set(maxRevision);
-        this.storeFootprint();
     }
 
     private updateVisibleRevisions(
@@ -661,20 +658,6 @@ export class ClientFeatureToggleDelta extends EventEmitter {
         const result =
             await this.clientFeatureToggleDeltaReadModel.getAll(query);
         return result;
-    }
-
-    storeFootprint() {
-        try {
-            const memory = this.getCacheSizeInBytes(this.delta);
-            this.eventBus.emit(CLIENT_DELTA_MEMORY, { memory });
-        } catch (e) {
-            this.logger.error('Client delta footprint error', e);
-        }
-    }
-
-    getCacheSizeInBytes(value: any): number {
-        const jsonString = JSON.stringify(value);
-        return Buffer.byteLength(jsonString, 'utf8');
     }
 }
 

--- a/src/lib/metric-events.ts
+++ b/src/lib/metric-events.ts
@@ -19,8 +19,6 @@ const AUTH_LOGIN_COMPLETED = 'auth-login-completed' as const;
 const CLIENT_METRICS_NAMEPREFIX = 'client-api-nameprefix';
 const CLIENT_METRICS_TAGS = 'client-api-tags';
 const CLIENT_METRICS_PROJECT = 'client-api-project';
-const CLIENT_FEATURES_MEMORY = 'client_features_memory';
-const CLIENT_DELTA_MEMORY = 'client_delta_memory';
 const CLIENT_REGISTERED = 'client_registered';
 const IMPACT_METRICS_QUERY_TIME = 'impact_metrics_query_time';
 
@@ -42,8 +40,6 @@ type MetricEvent =
     | typeof CLIENT_METRICS_NAMEPREFIX
     | typeof CLIENT_METRICS_TAGS
     | typeof CLIENT_METRICS_PROJECT
-    | typeof CLIENT_FEATURES_MEMORY
-    | typeof CLIENT_DELTA_MEMORY
     | typeof IMPACT_METRICS_QUERY_TIME;
 
 type RequestOriginEventPayload = {
@@ -112,8 +108,6 @@ export {
     CLIENT_METRICS_NAMEPREFIX,
     CLIENT_METRICS_TAGS,
     CLIENT_METRICS_PROJECT,
-    CLIENT_FEATURES_MEMORY,
-    CLIENT_DELTA_MEMORY,
     CLIENT_REGISTERED,
     IMPACT_METRICS_QUERY_TIME,
     type MetricEvent,

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -731,16 +731,6 @@ export function registerPrometheusMetrics(
         help: 'Number of API tokens without a project',
     });
 
-    const clientFeaturesMemory = createGauge({
-        name: 'client_features_memory',
-        help: 'The amount of memory client features endpoint is using for caching',
-    });
-
-    const clientDeltaMemory = createGauge({
-        name: 'client_delta_memory',
-        help: 'The amount of memory client features delta endpoint is using for caching',
-    });
-
     const orphanedTokensActive = createGauge({
         name: 'orphaned_api_tokens_active',
         help: 'Number of API tokens without a project, last seen within 3 months',
@@ -930,15 +920,6 @@ export function registerPrometheusMetrics(
         },
     );
 
-    eventBus.on(events.CLIENT_FEATURES_MEMORY, (event: { memory: number }) => {
-        clientFeaturesMemory.reset();
-        clientFeaturesMemory.set(event.memory);
-    });
-
-    eventBus.on(events.CLIENT_DELTA_MEMORY, (event: { memory: number }) => {
-        clientDeltaMemory.reset();
-        clientDeltaMemory.set(event.memory);
-    });
     eventBus.on(
         events.CLIENT_REGISTERED,
         ({ appName, environment, interval }) => {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -51,7 +51,6 @@ export type IFlagKey =
     | 'streaming'
     | 'denyStreamingForNonEdge'
     | 'deltaApi'
-    | 'deltaDiff'
     | 'uniqueSdkTracking'
     | 'consumptionModel'
     | 'consumptionModelUI'
@@ -241,10 +240,6 @@ const flags: IFlags = {
     ),
     deltaApi: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_DELTA_API,
-        false,
-    ),
-    deltaDiff: parseEnvVarBoolean(
-        process.env.UNLEASH_EXPERIMENTAL_DELTA_DIFF,
         false,
     ),
     uniqueSdkTracking: parseEnvVarBoolean(


### PR DESCRIPTION
Reduce memory footprint by removing obsolete Unleash-side deltaDiff parity diagnostics and cache-footprint metrics that serialized client feature and delta cache configuration payloads.

Drift can now be detected from the Edge side, so this removes the extra Unleash-side comparison/measurement path.