### PR TITLE
fix: remove SDK registration and metrics `environment` field

### DIFF
--- a/src/lib/features/frontend-api/frontend-api-service.ts
+++ b/src/lib/features/frontend-api/frontend-api-service.ts
@@ -133,15 +133,14 @@ export class FrontendApiService {
         const environment =
             this.services.clientMetricsServiceV2.resolveMetricsEnvironment(
                 token as ApiUser,
-                metrics,
             );
 
         await this.services.clientMetricsServiceV2.registerClientMetrics(
             {
                 ...metrics,
-                environment,
             },
             ip,
+            environment,
         );
 
         // Because we're keeping impact metrics out of the client schema for now,

--- a/src/lib/features/metrics/client-metrics/client-metrics-service.e2e.test.ts
+++ b/src/lib/features/metrics/client-metrics/client-metrics-service.e2e.test.ts
@@ -55,10 +55,12 @@ test('Apps registered should be announced', async () => {
     await clientInstanceService.registerBackendClient(
         clientRegistration,
         '127.0.0.1',
+        'default',
     );
     await clientInstanceService.registerBackendClient(
         differentClient,
         '127.0.0.1',
+        'default',
     );
     await clientInstanceService.bulkAdd(); // in prod called by a SchedulerService
     const first = await stores.clientApplicationsStore.getUnannounced();
@@ -66,6 +68,7 @@ test('Apps registered should be announced', async () => {
     await clientInstanceService.registerBackendClient(
         clientRegistration,
         '127.0.0.1',
+        'default',
     );
     await clientInstanceService.announceUnannounced(); // in prod called by a SchedulerService
     const second = await stores.clientApplicationsStore.getUnannounced();

--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.test.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.test.ts
@@ -60,6 +60,7 @@ test('process metrics properly', async () => {
         .fn<() => Promise<string[]>>()
         .mockResolvedValue(['myCoolToggle', 'myOtherToggle']);
 
+    const environment = 'test';
     await clientMetricsService.registerClientMetrics(
         {
             appName: 'test',
@@ -82,9 +83,9 @@ test('process metrics properly', async () => {
                     },
                 },
             },
-            environment: 'test',
         },
         '127.0.0.1',
+        environment,
     );
 
     expect(eventBus.emit).toHaveBeenCalledTimes(1);
@@ -94,6 +95,7 @@ test('process metrics properly', async () => {
 test('process metrics properly even when some names are not url friendly, filtering out invalid names when flag is on', async () => {
     const { clientMetricsService, eventBus, lastSeenService } =
         initClientMetrics();
+    const environment = 'test';
     await clientMetricsService.registerClientMetrics(
         {
             appName: 'test',
@@ -107,9 +109,9 @@ test('process metrics properly even when some names are not url friendly, filter
                     },
                 },
             },
-            environment: 'test',
         },
         '127.0.0.1',
+        environment,
     );
 
     // only toggle with a bad name gets filtered out

--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -300,7 +300,7 @@ export default class ClientMetricsServiceV2 {
         ).map((name) => ({
             featureName: name,
             appName: value.appName,
-            environment: environment ?? 'default',
+            environment,
             timestamp: bucket.stop, //we might need to approximate between start/stop...
             yes: bucket.toggles[name].yes ?? 0,
             no: bucket.toggles[name].no ?? 0,
@@ -414,7 +414,7 @@ export default class ClientMetricsServiceV2 {
                             no: 0,
                             yes: 0,
                             appName,
-                            environment: environment ?? 'default',
+                            environment,
                             featureName,
                         }
                     );

--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -269,6 +269,7 @@ export default class ClientMetricsServiceV2 {
     async registerClientMetrics(
         data: ClientMetricsSchema,
         _clientIp: string,
+        environment: string,
     ): Promise<void> {
         const value = await clientMetricsSchema.validateAsync(data);
 
@@ -299,7 +300,7 @@ export default class ClientMetricsServiceV2 {
         ).map((name) => ({
             featureName: name,
             appName: value.appName,
-            environment: value.environment ?? 'default',
+            environment: environment ?? 'default',
             timestamp: bucket.stop, //we might need to approximate between start/stop...
             yes: bucket.toggles[name].yes ?? 0,
             no: bucket.toggles[name].no ?? 0,
@@ -413,7 +414,7 @@ export default class ClientMetricsServiceV2 {
                             no: 0,
                             yes: 0,
                             appName,
-                            environment,
+                            environment: environment ?? 'default',
                             featureName,
                         }
                     );
@@ -423,15 +424,10 @@ export default class ClientMetricsServiceV2 {
         return result.sort((a, b) => compareAsc(a.timestamp, b.timestamp));
     }
 
-    resolveMetricsEnvironment(
-        user: IUser | IApiUser,
-        data: { environment?: string },
-    ): string {
+    resolveMetricsEnvironment(user: IUser | IApiUser): string {
         if (user instanceof ApiUser) {
             if (user.environment !== ALL) {
                 return user.environment;
-            } else if (user.environment === ALL && data.environment) {
-                return data.environment;
             }
         }
         return 'default';

--- a/src/lib/features/metrics/instance/instance-service.test.ts
+++ b/src/lib/features/metrics/instance/instance-service.test.ts
@@ -270,13 +270,14 @@ test('`registerInstance` sets `instanceId` to `default` if it is not provided', 
         config,
         {} as any,
     );
+    const environment = '';
 
     await instanceService.registerInstance(
         {
             appName: 'appName',
-            environment: '',
         },
         '::1',
+        environment,
     );
 
     expect(instanceService.seenClients.appName_default).toMatchObject({
@@ -304,18 +305,20 @@ describe('upserting into `seenClients`', () => {
             [key]: { ...client, sdkVersion: 'my-sdk' },
         };
 
+        const environment = 'blue';
+
         await instanceService.registerInstance(
             {
                 ...client,
-                environment: 'blue',
             },
             '::1',
+            environment,
         );
 
         expect(instanceService.seenClients[key]).toMatchObject({
             appName: 'appName',
             instanceId: 'instanceId',
-            environment: 'blue',
+            environment: environment,
             sdkVersion: 'my-sdk',
         });
     });
@@ -343,6 +346,7 @@ describe('upserting into `seenClients`', () => {
                 sdkVersion: 'my-sdk',
                 started: new Date(),
                 interval: 5,
+                environment: 'blue',
             },
             '::1',
         );

--- a/src/lib/features/metrics/instance/instance-service.test.ts
+++ b/src/lib/features/metrics/instance/instance-service.test.ts
@@ -46,10 +46,10 @@ test('Multiple registrations of same appname and instanceid within same time per
         started: new Date(),
         interval: 10,
     };
-    await clientMetrics.registerBackendClient(client1, '127.0.0.1');
-    await clientMetrics.registerBackendClient(client1, '127.0.0.1');
-    await clientMetrics.registerBackendClient(client1, '127.0.0.1');
-    await clientMetrics.registerBackendClient(client1, '127.0.0.1');
+    await clientMetrics.registerBackendClient(client1, '127.0.0.1', 'default');
+    await clientMetrics.registerBackendClient(client1, '127.0.0.1', 'default');
+    await clientMetrics.registerBackendClient(client1, '127.0.0.1', 'default');
+    await clientMetrics.registerBackendClient(client1, '127.0.0.1', 'default');
 
     await clientMetrics.bulkAdd(); // in prod called by a SchedulerService
 
@@ -104,12 +104,12 @@ test('Multiple unique clients causes multiple registrations', async () => {
         started: new Date(),
         interval: 10,
     };
-    await clientMetrics.registerBackendClient(client1, '127.0.0.1');
-    await clientMetrics.registerBackendClient(client1, '127.0.0.1');
-    await clientMetrics.registerBackendClient(client1, '127.0.0.1');
-    await clientMetrics.registerBackendClient(client2, '127.0.0.1');
-    await clientMetrics.registerBackendClient(client2, '127.0.0.1');
-    await clientMetrics.registerBackendClient(client2, '127.0.0.1');
+    await clientMetrics.registerBackendClient(client1, '127.0.0.1', 'default');
+    await clientMetrics.registerBackendClient(client1, '127.0.0.1', 'default');
+    await clientMetrics.registerBackendClient(client1, '127.0.0.1', 'default');
+    await clientMetrics.registerBackendClient(client2, '127.0.0.1', 'default');
+    await clientMetrics.registerBackendClient(client2, '127.0.0.1', 'default');
+    await clientMetrics.registerBackendClient(client2, '127.0.0.1', 'default');
 
     await clientMetrics.bulkAdd(); // in prod called by a SchedulerService
     const registrations: IClientApp[] = appStoreSpy.mock
@@ -147,15 +147,15 @@ test('Same client registered outside of dedup interval will be registered twice'
         started: new Date(),
         interval: 10,
     };
-    await clientMetrics.registerBackendClient(client1, '127.0.0.1');
-    await clientMetrics.registerBackendClient(client1, '127.0.0.1');
-    await clientMetrics.registerBackendClient(client1, '127.0.0.1');
+    await clientMetrics.registerBackendClient(client1, '127.0.0.1', 'default');
+    await clientMetrics.registerBackendClient(client1, '127.0.0.1', 'default');
+    await clientMetrics.registerBackendClient(client1, '127.0.0.1', 'default');
 
     await clientMetrics.bulkAdd(); // in prod called by a SchedulerService
 
-    await clientMetrics.registerBackendClient(client1, '127.0.0.1');
-    await clientMetrics.registerBackendClient(client1, '127.0.0.1');
-    await clientMetrics.registerBackendClient(client1, '127.0.0.1');
+    await clientMetrics.registerBackendClient(client1, '127.0.0.1', 'default');
+    await clientMetrics.registerBackendClient(client1, '127.0.0.1', 'default');
+    await clientMetrics.registerBackendClient(client1, '127.0.0.1', 'default');
 
     await clientMetrics.bulkAdd(); // in prod called by a SchedulerService
 
@@ -337,25 +337,28 @@ describe('upserting into `seenClients`', () => {
         const key = instanceService.clientKey(client);
 
         instanceService.seenClients = {
-            [key]: { ...client, environment: 'blue' },
+            [key]: {
+                ...client,
+                sdkVersion: 'previously-seen-sdk',
+                environment: 'blue',
+            },
         };
 
         await instanceService.registerBackendClient(
             {
                 ...client,
-                sdkVersion: 'my-sdk',
                 started: new Date(),
                 interval: 5,
-                environment: 'blue',
             },
             '::1',
+            'not-merged',
         );
 
         expect(instanceService.seenClients[key]).toMatchObject({
             appName: 'appName',
             instanceId: 'instanceId',
             environment: 'blue',
-            sdkVersion: 'my-sdk',
+            sdkVersion: 'previously-seen-sdk',
         });
     });
     test('registerFrontendClient merges its data', async () => {

--- a/src/lib/features/metrics/instance/instance-service.ts
+++ b/src/lib/features/metrics/instance/instance-service.ts
@@ -128,12 +128,15 @@ export default class ClientInstanceService {
     public async registerBackendClient(
         data: PartialSome<IClientApp, 'instanceId'>,
         clientIp: string,
+        environment: string,
     ): Promise<void> {
         const value = await clientRegisterSchema.validateAsync(data);
         value.clientIp = clientIp;
         value.createdBy = SYSTEM_USER.username!;
         value.sdkType = 'backend';
-        value.environment = data.environment;
+
+        const existing = this.seenClients[this.clientKey(value)];
+        value.environment = existing?.environment ?? environment; // existing or from the authenticated API token
 
         this.updateSeenClient(value);
         this.eventBus.emit(CLIENT_REGISTERED, value);

--- a/src/lib/features/metrics/instance/instance-service.ts
+++ b/src/lib/features/metrics/instance/instance-service.ts
@@ -107,16 +107,14 @@ export default class ClientInstanceService {
     };
 
     public async registerInstance(
-        data: Pick<
-            ClientMetricsSchema,
-            'appName' | 'instanceId' | 'environment'
-        >,
+        data: Pick<ClientMetricsSchema, 'appName' | 'instanceId'>,
         clientIp: string,
+        environment: string,
     ): Promise<void> {
         this.updateSeenClient({
             appName: data.appName,
             instanceId: data.instanceId ?? 'default',
-            environment: data.environment,
+            environment,
             clientIp: clientIp,
         });
     }
@@ -135,6 +133,8 @@ export default class ClientInstanceService {
         value.clientIp = clientIp;
         value.createdBy = SYSTEM_USER.username!;
         value.sdkType = 'backend';
+        value.environment = data.environment;
+
         this.updateSeenClient(value);
         this.eventBus.emit(CLIENT_REGISTERED, value);
 

--- a/src/lib/features/metrics/instance/metrics.ts
+++ b/src/lib/features/metrics/instance/metrics.ts
@@ -256,13 +256,23 @@ export default class ClientMetricsController extends Controller {
         if (this.config.flagResolver.isEnabled('disableMetrics')) {
             res.status(204).end();
         } else {
-            const { body } = req;
+            const { body, user } = req;
             const clientIp = extractClientIp(req);
             const { metrics, applications, impactMetrics } = body;
             const promises: Promise<void>[] = [];
 
+            // when an app omits its `environment` and
+            // the filter on raw `metrics[]` entries — only metrics
+            // matching the token's scope are persisted
+            const acceptedEnvironment =
+                this.metricsV2.resolveUserEnvironment(user);
+
             try {
                 for (const app of applications) {
+                    // per app `environment` from the body - when this bulk endpoint
+                    // forwards metrics from many environments for edge proxies
+                    const appEnvironment =
+                        app.environment ?? acceptedEnvironment;
                     if (
                         app.sdkType === 'frontend' &&
                         typeof app.sdkVersion === 'string'
@@ -270,7 +280,7 @@ export default class ClientMetricsController extends Controller {
                         this.clientInstanceService.registerFrontendClient({
                             appName: app.appName,
                             instanceId: app.instanceId,
-                            environment: app.environment,
+                            environment: appEnvironment,
                             sdkType: app.sdkType,
                             sdkVersion: app.sdkVersion,
                             projects: app.projects,
@@ -280,6 +290,7 @@ export default class ClientMetricsController extends Controller {
                             this.clientInstanceService.registerBackendClient(
                                 app,
                                 clientIp,
+                                appEnvironment,
                             ),
                         );
                     }
@@ -287,9 +298,6 @@ export default class ClientMetricsController extends Controller {
                 if (metrics && metrics.length > 0) {
                     const data: IClientMetricsEnv[] =
                         await clientMetricsEnvBulkSchema.validateAsync(metrics);
-                    const { user } = req;
-                    const acceptedEnvironment =
-                        this.metricsV2.resolveUserEnvironment(user);
                     const filteredData = data.filter(
                         (metric) => metric.environment === acceptedEnvironment,
                     );

--- a/src/lib/features/metrics/instance/metrics.ts
+++ b/src/lib/features/metrics/instance/metrics.ts
@@ -179,16 +179,19 @@ export default class ClientMetricsController extends Controller {
                 const { body: data, user } = req;
                 const clientIp = extractClientIp(req);
                 const { impactMetrics, ...metricsData } = data;
-                metricsData.environment =
-                    this.metricsV2.resolveMetricsEnvironment(user, metricsData);
+                const environment =
+                    this.metricsV2.resolveMetricsEnvironment(user);
+
                 await this.clientInstanceService.registerInstance(
                     metricsData,
                     clientIp,
+                    environment,
                 );
 
                 await this.metricsV2.registerClientMetrics(
                     metricsData,
                     clientIp,
+                    environment,
                 );
                 if (impactMetrics) {
                     await this.metricsV2.registerImpactMetrics(

--- a/src/lib/features/metrics/instance/register.ts
+++ b/src/lib/features/metrics/instance/register.ts
@@ -90,10 +90,14 @@ export default class RegisterController extends Controller {
     ): Promise<void> {
         const { body: data, user } = req;
         const clientIp = extractClientIp(req);
-        data.environment = this.resolveEnvironment(user);
+        const environment = this.resolveEnvironment(user); // derived from the API token only
         data.projects = this.resolveProject(user);
 
-        await this.clientInstanceService.registerBackendClient(data, clientIp);
+        await this.clientInstanceService.registerBackendClient(
+            data,
+            clientIp,
+            environment,
+        );
         res.header('X-Unleash-Version', version).status(202).end();
     }
 }

--- a/src/lib/features/metrics/instance/register.ts
+++ b/src/lib/features/metrics/instance/register.ts
@@ -6,7 +6,6 @@ import type { IUnleashConfig } from '../../../types/option.js';
 import type { Logger } from '../../../logger.js';
 import type ClientInstanceService from './instance-service.js';
 import type { IAuthRequest, IUser } from '../../../types/index.js';
-import type { IClientApp } from '../../../types/model.js';
 import ApiUser, { type IApiUser } from '../../../types/api-user.js';
 import { ALL } from '../../../types/models/api-token.js';
 import { NONE } from '../../../types/permissions.js';
@@ -69,15 +68,10 @@ export default class RegisterController extends Controller {
         });
     }
 
-    private resolveEnvironment(
-        user: IUser | IApiUser,
-        data: Partial<IClientApp>,
-    ) {
+    private resolveEnvironment(user: IUser | IApiUser) {
         if (user instanceof ApiUser) {
             if (user.environment !== ALL) {
                 return user.environment;
-            } else if (user.environment === ALL && data.environment) {
-                return data.environment;
             }
         }
         return 'default';
@@ -96,7 +90,7 @@ export default class RegisterController extends Controller {
     ): Promise<void> {
         const { body: data, user } = req;
         const clientIp = extractClientIp(req);
-        data.environment = this.resolveEnvironment(user, data);
+        data.environment = this.resolveEnvironment(user);
         data.projects = this.resolveProject(user);
 
         await this.clientInstanceService.registerBackendClient(data, clientIp);

--- a/src/lib/features/metrics/shared/schema.ts
+++ b/src/lib/features/metrics/shared/schema.ts
@@ -15,8 +15,7 @@ const countSchema = joi
     });
 
 // validated type from client-metrics-schema.ts with default values
-export type ValidatedClientMetrics = {
-    environment?: string;
+type ValidatedClientMetrics = {
     appName: string;
     instanceId: string;
     bucket?: IMetricsBucket;
@@ -26,7 +25,6 @@ export const clientMetricsSchema = joi
     .object<ValidatedClientMetrics>()
     .options({ stripUnknown: true })
     .keys({
-        environment: joi.string().optional(),
         appName: joi.string().required(),
         instanceId: joi.string().empty(['', null]).default('default'),
         // bucket is optional: requests carrying only impact metrics may omit it
@@ -47,7 +45,6 @@ export const clientMetricsEnvSchema = joi
     .options({ stripUnknown: true })
     .keys({
         featureName: joi.string().required().allow(''),
-        environment: joi.string().required(),
         appName: joi.string().required(),
         yes: joi.number().default(0),
         no: joi.number().default(0),
@@ -175,7 +172,6 @@ export const clientRegisterSchema = joi
         strategies: joi.array().items(joi.string(), joi.any().strip()),
         started: joi.date().required(),
         interval: joi.number().required(),
-        environment: joi.string().optional(),
         project: joi.string().optional(),
         projects: joi.array().optional().items(joi.string()),
     });

--- a/src/lib/features/metrics/shared/schema.ts
+++ b/src/lib/features/metrics/shared/schema.ts
@@ -45,6 +45,7 @@ export const clientMetricsEnvSchema = joi
     .options({ stripUnknown: true })
     .keys({
         featureName: joi.string().required().allow(''),
+        environment: joi.string().required(),
         appName: joi.string().required(),
         yes: joi.number().default(0),
         no: joi.number().default(0),

--- a/src/lib/openapi/spec/client-application-schema.ts
+++ b/src/lib/openapi/spec/client-application-schema.ts
@@ -24,12 +24,6 @@ export const clientApplicationSchema = {
                 'An SDK version identifier. Usually formatted as "unleash-client-<language>:<version>"',
             example: 'unleash-client-java:7.0.0',
         },
-        environment: {
-            description: `The SDK's configured 'environment' property. This property was deprecated in v5. This property  does **not** control which Unleash environment the SDK gets toggles for. To control Unleash environments, use the SDKs API key.`,
-            deprecated: true,
-            type: 'string',
-            example: 'development',
-        },
         platformName: {
             description:
                 'The platform the application is running on. For languages that compile to binaries, this can be omitted',

--- a/src/lib/openapi/spec/client-metrics-schema.ts
+++ b/src/lib/openapi/spec/client-metrics-schema.ts
@@ -20,13 +20,6 @@ export const clientMetricsSchema = {
             type: 'string',
             example: 'application-name-dacb1234',
         },
-        environment: {
-            description:
-                'Which environment the application is running in. This property was deprecated in v5. This can be determined by the API key calling this endpoint.',
-            type: 'string',
-            example: 'development',
-            deprecated: true,
-        },
         sdkVersion: {
             type: 'string',
             description:


### PR DESCRIPTION
## About the changes

We still hold environment field on SDK registration and metrics payloads despite being deprecated in v5. 

Here, we enforce the `environment` to be inferred from the API token rather than client-provided payload metadata.

Before:

```
resolveMetricsEnvironment(user, data) {
    if (user instanceof ApiUser) {
        if (user.environment !== ALL) {
            return user.environment;
        } else if (user.environment === ALL && data.environment) {
            return data.environment;    // <-- the change - this is GONE!
        }
    }
    return 'default';
}
```

Meaning that, when a wildcard-scoped token POSTs metrics with `environment` in the body, the server uses the body's value. But, now, the `environment` is not part of the schema, so, we remove the body field and metric attribution, thus, path changes to 'default' for those callers.

**Who's not affected**: everyone using narrow-scoped tokens (the already documented + recommended path, most customers do already).

**Who's affected**: users with instance-wide API tokens (environment='*'). The token-issuer doesn't fail, the metric just gets attributed to the wrong bucket. We already track these users and they are notified for the deprecation change. Thus, we assume no risk at the moment.

#### SDK situation 

The `unleash-node-sdk` already doesn't send `environment` in its [registration payload](https://github.com/Unleash/unleash-node-sdk/blob/747d20550595e08371a8bbb6f9825c5590588e55/src/metrics.ts#L414-#L426).
✔️  Node SDK users

But, even if any other SDK sends the `environment` field, the server silently drops it via Joi `stripUnknown: true`. 
✔️ No SDK breakage 



### In a nutshell, here, we:
- update OSS schemas (no environment params)
- remove the wildcard fallback on server logic part
- preserve-from-seenClients semantics (as broken test unveiled)
- adapt tests on new logic


Closes #EG-4386

## Discussion points

Update documentation with a note to explain that v8 attributes metrics from the token's environment, and customers using wildcard tokens for metrics need to issue narrower tokens or accept aggregation to default.


## OSS PR checklist

- [x] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [ ] I have added tests or explained why tests are not needed.
- [ ] I have updated documentation where relevant.
