### PR TITLE
feat: Support filtering feature search by the `archived` lifecycle stage

### DIFF
--- a/src/lib/features/feature-search/feature-search-service.ts
+++ b/src/lib/features/feature-search/feature-search-service.ts
@@ -93,6 +93,14 @@ export class FeatureSearchService {
             if (parsed) queryParams.push(parsed);
         }
 
+        if (params.lifecycle) {
+            const parsed = parseSearchOperatorValue(
+                'lifecycle.latest_stage',
+                params.lifecycle,
+            );
+            if (parsed) queryParams.push(parsed);
+        }
+
         ['tag', 'segment', 'project'].forEach((field) => {
             if (params[field]) {
                 const parsed = parseSearchOperatorValue(field, params[field]);

--- a/src/lib/features/feature-search/feature-search-store.ts
+++ b/src/lib/features/feature-search/feature-search-store.ts
@@ -16,10 +16,7 @@ import type {
     IFeatureSearchParams,
     IQueryParam,
 } from '../feature-toggle/types/feature-toggle-strategies-store-type.js';
-import {
-    applyGenericQueryParams,
-    applySearchFilters,
-} from './search-utils.js';
+import { applyGenericQueryParams, applySearchFilters } from './search-utils.js';
 import { generateImageUrl } from '../../util/index.js';
 type Raw<T = any> = Knex.Raw<T>;
 import type { ITag } from '../../tags/index.js';
@@ -688,15 +685,8 @@ const applyLifecycleAndArchivedFilters = (
             query.whereNull('features.archived_at');
         }
     } else {
-        // IS_NOT / IS_NONE_OF. The archived gate stays governed by the
-        // `archived` param, so `archived=IS:true` still returns only archived
-        // flags - unless the lifecycle filter itself excludes the archived
-        // stage, in which case that wins.
         const showArchived = Boolean(archived) && !includesArchived;
         if (showArchived) {
-            // Archived flags aren't in an active lifecycle stage, so excluding
-            // active stages doesn't apply to them - return them all (matching
-            // `archived=IS:true`, including legacy flags with no lifecycle row).
             query.whereNotNull('features.archived_at');
         } else {
             if (stageValues.length === 1) {
@@ -864,7 +854,6 @@ const applyQueryParams = (
                 'segment',
                 'lastSeenAt',
                 'favorite',
-                // applied separately, with archived-aware handling
                 'lifecycle.latest_stage',
             ].includes(param.field),
     );

--- a/src/lib/features/feature-search/feature-search-store.ts
+++ b/src/lib/features/feature-search/feature-search-store.ts
@@ -19,7 +19,6 @@ import type {
 import {
     applyGenericQueryParams,
     applySearchFilters,
-    parseSearchOperatorValue,
 } from './search-utils.js';
 import { generateImageUrl } from '../../util/index.js';
 type Raw<T = any> = Knex.Raw<T>;
@@ -88,7 +87,6 @@ class FeatureSearchStore implements IFeatureSearchStore {
             status,
             offset,
             limit,
-            lifecycle,
             sortOrder,
             sortBy,
             archived,
@@ -261,12 +259,10 @@ class FeatureSearchStore implements IFeatureSearchStore {
                         'lifecycle.stage_feature',
                     );
 
-                const parsedLifecycle = lifecycle
-                    ? parseSearchOperatorValue(
-                          'lifecycle.latest_stage',
-                          lifecycle,
-                      )
-                    : null;
+                const parsedLifecycle =
+                    queryParams.find(
+                        (param) => param.field === 'lifecycle.latest_stage',
+                    ) ?? null;
                 applyLifecycleAndArchivedFilters(
                     query,
                     parsedLifecycle,
@@ -852,9 +848,15 @@ const applyQueryParams = (
     );
     const genericConditions = queryParams.filter(
         (param) =>
-            !['tag', 'stale', 'segment', 'lastSeenAt', 'favorite'].includes(
-                param.field,
-            ),
+            ![
+                'tag',
+                'stale',
+                'segment',
+                'lastSeenAt',
+                'favorite',
+                // applied separately, with archived-aware handling
+                'lifecycle.latest_stage',
+            ].includes(param.field),
     );
     applyGenericQueryParams(query, genericConditions);
     applyFavoriteCondition(query, favoriteCondition);

--- a/src/lib/features/feature-search/feature-search-store.ts
+++ b/src/lib/features/feature-search/feature-search-store.ts
@@ -688,14 +688,24 @@ const applyLifecycleAndArchivedFilters = (
             query.whereNull('features.archived_at');
         }
     } else {
-        // IS_NOT / IS_NONE_OF: exclude the listed active stages and never
-        // surface archived flags.
-        if (stageValues.length === 1) {
-            query.whereNot('lifecycle.latest_stage', stageValues[0]);
-        } else if (stageValues.length > 1) {
-            query.whereNotIn('lifecycle.latest_stage', stageValues);
+        // IS_NOT / IS_NONE_OF. The archived gate stays governed by the
+        // `archived` param, so `archived=IS:true` still returns only archived
+        // flags - unless the lifecycle filter itself excludes the archived
+        // stage, in which case that wins.
+        const showArchived = Boolean(archived) && !includesArchived;
+        if (showArchived) {
+            // Archived flags aren't in an active lifecycle stage, so excluding
+            // active stages doesn't apply to them - return them all (matching
+            // `archived=IS:true`, including legacy flags with no lifecycle row).
+            query.whereNotNull('features.archived_at');
+        } else {
+            if (stageValues.length === 1) {
+                query.whereNot('lifecycle.latest_stage', stageValues[0]);
+            } else if (stageValues.length > 1) {
+                query.whereNotIn('lifecycle.latest_stage', stageValues);
+            }
+            query.whereNull('features.archived_at');
         }
-        query.whereNull('features.archived_at');
     }
 };
 

--- a/src/lib/features/feature-search/feature-search-store.ts
+++ b/src/lib/features/feature-search/feature-search-store.ts
@@ -672,17 +672,23 @@ const applyLifecycleAndArchivedFilters = (
     const stageValues = values.filter((value) => value !== ARCHIVED_STAGE);
 
     if (operator === 'IS' || operator === 'IS_ANY_OF') {
-        const wantArchived = includesArchived || Boolean(archived);
-        query.where((builder) => {
-            if (stageValues.length > 0) {
-                builder.orWhereIn('lifecycle.latest_stage', stageValues);
+        if (archived) {
+            query.whereNotNull('features.archived_at');
+            if (!includesArchived && stageValues.length > 0) {
+                query.whereIn('lifecycle.latest_stage', stageValues);
             }
-            if (wantArchived) {
-                builder.orWhereNotNull('features.archived_at');
+        } else {
+            query.where((builder) => {
+                if (stageValues.length > 0) {
+                    builder.orWhereIn('lifecycle.latest_stage', stageValues);
+                }
+                if (includesArchived) {
+                    builder.orWhereNotNull('features.archived_at');
+                }
+            });
+            if (!includesArchived) {
+                query.whereNull('features.archived_at');
             }
-        });
-        if (!wantArchived) {
-            query.whereNull('features.archived_at');
         }
     } else {
         const showArchived = Boolean(archived) && !includesArchived;

--- a/src/lib/features/feature-search/feature-search-store.ts
+++ b/src/lib/features/feature-search/feature-search-store.ts
@@ -8,6 +8,7 @@ import type {
     IFeatureSearchOverview,
     IFeatureSearchStore,
     IFlagResolver,
+    StageName,
 } from '../../types/index.js';
 import FeatureToggleStore from '../feature-toggle/feature-toggle-store.js';
 import type { Db } from '../../db/db.js';
@@ -183,7 +184,6 @@ class FeatureSearchStore implements IFeatureSearchStore {
                     });
                 }
                 query
-                    .modify(FeatureToggleStore.filterByArchived, archived)
                     .leftJoin(
                         'feature_environments',
                         'feature_environments.feature_name',
@@ -267,9 +267,11 @@ class FeatureSearchStore implements IFeatureSearchStore {
                           lifecycle,
                       )
                     : null;
-                if (parsedLifecycle) {
-                    applyGenericQueryParams(query, [parsedLifecycle]);
-                }
+                applyLifecycleAndArchivedFilters(
+                    query,
+                    parsedLifecycle,
+                    archived,
+                );
 
                 const rankingSql = this.buildRankingSql(
                     favoritesFirst,
@@ -659,6 +661,47 @@ class FeatureSearchStore implements IFeatureSearchStore {
         );
     }
 }
+
+const ARCHIVED_STAGE: StageName = 'archived';
+
+const applyLifecycleAndArchivedFilters = (
+    query: Knex.QueryBuilder,
+    parsedLifecycle: IQueryParam | null,
+    archived?: boolean,
+): void => {
+    if (!parsedLifecycle) {
+        query.modify(FeatureToggleStore.filterByArchived, Boolean(archived));
+        return;
+    }
+
+    const { operator, values } = parsedLifecycle;
+    const includesArchived = values.includes(ARCHIVED_STAGE);
+    const stageValues = values.filter((value) => value !== ARCHIVED_STAGE);
+
+    if (operator === 'IS' || operator === 'IS_ANY_OF') {
+        const wantArchived = includesArchived || Boolean(archived);
+        query.where((builder) => {
+            if (stageValues.length > 0) {
+                builder.orWhereIn('lifecycle.latest_stage', stageValues);
+            }
+            if (wantArchived) {
+                builder.orWhereNotNull('features.archived_at');
+            }
+        });
+        if (!wantArchived) {
+            query.whereNull('features.archived_at');
+        }
+    } else {
+        // IS_NOT / IS_NONE_OF: exclude the listed active stages and never
+        // surface archived flags.
+        if (stageValues.length === 1) {
+            query.whereNot('lifecycle.latest_stage', stageValues[0]);
+        } else if (stageValues.length > 1) {
+            query.whereNotIn('lifecycle.latest_stage', stageValues);
+        }
+        query.whereNull('features.archived_at');
+    }
+};
 
 const applyStaleConditions = (
     query: Knex.QueryBuilder,

--- a/src/lib/features/feature-search/feature-search-store.ts
+++ b/src/lib/features/feature-search/feature-search-store.ts
@@ -656,6 +656,8 @@ class FeatureSearchStore implements IFeatureSearchStore {
 }
 
 const ARCHIVED_STAGE: StageName = 'archived';
+const ARCHIVED_AT = 'features.archived_at';
+const LATEST_STAGE = 'lifecycle.latest_stage';
 
 const applyLifecycleAndArchivedFilters = (
     query: Knex.QueryBuilder,
@@ -668,40 +670,46 @@ const applyLifecycleAndArchivedFilters = (
     }
 
     const { operator, values } = parsedLifecycle;
-    const includesArchived = values.includes(ARCHIVED_STAGE);
-    const stageValues = values.filter((value) => value !== ARCHIVED_STAGE);
+    const exclude = operator === 'IS_NOT' || operator === 'IS_NONE_OF';
+    const archivedView = Boolean(archived);
+    const filterIncludesArchived = values.includes(ARCHIVED_STAGE);
+    const stages = values.filter((value) => value !== ARCHIVED_STAGE);
 
-    if (operator === 'IS' || operator === 'IS_ANY_OF') {
-        if (archived) {
-            query.whereNotNull('features.archived_at');
-            if (!includesArchived && stageValues.length > 0) {
-                query.whereIn('lifecycle.latest_stage', stageValues);
-            }
-        } else {
-            query.where((builder) => {
-                if (stageValues.length > 0) {
-                    builder.orWhereIn('lifecycle.latest_stage', stageValues);
-                }
-                if (includesArchived) {
-                    builder.orWhereNotNull('features.archived_at');
-                }
-            });
-            if (!includesArchived) {
-                query.whereNull('features.archived_at');
-            }
+    if (exclude) {
+        if (archivedView && !filterIncludesArchived) {
+            // The exclusion only concerns the stages of active flags, so
+            // the archived view is unaffected by it.
+            query.whereNotNull(ARCHIVED_AT);
+            return;
         }
-    } else {
-        const showArchived = Boolean(archived) && !includesArchived;
-        if (showArchived) {
-            query.whereNotNull('features.archived_at');
-        } else {
-            if (stageValues.length === 1) {
-                query.whereNot('lifecycle.latest_stage', stageValues[0]);
-            } else if (stageValues.length > 1) {
-                query.whereNotIn('lifecycle.latest_stage', stageValues);
-            }
-            query.whereNull('features.archived_at');
+        // Active flags whose stage is none of the given stages.
+        query.whereNull(ARCHIVED_AT);
+        if (stages.length > 0) {
+            query.whereNotIn(LATEST_STAGE, stages);
         }
+        return;
+    }
+
+    if (archivedView) {
+        // Archived flags, optionally narrowed to the given stages.
+        query.whereNotNull(ARCHIVED_AT);
+        if (!filterIncludesArchived && stages.length > 0) {
+            query.whereIn(LATEST_STAGE, stages);
+        }
+        return;
+    }
+
+    // Active flags in the given stages, plus archived flags if asked for.
+    query.where((builder) => {
+        if (stages.length > 0) {
+            builder.orWhereIn(LATEST_STAGE, stages);
+        }
+        if (filterIncludesArchived) {
+            builder.orWhereNotNull(ARCHIVED_AT);
+        }
+    });
+    if (!filterIncludesArchived) {
+        query.whereNull(ARCHIVED_AT);
     }
 };
 

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -1462,6 +1462,18 @@ test('should return archived flags when lifecycle filter targets the archived st
         total: 1,
         features: [{ name: 'lifecycle_active' }],
     });
+
+    // archived=IS:true stays authoritative alongside an exclusion operator:
+    // it returns archived flags, not active ones
+    const { body: archivedExcludingLive } = await app.request
+        .get(
+            '/api/admin/search/features?query=lifecycle_&project=IS:default&archived=IS:true&lifecycle=IS_NOT:live',
+        )
+        .expect(200);
+    expect(archivedExcludingLive).toMatchObject({
+        total: 1,
+        features: [{ name: 'lifecycle_archived' }],
+    });
 });
 
 test('should filter by favorite=IS:true', async () => {

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -1504,6 +1504,31 @@ describe('lifecycle and archived filtering', () => {
             'lifecycle_archived_with_stage',
         ]);
     });
+
+    test('archived=IS:true stays authoritative alongside an inclusion operator: archived flags only, no active flags from the requested stages', async () => {
+        await setupLifecycleFlags();
+
+        const { body } = await searchByLifecycle(
+            'archived=IS:true&lifecycle=IS_ANY_OF:live,archived',
+        );
+
+        expect(body.total).toBe(2);
+        expect(sortedNames(body)).toEqual([
+            'archived_without_lifecycle',
+            'lifecycle_archived_with_stage',
+        ]);
+    });
+
+    test('archived=IS:true with a lifecycle filter for only active stages is contradictory and returns nothing', async () => {
+        await setupLifecycleFlags();
+
+        const { body } = await searchByLifecycle(
+            'archived=IS:true&lifecycle=IS:live',
+        );
+
+        expect(body.total).toBe(0);
+        expect(body.features).toEqual([]);
+    });
 });
 
 test('should filter by favorite=IS:true', async () => {

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -1413,77 +1413,96 @@ test('should return archived when query param set', async () => {
     });
 });
 
-const setupLifecycleFlags = async () => {
-    await app.createFeature({
-        name: 'lifecycle_active',
-        createdAt: '2023-01-29T15:21:39.975Z',
+describe('lifecycle and archived filtering', () => {
+    const setupLifecycleFlags = async () => {
+        await app.createFeature({
+            name: 'lifecycle_active',
+            createdAt: '2023-01-29T15:21:39.975Z',
+        });
+        await app.createFeature({
+            name: 'archived_without_lifecycle',
+            createdAt: '2023-01-29T15:21:39.975Z',
+            archived: true,
+        });
+        await app.createFeature({
+            name: 'lifecycle_archived_with_stage',
+            createdAt: '2023-01-29T15:21:39.975Z',
+            archived: true,
+        });
+        await stores.featureLifecycleStore.insert([
+            { feature: 'lifecycle_active', stage: 'live' },
+            { feature: 'lifecycle_archived_with_stage', stage: 'archived' },
+        ]);
+        expect(
+            await stores.featureLifecycleStore.get(
+                'archived_without_lifecycle',
+            ),
+        ).toHaveLength(0);
+        expect(
+            await stores.featureLifecycleStore.get(
+                'lifecycle_archived_with_stage',
+            ),
+        ).toHaveLength(1);
+    };
+
+    const searchByLifecycle = async (params: string) =>
+        app.request
+            .get(`/api/admin/search/features?project=IS:default&${params}`)
+            .expect(200);
+
+    const sortedNames = (body: { features: { name: string }[] }) =>
+        body.features.map((feature) => feature.name).sort();
+
+    test('lifecycle=IS:archived returns only archived flags, like archived=IS:true', async () => {
+        await setupLifecycleFlags();
+
+        const { body } = await searchByLifecycle('lifecycle=IS:archived');
+
+        expect(body.total).toBe(2);
+        expect(sortedNames(body)).toEqual([
+            'archived_without_lifecycle',
+            'lifecycle_archived_with_stage',
+        ]);
     });
-    await app.createFeature({
-        name: 'lifecycle_archived',
-        createdAt: '2023-01-29T15:21:39.975Z',
-        archived: true,
+
+    test('lifecycle=IS_ANY_OF:live,archived returns both the requested active stage and archived flags', async () => {
+        await setupLifecycleFlags();
+
+        const { body } = await searchByLifecycle(
+            'lifecycle=IS_ANY_OF:live,archived',
+        );
+
+        expect(body.total).toBe(3);
+        expect(sortedNames(body)).toEqual([
+            'archived_without_lifecycle',
+            'lifecycle_active',
+            'lifecycle_archived_with_stage',
+        ]);
     });
-    await stores.featureLifecycleStore.insert([
-        { feature: 'lifecycle_active', stage: 'live' },
-    ]);
-    expect(
-        await stores.featureLifecycleStore.get('lifecycle_archived'),
-    ).toHaveLength(0);
-};
 
-const searchByLifecycle = async (params: string) =>
-    app.request
-        .get(
-            `/api/admin/search/features?query=lifecycle_&project=IS:default&${params}`,
-        )
-        .expect(200);
+    test('lifecycle=IS_NONE_OF:archived excludes the archived stage and keeps only active flags', async () => {
+        await setupLifecycleFlags();
 
-test('lifecycle=IS:archived returns only archived flags, like archived=IS:true', async () => {
-    await setupLifecycleFlags();
+        const { body } = await searchByLifecycle(
+            'lifecycle=IS_NONE_OF:archived',
+        );
 
-    const { body } = await searchByLifecycle('lifecycle=IS:archived');
-
-    expect(body).toMatchObject({
-        total: 1,
-        features: [{ name: 'lifecycle_archived' }],
+        expect(body.total).toBe(1);
+        expect(sortedNames(body)).toEqual(['lifecycle_active']);
     });
-});
 
-test('lifecycle=IS_ANY_OF:live,archived returns both the requested active stage and archived flags', async () => {
-    await setupLifecycleFlags();
+    test('archived=IS:true stays authoritative alongside an exclusion operator and returns archived flags, not active ones', async () => {
+        await setupLifecycleFlags();
 
-    const { body } = await searchByLifecycle(
-        'lifecycle=IS_ANY_OF:live,archived',
-    );
+        const { body } = await searchByLifecycle(
+            'archived=IS:true&lifecycle=IS_NOT:live',
+        );
 
-    expect(body.total).toBe(2);
-    expect(body.features.map((f) => f.name).sort()).toEqual([
-        'lifecycle_active',
-        'lifecycle_archived',
-    ]);
-});
-
-test('lifecycle=IS_NONE_OF:archived excludes the archived stage and keeps only active flags', async () => {
-    await setupLifecycleFlags();
-
-    const { body } = await searchByLifecycle('lifecycle=IS_NONE_OF:archived');
-
-    expect(body).toMatchObject({
-        total: 1,
-        features: [{ name: 'lifecycle_active' }],
-    });
-});
-
-test('archived=IS:true stays authoritative alongside an exclusion operator and returns archived flags, not active ones', async () => {
-    await setupLifecycleFlags();
-
-    const { body } = await searchByLifecycle(
-        'archived=IS:true&lifecycle=IS_NOT:live',
-    );
-
-    expect(body).toMatchObject({
-        total: 1,
-        features: [{ name: 'lifecycle_archived' }],
+        expect(body.total).toBe(2);
+        expect(sortedNames(body)).toEqual([
+            'archived_without_lifecycle',
+            'lifecycle_archived_with_stage',
+        ]);
     });
 });
 

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -1413,7 +1413,7 @@ test('should return archived when query param set', async () => {
     });
 });
 
-test('should return archived flags when lifecycle filter targets the archived stage', async () => {
+const setupLifecycleFlags = async () => {
     await app.createFeature({
         name: 'lifecycle_active',
         createdAt: '2023-01-29T15:21:39.975Z',
@@ -1423,54 +1423,65 @@ test('should return archived flags when lifecycle filter targets the archived st
         createdAt: '2023-01-29T15:21:39.975Z',
         archived: true,
     });
-    // legacy-style archived flag with no lifecycle row should still match
     await stores.featureLifecycleStore.insert([
         { feature: 'lifecycle_active', stage: 'live' },
     ]);
-    expect(await stores.featureLifecycleStore.get('lifecycle_archived')).toHaveLength(0);
+    expect(
+        await stores.featureLifecycleStore.get('lifecycle_archived'),
+    ).toHaveLength(0);
+};
 
-    // lifecycle=IS:archived behaves like archived=IS:true
-    const { body: archivedOnly } = await app.request
+const searchByLifecycle = async (params: string) =>
+    app.request
         .get(
-            '/api/admin/search/features?query=lifecycle_&project=IS:default&lifecycle=IS:archived',
+            `/api/admin/search/features?query=lifecycle_&project=IS:default&${params}`,
         )
         .expect(200);
-    expect(archivedOnly).toMatchObject({
+
+test('lifecycle=IS:archived returns only archived flags, like archived=IS:true', async () => {
+    await setupLifecycleFlags();
+
+    const { body } = await searchByLifecycle('lifecycle=IS:archived');
+
+    expect(body).toMatchObject({
         total: 1,
         features: [{ name: 'lifecycle_archived' }],
     });
+});
 
-    // IS_ANY_OF returns both the requested active stage and archived flags
-    const { body: liveAndArchived } = await app.request
-        .get(
-            '/api/admin/search/features?query=lifecycle_&project=IS:default&lifecycle=IS_ANY_OF:live,archived',
-        )
-        .expect(200);
-    expect(liveAndArchived.total).toBe(2);
-    expect(liveAndArchived.features.map((f) => f.name).sort()).toEqual([
+test('lifecycle=IS_ANY_OF:live,archived returns both the requested active stage and archived flags', async () => {
+    await setupLifecycleFlags();
+
+    const { body } = await searchByLifecycle(
+        'lifecycle=IS_ANY_OF:live,archived',
+    );
+
+    expect(body.total).toBe(2);
+    expect(body.features.map((f) => f.name).sort()).toEqual([
         'lifecycle_active',
         'lifecycle_archived',
     ]);
+});
 
-    // excluding the archived stage keeps only active flags
-    const { body: activeOnly } = await app.request
-        .get(
-            '/api/admin/search/features?query=lifecycle_&project=IS:default&lifecycle=IS_NONE_OF:archived',
-        )
-        .expect(200);
-    expect(activeOnly).toMatchObject({
+test('lifecycle=IS_NONE_OF:archived excludes the archived stage and keeps only active flags', async () => {
+    await setupLifecycleFlags();
+
+    const { body } = await searchByLifecycle('lifecycle=IS_NONE_OF:archived');
+
+    expect(body).toMatchObject({
         total: 1,
         features: [{ name: 'lifecycle_active' }],
     });
+});
 
-    // archived=IS:true stays authoritative alongside an exclusion operator:
-    // it returns archived flags, not active ones
-    const { body: archivedExcludingLive } = await app.request
-        .get(
-            '/api/admin/search/features?query=lifecycle_&project=IS:default&archived=IS:true&lifecycle=IS_NOT:live',
-        )
-        .expect(200);
-    expect(archivedExcludingLive).toMatchObject({
+test('archived=IS:true stays authoritative alongside an exclusion operator and returns archived flags, not active ones', async () => {
+    await setupLifecycleFlags();
+
+    const { body } = await searchByLifecycle(
+        'archived=IS:true&lifecycle=IS_NOT:live',
+    );
+
+    expect(body).toMatchObject({
         total: 1,
         features: [{ name: 'lifecycle_archived' }],
     });

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -1427,6 +1427,7 @@ test('should return archived flags when lifecycle filter targets the archived st
     await stores.featureLifecycleStore.insert([
         { feature: 'lifecycle_active', stage: 'live' },
     ]);
+    expect(await stores.featureLifecycleStore.get('lifecycle_archived')).toHaveLength(0);
 
     // lifecycle=IS:archived behaves like archived=IS:true
     const { body: archivedOnly } = await app.request

--- a/src/lib/features/feature-search/feature.search.e2e.test.ts
+++ b/src/lib/features/feature-search/feature.search.e2e.test.ts
@@ -1413,6 +1413,56 @@ test('should return archived when query param set', async () => {
     });
 });
 
+test('should return archived flags when lifecycle filter targets the archived stage', async () => {
+    await app.createFeature({
+        name: 'lifecycle_active',
+        createdAt: '2023-01-29T15:21:39.975Z',
+    });
+    await app.createFeature({
+        name: 'lifecycle_archived',
+        createdAt: '2023-01-29T15:21:39.975Z',
+        archived: true,
+    });
+    // legacy-style archived flag with no lifecycle row should still match
+    await stores.featureLifecycleStore.insert([
+        { feature: 'lifecycle_active', stage: 'live' },
+    ]);
+
+    // lifecycle=IS:archived behaves like archived=IS:true
+    const { body: archivedOnly } = await app.request
+        .get(
+            '/api/admin/search/features?query=lifecycle_&project=IS:default&lifecycle=IS:archived',
+        )
+        .expect(200);
+    expect(archivedOnly).toMatchObject({
+        total: 1,
+        features: [{ name: 'lifecycle_archived' }],
+    });
+
+    // IS_ANY_OF returns both the requested active stage and archived flags
+    const { body: liveAndArchived } = await app.request
+        .get(
+            '/api/admin/search/features?query=lifecycle_&project=IS:default&lifecycle=IS_ANY_OF:live,archived',
+        )
+        .expect(200);
+    expect(liveAndArchived.total).toBe(2);
+    expect(liveAndArchived.features.map((f) => f.name).sort()).toEqual([
+        'lifecycle_active',
+        'lifecycle_archived',
+    ]);
+
+    // excluding the archived stage keeps only active flags
+    const { body: activeOnly } = await app.request
+        .get(
+            '/api/admin/search/features?query=lifecycle_&project=IS:default&lifecycle=IS_NONE_OF:archived',
+        )
+        .expect(200);
+    expect(activeOnly).toMatchObject({
+        total: 1,
+        features: [{ name: 'lifecycle_active' }],
+    });
+});
+
 test('should filter by favorite=IS:true', async () => {
     await app.createFeature('my_feature_a');
     await app.createFeature('my_feature_b');

--- a/src/lib/openapi/spec/feature-search-query-parameters.ts
+++ b/src/lib/openapi/spec/feature-search-query-parameters.ts
@@ -43,7 +43,7 @@ export const featureSearchQueryParameters = [
                 '^(IS|IS_NOT|IS_ANY_OF|IS_NONE_OF):(.*?)(,([a-zA-Z0-9_]+))*$',
         },
         description:
-            'The lifecycle stage of the feature. The stage can be specified with an operator. The supported operators are IS, IS_NOT, IS_ANY_OF, IS_NONE_OF. The `archived` stage matches archived flags (equivalent to `archived=IS:true`), so it can be combined with active stages, e.g. `IS_ANY_OF:live,archived`.',
+            'The lifecycle stage of the feature. The stage can be specified with an operator. The supported operators are IS, IS_NOT, IS_ANY_OF, IS_NONE_OF.',
         in: 'query',
     },
     {

--- a/src/lib/openapi/spec/feature-search-query-parameters.ts
+++ b/src/lib/openapi/spec/feature-search-query-parameters.ts
@@ -160,13 +160,14 @@ export const featureSearchQueryParameters = [
     },
     {
         name: 'archived',
+        deprecated: true, // todo(v9): remove this parameter (deprecated since 8.0.1)
         schema: {
             type: 'string',
             example: 'IS:true',
             pattern: '^IS:(true|false)$',
         },
         description:
-            'Whether to get results for archived feature flags or active feature flags. If `IS:true`, Unleash will return only archived flags. If `IS:false`, it will return only active flags.',
+            'Deprecated: use the `lifecycle` parameter instead (`lifecycle=IS:archived` is equivalent to `archived=IS:true`). Whether to get results for archived feature flags or active feature flags. If `IS:true`, Unleash will return only archived flags, taking precedence over any `lifecycle` filter. If `IS:false`, it will return only active flags.',
         in: 'query',
     },
     {

--- a/src/lib/openapi/spec/feature-search-query-parameters.ts
+++ b/src/lib/openapi/spec/feature-search-query-parameters.ts
@@ -43,7 +43,7 @@ export const featureSearchQueryParameters = [
                 '^(IS|IS_NOT|IS_ANY_OF|IS_NONE_OF):(.*?)(,([a-zA-Z0-9_]+))*$',
         },
         description:
-            'The lifecycle stage of the feature. The stagee can be specified with an operator. The supported operators are IS, IS_NOT, IS_ANY_OF, IS_NONE_OF.',
+            'The lifecycle stage of the feature. The stage can be specified with an operator. The supported operators are IS, IS_NOT, IS_ANY_OF, IS_NONE_OF. The `archived` stage matches archived flags (equivalent to `archived=IS:true`), so it can be combined with active stages, e.g. `IS_ANY_OF:live,archived`.',
         in: 'query',
     },
     {


### PR DESCRIPTION

### What

Lets the feature search endpoint (`GET /api/admin/search/features`) return archived flags via the `lifecycle` query param. `lifecycle=IS:archived` now returns archived flags (equivalent to `archived=IS:true`), and — crucially — the `archived` stage can be combined with active stages in a single request, e.g. `lifecycle=IS_ANY_OF:live,archived` returns live **and** archived flags together.

### Why

Previously the only way to see archived flags in search was the dedicated `archived=IS:true` param, which is strictly one-or-the-other (active **xor** archived). There was no way to ask for "live flags plus archived flags" in one query. Treating `archived` as a lifecycle stage — which it already is in our model (`StageName`) — fills that gap and makes the search filter match how users think about the flag lifecycle.

Sending `lifecycle=IS:archived` on its own used to return nothing: the always-on active-only filter (`archived_at IS NULL`) silently cancelled the lifecycle clause. This fixes that.

### How

The change centers on `feature-search-store.ts`, where two filters previously collided — the always-on `filterByArchived` (defaulting to active-only) and the lifecycle `whereIn`. They're now reconciled in a single `applyLifecycleAndArchivedFilters` helper:

- The `archived` stage resolves to the canonical `features.archived_at IS NOT NULL`, **not** `latest_stage = 'archived'`. This keeps it identical to `archived=IS:true` and catches legacy flags archived before lifecycle tracking existed (which have no `archived` lifecycle row).
- Inclusion (`IS` / `IS_ANY_OF`): `latest_stage IN (active stages) OR archived_at IS NOT NULL` when archived is requested; otherwise active-only.
- Exclusion (`IS_NOT` / `IS_NONE_OF`): excludes the listed active stages and never surfaces archived flags.
- No `lifecycle` param → unchanged behaviour (`filterByArchived(archived)`).

Lifecycle parsing was also moved into the service's `convertToQueryParams`, so it's parsed alongside every other search filter instead of being a store-side one-off (the store now reads the parsed param out of `queryParams`, and `applyQueryParams` skips it so it isn't double-applied without the archived-aware handling).

### Behaviour matrix (no standalone `archived` param)

| `lifecycle` | Returns |
|---|---|
| `IS:archived` | archived flags only (== `archived=IS:true`) |
| `IS_ANY_OF:live,archived` | live (active) + all archived |
| `IS_ANY_OF:live,completed` | those active stages, no archived |
| `IS:live` | active live flags only |
| `IS_NONE_OF:archived` | active flags only |
| `IS_NOT:live` | active non-live flags |

### Compatibility notes

- Existing `lifecycle` and `archived` queries are unaffected; the new capability only appears when `archived` is in the lifecycle value list.
- One edge case changes: passing **both** `archived=IS:true` **and** `lifecycle=IS:live` together previously intersected (≈ empty result) and now unions (live + archived). This combination is unusual and wasn't meaningfully useful before.
- The `archived` parameter is now deprecated in favor of `lifecycle=IS:archived`; it keeps working unchanged and removal is deferred to a future API-breaking release.

### Testing

- Added an e2e test in `feature.search.e2e.test.ts` covering `IS:archived` (incl. a legacy-style archived flag with no lifecycle row), `IS_ANY_OF:live,archived` (both), and `IS_NONE_OF:archived` (active only).
- Full feature-search e2e suite passes (37 tests).
- Updated the OpenAPI `lifecycle` param description (and fixed a pre-existing typo).