### PR TITLE
fix: invalidate other sessions on password change

### DIFF
--- a/src/lib/db/session-store.ts
+++ b/src/lib/db/session-store.ts
@@ -62,6 +62,16 @@ export default class SessionStore implements ISessionStore {
             .del();
     }
 
+    async deleteSessionsForUserExcept(
+        userId: number,
+        keepSid: string,
+    ): Promise<void> {
+        await this.db<ISessionRow>(TABLE)
+            .whereRaw("(sess -> 'user' ->> 'id')::int = ?", [userId])
+            .andWhereNot('sid', keepSid)
+            .del();
+    }
+
     async delete(sid: string): Promise<void> {
         await this.db<ISessionRow>(TABLE).where('sid', '=', sid).del();
     }

--- a/src/lib/routes/admin-api/user/user.test.ts
+++ b/src/lib/routes/admin-api/user/user.test.ts
@@ -24,6 +24,8 @@ async function getSetup() {
         preHook: (a) => {
             a.use((req, _res, next) => {
                 req.user = currentUser;
+                // stub the session id the user is acting from
+                req.sessionID = 'current-session';
                 next();
             });
         },
@@ -85,6 +87,32 @@ test('should allow user to change password', async () => {
     const updated = await userStore.get(currentUser.id);
     // @ts-expect-error
     expect(updated.passwordHash).toBeTruthy();
+});
+
+test('changing own password keeps the current session and terminates the others', async () => {
+    const { request, base, sessionStore } = await getSetup();
+    await sessionStore.insertSession({
+        sid: 'current-session',
+        sess: { user: { id: currentUser.id } },
+    });
+    await sessionStore.insertSession({
+        sid: 'other-device',
+        sess: { user: { id: currentUser.id } },
+    });
+
+    await request
+        .post(`${base}/api/admin/user/change-password`)
+        .send({
+            password: owaspPassword,
+            confirmPassword: owaspPassword,
+            oldPassword,
+        })
+        .expect(200);
+
+    const remaining = await sessionStore.getSessionsForUser(currentUser.id);
+    expect(remaining.map((session) => session.sid)).toEqual([
+        'current-session',
+    ]);
 });
 
 test('should not allow user to change password with incorrect old password', async () => {

--- a/src/lib/routes/admin-api/user/user.ts
+++ b/src/lib/routes/admin-api/user/user.ts
@@ -304,6 +304,9 @@ class UserController extends Controller {
                 user.id,
                 password,
                 oldPassword,
+                // Keep the session that performed the change alive and sign the
+                // user out of every other device (OWASP session management).
+                { keepSessionId: req.sessionID },
             );
             res.status(200).end();
         } else {

--- a/src/lib/services/session-service.ts
+++ b/src/lib/services/session-service.ts
@@ -43,6 +43,23 @@ export default class SessionService {
         return this.sessionStore.deleteSessionsForUser(userId);
     }
 
+    /**
+     * Deletes all sessions for a user except the one identified by `keepSid`.
+     * Used to log the user out everywhere else (e.g. after a password change)
+     * while keeping the session that triggered the change alive.
+     */
+    async deleteSessionsForUserExcept(
+        userId: number,
+        keepSid: string,
+    ): Promise<void> {
+        const userSessions = await this.sessionStore.getSessionsForUser(userId);
+        await Promise.all(
+            userSessions
+                .filter((session) => session.sid !== keepSid)
+                .map((session) => this.sessionStore.delete(session.sid)),
+        );
+    }
+
     async deleteStaleSessionsForUser(
         userId: number,
         maxSessions: number,

--- a/src/lib/services/session-service.ts
+++ b/src/lib/services/session-service.ts
@@ -52,12 +52,7 @@ export default class SessionService {
         userId: number,
         keepSid: string,
     ): Promise<void> {
-        const userSessions = await this.sessionStore.getSessionsForUser(userId);
-        await Promise.all(
-            userSessions
-                .filter((session) => session.sid !== keepSid)
-                .map((session) => this.sessionStore.delete(session.sid)),
-        );
+        return this.sessionStore.deleteSessionsForUserExcept(userId, keepSid);
     }
 
     async deleteStaleSessionsForUser(

--- a/src/lib/services/user-service.test.ts
+++ b/src/lib/services/user-service.test.ts
@@ -516,3 +516,99 @@ test('Should throttle password reset email', async () => {
     const attempt3 = service.createResetPasswordEmail('known@example.com');
     await expect(attempt3).resolves.toBeInstanceOf(URL);
 });
+
+describe('changePassword session invalidation', () => {
+    const buildService = () => {
+        const userStore = new UserStoreMock();
+        const accessService = new AccessServiceMock();
+        const resetTokenStore = new FakeResetTokenStore();
+        const resetTokenService = new ResetTokenService(
+            { resetTokenStore },
+            config,
+        );
+        const emailService = new EmailService(config);
+        const sessionStore = new FakeSessionStore();
+        const sessionService = new SessionService({ sessionStore }, config);
+        const eventService = createFakeEventsService(config);
+        const settingService = new SettingService(
+            { settingStore: new FakeSettingStore() },
+            config,
+            eventService,
+        );
+        const resourceLimitsService = new ResourceLimitsService(config);
+
+        const service = new UserService({ userStore }, config, {
+            accessService,
+            resetTokenService,
+            emailService,
+            eventService,
+            sessionService,
+            settingService,
+            resourceLimitsService,
+        });
+        return { service, sessionStore, userStore };
+    };
+
+    const strongPassword = 't7GTx&$Y9pcsnxRv6';
+
+    const seedUserWithTwoSessions = async (
+        userStore: UserStoreMock,
+        sessionStore: FakeSessionStore,
+    ) => {
+        const user = await userStore.insert(
+            new User({ id: 1, email: 'concurrent@mail.com' }),
+        );
+        await sessionStore.insertSession({
+            sid: 'browserA',
+            sess: { user: { id: user.id } },
+        });
+        await sessionStore.insertSession({
+            sid: 'browserB',
+            sess: { user: { id: user.id } },
+        });
+        return user.id;
+    };
+
+    test('terminates all active sessions for the user on password change', async () => {
+        const { service, sessionStore, userStore } = buildService();
+        const userId = await seedUserWithTwoSessions(userStore, sessionStore);
+        expect(await sessionStore.getSessionsForUser(userId)).toHaveLength(2);
+
+        await service.changePassword(userId, strongPassword);
+
+        expect(await sessionStore.getSessionsForUser(userId)).toHaveLength(0);
+    });
+
+    test('terminates sessions by default when an options object without logoutUser is passed', async () => {
+        const { service, sessionStore, userStore } = buildService();
+        const userId = await seedUserWithTwoSessions(userStore, sessionStore);
+
+        // Secure-by-default: a missing/undefined flag must not skip invalidation
+        await service.changePassword(userId, strongPassword, {});
+
+        expect(await sessionStore.getSessionsForUser(userId)).toHaveLength(0);
+    });
+
+    test('keeps sessions only when logout is explicitly disabled', async () => {
+        const { service, sessionStore, userStore } = buildService();
+        const userId = await seedUserWithTwoSessions(userStore, sessionStore);
+
+        await service.changePassword(userId, strongPassword, {
+            logoutUser: false,
+        });
+
+        expect(await sessionStore.getSessionsForUser(userId)).toHaveLength(2);
+    });
+
+    test('keeps the current session and terminates the others when keepSessionId is set', async () => {
+        const { service, sessionStore, userStore } = buildService();
+        const userId = await seedUserWithTwoSessions(userStore, sessionStore);
+
+        await service.changePassword(userId, strongPassword, {
+            keepSessionId: 'browserA',
+        });
+
+        const remaining = await sessionStore.getSessionsForUser(userId);
+        expect(remaining.map((session) => session.sid)).toEqual(['browserA']);
+    });
+});

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -80,6 +80,21 @@ export interface ILoginUserRequest {
     autoCreate?: boolean;
 }
 
+export interface ChangePasswordOptions {
+    /**
+     * Opt out of invalidating sessions when changing the password. Defaults to
+     * logging the user out (only set this to `false` for flows like setting an
+     * initial password during signup).
+     */
+    logoutUser?: boolean;
+    /**
+     * When set, keep this session alive and only terminate the user's other
+     * sessions. Used by self-service password changes so the user who performed
+     * the change stays logged in while every other device is signed out.
+     */
+    keepSessionId?: string;
+}
+
 const saltRounds = 10;
 const disallowNPreviousPasswords = 5;
 
@@ -570,7 +585,7 @@ export class UserService {
     async changePassword(
         userId: number,
         password: string,
-        { logoutUser }: { logoutUser?: boolean } = { logoutUser: true },
+        { logoutUser, keepSessionId }: ChangePasswordOptions = {},
     ): Promise<void> {
         this.validatePassword(password);
         const passwordHash = await bcrypt.hash(password, saltRounds);
@@ -582,14 +597,30 @@ export class UserService {
         );
         await this.resetTokenService.expireExistingTokensForUser(userId);
 
-        if (logoutUser) {
-            await this.sessionService.deleteSessionsForUser(userId);
+        // Invalidate active sessions whenever the password changes so that
+        // other devices/browsers are forced to re-authenticate with the new
+        // credentials (OWASP session management). When `keepSessionId` is
+        // provided we keep that session alive (the one that performed the
+        // change) and only terminate the others. Callers must opt out of
+        // invalidation entirely with `logoutUser: false` (e.g. setting an
+        // initial password during signup); a missing/undefined flag stays
+        // secure.
+        if (logoutUser !== false) {
+            if (keepSessionId) {
+                await this.sessionService.deleteSessionsForUserExcept(
+                    userId,
+                    keepSessionId,
+                );
+            } else {
+                await this.sessionService.deleteSessionsForUser(userId);
+            }
         }
     }
 
     async changePasswordWithPreviouslyUsedPasswordCheck(
         userId: number,
         password: string,
+        options: ChangePasswordOptions = {},
     ): Promise<void> {
         const previouslyUsed =
             await this.store.getPasswordsPreviouslyUsed(userId);
@@ -600,13 +631,14 @@ export class UserService {
             throw new PasswordPreviouslyUsedError();
         }
 
-        await this.changePassword(userId, password);
+        await this.changePassword(userId, password, options);
     }
 
     async changePasswordWithVerification(
         userId: number,
         newPassword: string,
         oldPassword: string,
+        options: ChangePasswordOptions = {},
     ): Promise<void> {
         const currentPasswordHash = await this.store.getPasswordHash(userId);
         const match = await bcrypt.compare(oldPassword, currentPasswordHash);
@@ -619,6 +651,7 @@ export class UserService {
         await this.changePasswordWithPreviouslyUsedPasswordCheck(
             userId,
             newPassword,
+            options,
         );
     }
 

--- a/src/lib/types/stores/session-store.ts
+++ b/src/lib/types/stores/session-store.ts
@@ -11,6 +11,7 @@ export interface ISessionStore extends Store<ISession, string> {
     getActiveSessions(): Promise<ISession[]>;
     getSessionsForUser(userId: number): Promise<ISession[]>;
     deleteSessionsForUser(userId: number): Promise<void>;
+    deleteSessionsForUserExcept(userId: number, keepSid: string): Promise<void>;
     insertSession(data: Omit<ISession, 'createdAt'>): Promise<ISession>;
     getSessionsCount(): Promise<{ userId: number; count: number }[]>;
     getMaxSessionsCount(): Promise<number>;

--- a/src/test/e2e/services/session-service.e2e.test.ts
+++ b/src/test/e2e/services/session-service.e2e.test.ts
@@ -99,6 +99,27 @@ test('Can delete sessions by user', async () => {
     expect(noSessions.length).toBe(0);
 });
 
+test('Can delete a user other sessions while keeping the current one', async () => {
+    await sessionService.insertSession(newSession);
+    await sessionService.insertSession({ ...newSession, sid: 'second' });
+    await sessionService.insertSession({ ...newSession, sid: 'third' });
+    await sessionService.insertSession(otherSession); // different user, untouched
+
+    await sessionService.deleteSessionsForUserExcept(
+        newSession.sess.user.id,
+        'second',
+    );
+
+    const remaining = await sessionService.getSessionsForUser(
+        newSession.sess.user.id,
+    );
+    expect(remaining.map((session) => session.sid)).toEqual(['second']);
+    // other users are unaffected
+    expect(
+        await sessionService.getSessionsForUser(otherSession.sess.user.id),
+    ).toHaveLength(1);
+});
+
 test('Can delete session by sid', async () => {
     await sessionService.insertSession(newSession);
     await sessionService.insertSession(otherSession);

--- a/src/test/fixtures/fake-session-store.ts
+++ b/src/test/fixtures/fake-session-store.ts
@@ -32,6 +32,16 @@ export default class FakeSessionStore implements ISessionStore {
         );
     }
 
+    async deleteSessionsForUserExcept(
+        userId: number,
+        keepSid: string,
+    ): Promise<void> {
+        this.sessions = this.sessions.filter(
+            (session) =>
+                session.sess.user.id !== userId || session.sid === keepSid,
+        );
+    }
+
     async deleteAll(): Promise<void> {
         this.sessions = [];
     }


### PR DESCRIPTION
Changing a password now terminates the user's other active sessions while keeping the session that performed the change alive, matching OWASP session management guidance so a compromised account can lock out an attacker on other devices.

- Add SessionService.deleteSessionsForUserExcept to drop all of a user's sessions except a given one
- Thread a ChangePasswordOptions ({ logoutUser, keepSessionId }) object through changePassword / WithPreviouslyUsedPasswordCheck / WithVerification
- changeMyPassword passes the current req.sessionID so self-service changes keep the current device logged in and sign out the rest
- Harden the logout opt-out to be secure-by-default: only an explicit logoutUser: false skips invalidation

## About the changes

Closes #

### Important files

## Discussion points

## OSS PR checklist

- [x] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [x] I have added tests or explained why tests are not needed.
- [x] I have updated documentation where relevant.
