### PR TITLE
task: make environment_revision_id gauge register idempotent

### DIFF
--- a/src/lib/features/feature-toggle/configuration-revision-service.test.ts
+++ b/src/lib/features/feature-toggle/configuration-revision-service.test.ts
@@ -1,0 +1,22 @@
+import { register } from 'prom-client';
+
+afterEach(() => {
+    register.clear();
+    vi.resetModules();
+});
+
+test('reuses an existing revision id metric when the module is loaded again', async () => {
+    register.clear();
+    vi.resetModules();
+
+    await import('./configuration-revision-service.js');
+    vi.resetModules();
+    await import('./configuration-revision-service.js');
+
+    const metrics = await register.getMetricsAsJSON();
+    const revisionIdMetrics = metrics.filter(
+        ({ name }) => name === 'environment_revision_id',
+    );
+
+    expect(revisionIdMetrics).toHaveLength(1);
+});

--- a/src/lib/features/feature-toggle/configuration-revision-service.ts
+++ b/src/lib/features/feature-toggle/configuration-revision-service.ts
@@ -6,15 +6,38 @@ import type {
     IUnleashStores,
 } from '../../types/index.js';
 import EventEmitter from 'events';
-import { createGauge } from '../../util/metrics/index.js';
+import {
+    Gauge as PromGauge,
+    register as prometheusRegister,
+} from 'prom-client';
+import { createGauge, type Gauge } from '../../util/metrics/index.js';
 
 export const UPDATE_REVISION = 'UPDATE_REVISION';
 
-const revisionIdMetric = createGauge({
-    name: 'environment_revision_id',
-    help: 'Current revision id for environment',
-    labelNames: ['environment'],
+const revisionIdMetricName = 'environment_revision_id';
+
+const asGaugeWrapper = <T extends string>(gauge: PromGauge<T>): Gauge<T> => ({
+    gauge,
+    labels: (labels: Record<T, string | number>) => gauge.labels(labels),
+    reset: () => gauge.reset(),
+    set: (value: number) => gauge.set(value),
 });
+
+const getRevisionIdMetric = (): Gauge<'environment'> => {
+    const existing = prometheusRegister.getSingleMetric(revisionIdMetricName);
+
+    if (existing instanceof PromGauge) {
+        return asGaugeWrapper(existing as PromGauge<'environment'>);
+    }
+
+    return createGauge({
+        name: revisionIdMetricName,
+        help: 'Current revision id for environment',
+        labelNames: ['environment'],
+    });
+};
+
+const revisionIdMetric = getRevisionIdMetric();
 
 // Should only be used for standard polling
 export default class ConfigurationRevisionService extends EventEmitter {


### PR DESCRIPTION
## About the changes

When running tests with oss loaded in enterprise, this metric register fails due to already being registered. This PR makes the register idempotent, so it should no longer fail.

### Important files

## Discussion points

## OSS PR checklist

- [x] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [x] I have added tests or explained why tests are not needed.
- [x] I have updated documentation where relevant.
