### PR TITLE
chore: add new lifecycle options so that we can show archived

### DIFF
--- a/frontend/src/component/common/LifecycleFilters/LifecycleFilters.tsx
+++ b/frontend/src/component/common/LifecycleFilters/LifecycleFilters.tsx
@@ -8,6 +8,7 @@ import { DropdownMenu } from '../DropdownMenu/DropdownMenu.tsx';
 import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined';
 import { LifecycleChip } from './LifecycleChip.tsx';
 import { FlagsCountBadge } from './FlagsCountBadge.tsx';
+import { useUiFlag } from 'hooks/useUiFlag.ts';
 
 interface ILifecycleFiltersBaseProps {
     state: FilterItemParamHolder;
@@ -38,7 +39,7 @@ const StyledMinimalChipContainer = styled(Box)(({ theme }) => ({
     width: '100%',
 }));
 
-const lifecycleOptions: {
+const oldLifecycleOptions: {
     label: string;
     value: LifecycleStage['name'] | null;
 }[] = [
@@ -46,6 +47,17 @@ const lifecycleOptions: {
     { label: 'Develop', value: 'pre-live' },
     { label: 'Rollout production', value: 'live' },
     { label: 'Cleanup', value: 'completed' },
+];
+
+const newLifecycleOptions: {
+    label: string;
+    value: LifecycleStage['name'] | null;
+}[] = [
+    { label: 'Active flags', value: null },
+    { label: 'Develop', value: 'pre-live' },
+    { label: 'Rollout production', value: 'live' },
+    { label: 'Cleanup', value: 'completed' },
+    { label: 'Archived', value: 'archived' },
 ];
 
 const MinimalChip = ({
@@ -81,6 +93,10 @@ export const LifecycleFilters = ({
     const theme = useTheme();
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
     const selectedLifecycle = state.lifecycle?.values?.[0] ?? null;
+    const useNewLifecycleOptions = useUiFlag('archiveInFlagsView');
+    const lifecycleOptions = useNewLifecycleOptions
+        ? newLifecycleOptions
+        : oldLifecycleOptions;
 
     const isActive = (value: LifecycleStage['name'] | null) => {
         return value === selectedLifecycle;


### PR DESCRIPTION
Updates the lifecycle selector to also include an "archived" option when the flag is enabled. The query doesn't return any results for now, likely because it needs some work on the back end. 

Also changes the "all lifecycles" wording to be "active flags"

It seems the query doesn't work because it uses the lifecycle to query for archived instead of the is:archived.

E.g., the current table uses:
`?archived=IS%3Atrue`
but with the lifecycle selector, it should probably also allow:
`?lifecycle=IS%3Aarchived`

Flag enabled:
<img width="770" height="59" alt="image" src="https://github.com/user-attachments/assets/7397b019-45a3-4f9c-bcc7-3389cde6e7a6" />


Flag disabled:
<img width="760" height="62" alt="image" src="https://github.com/user-attachments/assets/35b8e0de-a8f2-464e-a851-bc4dccc6a476" />
