### PR TITLE
docs: add unleash_test database creation step to setup guide

### DIFF
--- a/contributing/CONTRIBUTING.md
+++ b/contributing/CONTRIBUTING.md
@@ -110,6 +110,12 @@ You'll need:
 
    The **connection details** that Unleash will try to use are found in **`src/server-dev.ts`**. The above command works with the current defaults (at the time of writing).
 
+   - Also create the **test database** used by `pnpm test`:
+
+   ```bash
+   docker exec postgres createdb -U unleash_user unleash_test
+   ```
+
    - If you've set up the database previously, you can restart the container by running this (assuming `postgres` is the name you gave the container):
 
    ```bash


### PR DESCRIPTION
## Summary

- Adds a `docker exec postgres createdb -U unleash_user unleash_test` step to the first-time setup in `CONTRIBUTING.md`
- Placed immediately after the initial `docker run` so both `unleash` and `unleash_test` databases are created before the developer runs `pnpm dev` or `pnpm test`

Without this step, a developer following the setup guide and then running `pnpm test` hits a cryptic `error: database "unleash_test" does not exist` error with no pointer to the fix.

Closes #12253

## Test plan

- [ ] Follow the updated setup steps from scratch and verify `pnpm dev` and `pnpm test` both work without additional intervention