### PR TITLE
chore: add timing metric for old project list path

### DIFF
--- a/src/lib/features/project/project-service.ts
+++ b/src/lib/features/project/project-service.ts
@@ -240,6 +240,7 @@ export default class ProjectService {
         query?: IProjectQuery & IProjectsQuery,
         userId?: number,
     ): Promise<ProjectForUi[]> {
+        const stopTimer = this.timer('oldProjectListFields');
         const allProjects = await this.projectReadModel.getProjectsForAdminUi(
             query,
             userId,
@@ -258,6 +259,7 @@ export default class ProjectService {
                 );
             }
         }
+        stopTimer();
 
         if (this.flagResolver.isEnabled('newProjectList')) {
             //TODO: update project-schema when removing this flag


### PR DESCRIPTION
We recently added a couple of queries in the project service as part of the project cards redesign project. 
We want to answer the question "how was this query performing before the new fields, and is the added overhead worth optimizing?".

This wraps the baseline `getProjects` path (project read model + private-project access filtering) in a `oldProjectListFields` timer, emitted via `function_duration_seconds`.

