### PR TITLE
fix: only show impact metrics tip once flag setup is complete

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
@@ -76,6 +76,7 @@ export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
         loading: projectLoading,
         refetch: refetchProject,
     } = useProjectOverview(projectId);
+    const allLoadingDone = !featureLoading && !projectLoading;
 
     // A completed setup step can advance the project's or the feature's onboarding status,
     // so refresh both to re-evaluate the stage.
@@ -87,6 +88,8 @@ export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
         projectOnboardingStatus: project?.onboardingStatus?.status,
         feature: feature as FeatureSchema,
     });
+    const shouldShowSetup = setupStage !== 'setup-completed';
+
     const dragTooltipSplashId = 'strategy-drag-tooltip';
     const shouldShowStrategyDragTooltip = !splash?.[dragTooltipSplashId];
     const toggleShowTooltip = (envIsOpen: boolean) => {
@@ -118,9 +121,8 @@ export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
                     </div>
                 )}
                 <StyledMainContent>
-                    {!featureLoading &&
-                        !projectLoading &&
-                        (setupStage !== null ? (
+                    {allLoadingDone &&
+                        (shouldShowSetup ? (
                             <FeatureSetupBanner
                                 project={{
                                     ...(project as ProjectOverviewSchema),

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
@@ -22,6 +22,7 @@ import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectO
 import { useMinimumUnleashVersion } from 'hooks/useMinimumUnleashVersion.ts';
 import type { FeatureSchema, ProjectOverviewSchema } from 'openapi/index.ts';
 import { FeatureSetupBanner } from './FeatureSetupBanner.tsx';
+import { getFeatureSetupStage } from './getFeatureSetupStage.ts';
 
 const StyledContainer = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -82,6 +83,10 @@ export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
         refetchFeature();
         refetchProject();
     };
+    const setupStage = getFeatureSetupStage({
+        projectOnboardingStatus: project?.onboardingStatus?.status,
+        feature: feature as FeatureSchema,
+    });
     const dragTooltipSplashId = 'strategy-drag-tooltip';
     const shouldShowStrategyDragTooltip = !splash?.[dragTooltipSplashId];
     const toggleShowTooltip = (envIsOpen: boolean) => {
@@ -113,20 +118,23 @@ export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
                     </div>
                 )}
                 <StyledMainContent>
-                    {!featureLoading && !projectLoading && (
-                        <FeatureSetupBanner
-                            project={{
-                                ...(project as ProjectOverviewSchema),
-                                id: projectId,
-                            }}
-                            feature={{
-                                ...(feature as FeatureSchema),
-                                id: featureId,
-                            }}
-                            onComplete={refreshSetupBanner}
-                        />
-                    )}
-                    {!featureLoading && header}
+                    {!featureLoading &&
+                        !projectLoading &&
+                        (setupStage !== null ? (
+                            <FeatureSetupBanner
+                                project={{
+                                    ...(project as ProjectOverviewSchema),
+                                    id: projectId,
+                                }}
+                                feature={{
+                                    ...(feature as FeatureSchema),
+                                    id: featureId,
+                                }}
+                                onComplete={refreshSetupBanner}
+                            />
+                        ) : (
+                            header
+                        ))}
                     <FeatureOverviewEnvironments
                         onToggleEnvOpen={toggleShowTooltip}
                         hiddenEnvironments={hiddenEnvironments}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/getFeatureSetupStage.test.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/getFeatureSetupStage.test.ts
@@ -88,7 +88,7 @@ describe('getFeatureSetupStage', () => {
                     environments: [env(), env([{ name: 'flexibleRollout' }])],
                 },
             }),
-        ).toBeNull();
+        ).toBe('setup-completed');
     });
 
     it('returns null for the completed stage', () => {
@@ -97,7 +97,7 @@ describe('getFeatureSetupStage', () => {
                 projectOnboardingStatus: 'onboarded',
                 feature: { lifecycle: lifecycle('completed') },
             }),
-        ).toBeNull();
+        ).toBe('setup-completed');
     });
 
     it('returns null for the archived stage', () => {
@@ -106,6 +106,6 @@ describe('getFeatureSetupStage', () => {
                 projectOnboardingStatus: 'onboarded',
                 feature: { lifecycle: lifecycle('archived') },
             }),
-        ).toBeNull();
+        ).toBe('setup-completed');
     });
 });

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/getFeatureSetupStage.ts
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/getFeatureSetupStage.ts
@@ -4,7 +4,7 @@ export type FeatureSetupStage =
     | 'connect-sdk'
     | 'implement-flag'
     | 'add-strategy'
-    | null;
+    | 'setup-completed';
 
 export const getFeatureSetupStage = ({
     projectOnboardingStatus,
@@ -40,5 +40,5 @@ export const getFeatureSetupStage = ({
         return 'add-strategy';
     }
 
-    return null;
+    return 'setup-completed';
 };


### PR DESCRIPTION
Only renders the tip banner about adding impact metrics if the set up stages are cleared.

Before:
<img width="1520" height="510" alt="Screenshot 2026-06-08 at 15 02 35" src="https://github.com/user-attachments/assets/22fa18cb-36c7-445f-8ac7-5a47a3a1fbf1" />


After:
<img width="1520" height="510" alt="Screenshot 2026-06-08 at 15 02 03" src="https://github.com/user-attachments/assets/27c30246-1d45-478c-8d69-9464656bf32a" />

