### PR TITLE
fix: update lifecycle counts immediately after archiving/reviving/deleting flags

### DIFF
--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -40,6 +40,7 @@ import {
 import { AvatarCell } from './AvatarCell.tsx';
 import { Box, styled, useMediaQuery, useTheme } from '@mui/material';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
+import { useProjectStatus } from 'hooks/api/getters/useProjectStatus/useProjectStatus';
 import { ConnectSdkDialog } from '../../../onboarding/dialog/ConnectSdkDialog/ConnectSdkDialog.tsx';
 import { ProjectOnboarding } from '../../../onboarding/flow/ProjectOnboarding.tsx';
 import { useLocalStorageState } from 'hooks/useLocalStorageState';
@@ -123,6 +124,12 @@ export const ProjectFeatureToggles = ({
     const { onFlagTypeClick, onTagClick, onAvatarClick } =
         useProjectFeatureSearchActions(tableState, setTableState);
 
+    const { refetch: refetchProjectStatus } = useProjectStatus(projectId);
+    const refetchWithLifecycleCounts = useCallback(() => {
+        refetch();
+        refetchProjectStatus();
+    }, [refetch, refetchProjectStatus]);
+
     const filterState = {
         tag: tableState.tag,
         createdAt: tableState.createdAt,
@@ -164,7 +171,11 @@ export const ProjectFeatureToggles = ({
         setShowMarkCompletedDialogue,
         setShowFeatureReviveDialogue,
         setShowFeatureDeleteDialogue,
-    } = useRowActions(refetch, projectId, trackArchiveAction);
+    } = useRowActions(
+        refetchWithLifecycleCounts,
+        projectId,
+        trackArchiveAction,
+    );
 
     const isPlaceholder = Boolean(initialLoad || loading);
 
@@ -279,7 +290,7 @@ export const ProjectFeatureToggles = ({
                                 open: true,
                             });
                         }}
-                        onUncomplete={refetch}
+                        onUncomplete={refetchWithLifecycleCounts}
                         onArchive={() => setFeatureArchiveState(original.name)}
                         data-loading
                     />
@@ -627,7 +638,7 @@ export const ProjectFeatureToggles = ({
                         selectedIds={Object.keys(rowSelection)}
                         projectId={projectId}
                         onConfirm={() => {
-                            refetch();
+                            refetchWithLifecycleCounts();
                             table.resetRowSelection();
                             trackArchiveAction('bulk archived');
                         }}
@@ -638,7 +649,7 @@ export const ProjectFeatureToggles = ({
                         data={selectedData}
                         projectId={projectId}
                         onResetSelection={table.resetRowSelection}
-                        onChange={refetch}
+                        onChange={refetchWithLifecycleCounts}
                     />
                 )}
             </BatchSelectionActionsBar>

--- a/src/lib/features/project-status/project-lifecycle-read-model/project-lifecycle-summary-read-model.test.ts
+++ b/src/lib/features/project-status/project-lifecycle-read-model/project-lifecycle-summary-read-model.test.ts
@@ -313,6 +313,46 @@ describe('count current flags in each stage', () => {
         });
     });
 
+    test('a revived flag whose latest lifecycle stage is still archived is counted as initial', async () => {
+        const project = await db.stores.projectStore.create({
+            name: 'project',
+            id: randomId(),
+        });
+
+        const flag = await db.stores.featureToggleStore.create(project.id, {
+            name: randomId(),
+            createdByUserId: 1,
+        });
+
+        const time = Date.now();
+        const stages = ['initial', 'archived'];
+        for (const [index, stage] of stages.entries()) {
+            await db.stores.featureLifecycleStore.insert([
+                {
+                    feature: flag.name,
+                    stage: stage as StageName,
+                },
+            ]);
+
+            await db
+                .rawDatabase('feature_lifecycles')
+                .where({
+                    feature: flag.name,
+                    stage: stage,
+                })
+                .update({
+                    created_at: addMinutes(time, index),
+                });
+        }
+
+        const result = await readModel.getCurrentFlagsInEachStage(project.id);
+
+        expect(result).toMatchObject({
+            initial: 1,
+            archived: 0,
+        });
+    });
+
     test('the archived count is based on the features table (source of truth), not the lifecycle table', async () => {
         const project = await db.stores.projectStore.create({
             name: 'project',

--- a/src/lib/features/project-status/project-lifecycle-read-model/project-lifecycle-summary-read-model.ts
+++ b/src/lib/features/project-status/project-lifecycle-read-model/project-lifecycle-summary-read-model.ts
@@ -98,7 +98,6 @@ export class ProjectLifecycleSummaryReadModel
             })
             .innerJoin('features as f', 'fl.feature', 'f.name')
             .where('f.project', projectId)
-            .whereNot('fl.stage', 'archived')
             .whereNull('f.archived_at')
             .select('fl.stage')
             .count('fl.feature as flag_count')
@@ -113,7 +112,11 @@ export class ProjectLifecycleSummaryReadModel
 
         const lifecycleStages = result.reduce(
             (acc, row) => {
-                acc[row.stage] = Number(row.flag_count);
+                // A non-archived flag whose latest lifecycle stage is
+                // 'archived' has just been revived; the lifecycle event
+                // listener will move it back to 'initial' shortly.
+                const stage = row.stage === 'archived' ? 'initial' : row.stage;
+                acc[stage] += Number(row.flag_count);
                 return acc;
             },
             {


### PR DESCRIPTION
The lifecycle stage counts (shown in the lifecycle filter chips) went stale after archiving or reviving a flag, and only recovered on a full page refresh. Two separate causes:

- The project flags table only refetched the feature search after archive/revive/delete/complete actions, never the project status endpoint that provides the lifecycle summary.

- Even with a refetch, a revived flag was counted in no stage at all for a short while. Reviving clears features.archived_at synchronously, but the feature_lifecycles rows are only rewritten once the FEATURE_REVIVED event is announced and handled, and the event announcer runs on a 1s schedule. In that window the flag's latest lifecycle stage was still archived, which the lifecycle summary query excluded entirely.

This fixes both ends:

- ProjectFeatureToggles refetches the project status alongside the feature search for every action that changes lifecycle stage membership (archive, revive, delete, mark completed, and their batch variants).

- The project lifecycle summary read model counts non-archived flags whose latest lifecycle stage is still archived as initial -- the stage the lifecycle event handler is about to move them to anyway.

