### PR TITLE
remove v8 flag check; standardize new behavior

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
@@ -19,7 +19,6 @@ import { StrategyDragTooltip } from './StrategyDragTooltip.tsx';
 import { CleanupReminder } from '../CleanupReminder/CleanupReminder.tsx';
 import { useFeature } from '../../../../hooks/api/getters/useFeature/useFeature.ts';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
-import { useMinimumUnleashVersion } from 'hooks/useMinimumUnleashVersion.ts';
 import type { FeatureSchema, ProjectOverviewSchema } from 'openapi/index.ts';
 import { FeatureSetupBanner } from './FeatureSetupBanner.tsx';
 import { getFeatureSetupStage } from './getFeatureSetupStage.ts';
@@ -49,7 +48,6 @@ interface FeatureOverviewProps {
 }
 
 export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
-    const flipMainContentOrder = useMinimumUnleashVersion('8.0.0');
     const navigate = useNavigate();
     const projectId = useRequiredPathParam('projectId');
     const featureId = useRequiredPathParam('featureId');
@@ -106,20 +104,6 @@ export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
         <div>
             <CleanupReminder feature={feature} onChange={refetchFeature} />
             <StyledContainer>
-                {!flipMainContentOrder && (
-                    <div>
-                        {!featureLoading ? (
-                            <FeatureOverviewMetaData
-                                hiddenEnvironments={hiddenEnvironments}
-                                onEnvironmentVisibilityChange={
-                                    onEnvironmentVisibilityChange
-                                }
-                                feature={feature}
-                                onChange={refetchFeature}
-                            />
-                        ) : null}
-                    </div>
-                )}
                 <StyledMainContent>
                     {allLoadingDone &&
                         (shouldShowSetup ? (
@@ -142,20 +126,18 @@ export const FeatureOverview = ({ header }: FeatureOverviewProps) => {
                         hiddenEnvironments={hiddenEnvironments}
                     />
                 </StyledMainContent>
-                {flipMainContentOrder && (
-                    <div>
-                        {!featureLoading ? (
-                            <FeatureOverviewMetaData
-                                hiddenEnvironments={hiddenEnvironments}
-                                onEnvironmentVisibilityChange={
-                                    onEnvironmentVisibilityChange
-                                }
-                                feature={feature}
-                                onChange={refetchFeature}
-                            />
-                        ) : null}
-                    </div>
-                )}
+                <div>
+                    {!featureLoading ? (
+                        <FeatureOverviewMetaData
+                            hiddenEnvironments={hiddenEnvironments}
+                            onEnvironmentVisibilityChange={
+                                onEnvironmentVisibilityChange
+                            }
+                            feature={feature}
+                            onChange={refetchFeature}
+                        />
+                    ) : null}
+                </div>
                 <Routes>
                     <Route
                         path='strategies/create'

--- a/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx
@@ -1,32 +1,13 @@
-import { type PropsWithChildren, useState, type FC } from 'react';
-import {
-    IconButton,
-    styled,
-    Tab,
-    Tabs,
-    type Theme,
-    Typography,
-} from '@mui/material';
-import ArchiveOutlined from '@mui/icons-material/ArchiveOutlined';
-import WatchLaterOutlined from '@mui/icons-material/WatchLaterOutlined';
-import LibraryAddOutlined from '@mui/icons-material/LibraryAddOutlined';
-import Star from '@mui/icons-material/Star';
+import { useState, type FC } from 'react';
+import { styled, Tab, Tabs, type Theme, Typography } from '@mui/material';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
-import {
-    CREATE_FEATURE,
-    DELETE_FEATURE,
-    UPDATE_FEATURE,
-} from 'component/providers/AccessProvider/permissions';
-import PermissionIconButton from 'component/common/PermissionIconButton/PermissionIconButton';
 import { FeatureStatusChip } from 'component/common/FeatureStatusChip/FeatureStatusChip';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { useFavoriteFeaturesApi } from 'hooks/api/actions/useFavoriteFeaturesApi/useFavoriteFeaturesApi';
 import useToast from 'hooks/useToast';
 import { useUiFlag } from 'hooks/useUiFlag';
 import type { IFeatureToggle } from 'interfaces/featureToggle';
-import StarBorder from '@mui/icons-material/StarBorder';
-import { TooltipResolver } from 'component/common/TooltipResolver/TooltipResolver';
 import { ManageTagsDialog } from './FeatureOverview/ManageTagsDialog/ManageTagsDialog.tsx';
 import { FeatureStaleDialog } from 'component/common/FeatureStaleDialog/FeatureStaleDialog';
 import { FeatureArchiveDialog } from 'component/common/FeatureArchiveDialog/FeatureArchiveDialog';
@@ -64,40 +45,8 @@ const StyledTitle = styled('div')(({ theme }) => ({
 const LowerHeaderRow = styled(UpperHeaderRow)(({ theme }) => ({
     justifyContent: 'space-between',
     columnGap: 0,
-    alignItems: 'center',
     flexFlow: 'row nowrap',
 }));
-
-const HeaderActions = styled('div', {
-    shouldForwardProp: (propName) => propName !== 'showOnNarrowScreens',
-})<{ showOnNarrowScreens?: boolean }>(({ theme, showOnNarrowScreens }) => ({
-    display: showOnNarrowScreens ? 'flex' : 'none',
-    flexFlow: 'row nowrap',
-    alignItems: 'center',
-
-    ...onWideHeader(theme, {
-        display: showOnNarrowScreens ? 'none' : 'flex',
-    }),
-}));
-
-const IconButtonWithTooltip: FC<
-    PropsWithChildren<{
-        onClick: () => void;
-        label: string;
-    }>
-> = ({ children, label, onClick }) => {
-    return (
-        <TooltipResolver
-            title={label}
-            arrow
-            onClick={(e) => e.preventDefault()}
-        >
-            <IconButton aria-label={label} onClick={onClick}>
-                {children}
-            </IconButton>
-        </TooltipResolver>
-    );
-};
 
 const StyledTabs = styled(Tabs)({
     minWidth: 0,
@@ -133,72 +82,6 @@ const useLegacyVariants = (environments: IFeatureToggle['environments']) => {
         (environment) => environment.variants?.length,
     );
     return enableLegacyVariants || existingLegacyVariantsExist;
-};
-
-type HeaderActionsProps = {
-    feature: IFeatureToggle;
-    showOnNarrowScreens?: boolean;
-    onFavorite: () => void;
-    openStaleDialog: () => void;
-    openDeleteDialog: () => void;
-};
-
-const HeaderActionsComponent = ({
-    showOnNarrowScreens,
-    feature,
-    onFavorite,
-    openStaleDialog,
-    openDeleteDialog,
-}: HeaderActionsProps) => {
-    const projectId = useRequiredPathParam('projectId');
-    const featureId = useRequiredPathParam('featureId');
-    return (
-        <HeaderActions showOnNarrowScreens={showOnNarrowScreens}>
-            <IconButtonWithTooltip
-                label='Favorite this feature flag'
-                onClick={onFavorite}
-                data-loading
-            >
-                {feature.favorite ? <Star /> : <StarBorder />}
-            </IconButtonWithTooltip>
-            <PermissionIconButton
-                permission={CREATE_FEATURE}
-                projectId={projectId}
-                data-loading
-                component={Link}
-                nativeButton={false}
-                to={`/projects/${projectId}/features/${featureId}/copy`}
-                tooltipProps={{
-                    title: 'Clone',
-                }}
-            >
-                <LibraryAddOutlined />
-            </PermissionIconButton>
-
-            <PermissionIconButton
-                permission={DELETE_FEATURE}
-                projectId={projectId}
-                tooltipProps={{
-                    title: 'Archive feature flag',
-                }}
-                data-loading
-                onClick={openDeleteDialog}
-            >
-                <ArchiveOutlined />
-            </PermissionIconButton>
-            <PermissionIconButton
-                onClick={openStaleDialog}
-                permission={UPDATE_FEATURE}
-                projectId={projectId}
-                tooltipProps={{
-                    title: 'Toggle stale state',
-                }}
-                data-loading
-            >
-                <WatchLaterOutlined />
-            </PermissionIconButton>
-        </HeaderActions>
-    );
 };
 
 type Props = {

--- a/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx
@@ -1,6 +1,6 @@
 import { useState, type FC } from 'react';
 import { styled, Tab, Tabs, type Theme, Typography } from '@mui/material';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
 import { FeatureStatusChip } from 'component/common/FeatureStatusChip/FeatureStatusChip';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
@@ -8,7 +8,6 @@ import { useFavoriteFeaturesApi } from 'hooks/api/actions/useFavoriteFeaturesApi
 import useToast from 'hooks/useToast';
 import { useUiFlag } from 'hooks/useUiFlag';
 import type { IFeatureToggle } from 'interfaces/featureToggle';
-import { ManageTagsDialog } from './FeatureOverview/ManageTagsDialog/ManageTagsDialog.tsx';
 import { FeatureStaleDialog } from 'component/common/FeatureStaleDialog/FeatureStaleDialog';
 import { FeatureArchiveDialog } from 'component/common/FeatureArchiveDialog/FeatureArchiveDialog';
 import { FeatureArchiveNotAllowedDialog } from 'component/common/FeatureArchiveDialog/FeatureArchiveNotAllowedDialog';
@@ -42,11 +41,11 @@ const StyledTitle = styled('div')(({ theme }) => ({
     columnGap: theme.spacing(0.5),
 }));
 
-const LowerHeaderRow = styled(UpperHeaderRow)(({ theme }) => ({
+const LowerHeaderRow = styled(UpperHeaderRow)({
     justifyContent: 'space-between',
     columnGap: 0,
     flexFlow: 'row nowrap',
-}));
+});
 
 const StyledTabs = styled(Tabs)({
     minWidth: 0,
@@ -68,14 +67,6 @@ const StyledTabButton = styled(Tab)(({ theme }) => ({
     }),
 }));
 
-export const StyledLink = styled(Link)(() => ({
-    maxWidth: '100%',
-    textDecoration: 'none',
-    '&:hover, &:focus': {
-        textDecoration: 'underline',
-    },
-}));
-
 const useLegacyVariants = (environments: IFeatureToggle['environments']) => {
     const enableLegacyVariants = useUiFlag('enableLegacyVariants');
     const existingLegacyVariantsExist = environments.some(
@@ -95,7 +86,6 @@ export const FeatureViewHeader: FC<Props> = ({ feature }) => {
     const { refetchFeature } = useFeature(projectId, featureId);
     const { setToastApiError } = useToast();
 
-    const [openTagDialog, setOpenTagDialog] = useState(false);
     const [showDelDialog, setShowDelDialog] = useState(false);
     const [openStaleDialog, setOpenStaleDialog] = useState(false);
 
@@ -215,7 +205,6 @@ export const FeatureViewHeader: FC<Props> = ({ feature }) => {
                 featureId={featureId}
                 projectId={projectId}
             />
-            <ManageTagsDialog open={openTagDialog} setOpen={setOpenTagDialog} />
         </>
     );
 };

--- a/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureViewHeader.tsx
@@ -32,7 +32,6 @@ import { FeatureStaleDialog } from 'component/common/FeatureStaleDialog/FeatureS
 import { FeatureArchiveDialog } from 'component/common/FeatureArchiveDialog/FeatureArchiveDialog';
 import { FeatureArchiveNotAllowedDialog } from 'component/common/FeatureArchiveDialog/FeatureArchiveNotAllowedDialog';
 import { FeatureCopyName } from './FeatureCopyName/FeatureCopyName.tsx';
-import { useMinimumUnleashVersion } from 'hooks/useMinimumUnleashVersion';
 import { FeatureHeaderActionsKebab } from './FeatureHeaderActionsKebab';
 
 const StyledHeader = styled('div')(({ theme }) => ({
@@ -65,16 +64,8 @@ const StyledTitle = styled('div')(({ theme }) => ({
 const LowerHeaderRow = styled(UpperHeaderRow)(({ theme }) => ({
     justifyContent: 'space-between',
     columnGap: 0,
-    flexFlow: 'column nowrap',
-    alignItems: 'flex-start',
-    '&[data-reflow-on-narrow="false"]': {
-        alignItems: 'center',
-        flexFlow: 'row nowrap',
-    },
-    ...onWideHeader(theme, {
-        alignItems: 'center',
-        flexFlow: 'row nowrap',
-    }),
+    alignItems: 'center',
+    flexFlow: 'row nowrap',
 }));
 
 const HeaderActions = styled('div', {
@@ -232,7 +223,6 @@ export const FeatureViewHeader: FC<Props> = ({ feature }) => {
     const basePath = `/projects/${projectId}/features/${featureId}`;
 
     const showLegacyVariants = useLegacyVariants(feature.environments);
-    const useKebabActions = !useMinimumUnleashVersion('8.0.0');
 
     const tabData = [
         {
@@ -278,20 +268,6 @@ export const FeatureViewHeader: FC<Props> = ({ feature }) => {
         }
     };
 
-    const HeaderActionsInner: FC<{ showOnNarrowScreens?: boolean }> = ({
-        showOnNarrowScreens,
-    }) => {
-        return (
-            <HeaderActionsComponent
-                showOnNarrowScreens={showOnNarrowScreens}
-                feature={feature}
-                onFavorite={onFavorite}
-                openStaleDialog={() => setOpenStaleDialog(true)}
-                openDeleteDialog={() => setShowDelDialog(true)}
-            />
-        );
-    };
-
     return (
         <>
             <StyledHeader>
@@ -302,10 +278,7 @@ export const FeatureViewHeader: FC<Props> = ({ feature }) => {
                     </StyledTitle>
                     {feature.stale ? <FeatureStatusChip stale={true} /> : null}
                 </UpperHeaderRow>
-                <LowerHeaderRow data-reflow-on-narrow={!useKebabActions}>
-                    {!useKebabActions && (
-                        <HeaderActionsInner showOnNarrowScreens />
-                    )}
+                <LowerHeaderRow>
                     <StyledTabs
                         value={activeTab.path}
                         indicatorColor='primary'
@@ -323,16 +296,12 @@ export const FeatureViewHeader: FC<Props> = ({ feature }) => {
                             />
                         ))}
                     </StyledTabs>
-                    {useKebabActions ? (
-                        <FeatureHeaderActionsKebab
-                            feature={feature}
-                            onFavorite={onFavorite}
-                            openStaleDialog={() => setOpenStaleDialog(true)}
-                            openDeleteDialog={() => setShowDelDialog(true)}
-                        />
-                    ) : (
-                        <HeaderActionsInner />
-                    )}
+                    <FeatureHeaderActionsKebab
+                        feature={feature}
+                        onFavorite={onFavorite}
+                        openStaleDialog={() => setOpenStaleDialog(true)}
+                        openDeleteDialog={() => setShowDelDialog(true)}
+                    />
                 </LowerHeaderRow>
             </StyledHeader>
             {feature.children.length > 0 ? (


### PR DESCRIPTION
Makes the kebab menu and the flipped env/meta section of feature flags the new standard / removes the v8 flag. 

And yes, the check was flipped for the kebab menu. I accidentally committed a reversal.