### PR TITLE
 feat: lifecycle-driven archived view in project flags 

### DIFF
--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.test.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.test.tsx
@@ -3,8 +3,12 @@ import { render } from 'utils/testRenderer';
 import { Route, Routes } from 'react-router-dom';
 import { ProjectFeatureToggles } from './ProjectFeatureToggles.tsx';
 import { testServerRoute, testServerSetup } from 'utils/testServer';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import { BATCH_SELECTED_COUNT } from 'utils/testIds';
+import {
+    DELETE_FEATURE,
+    UPDATE_FEATURE,
+} from 'component/providers/AccessProvider/permissions';
 
 const server = testServerSetup();
 
@@ -315,4 +319,62 @@ test('clears lifecycle filter when switching to archived view', async () => {
 
     expect(window.location.href).not.toContain('lifecycle=IS%3Alive');
     expect(window.location.href).toContain('archived=IS%3Atrue');
+}, 10000);
+
+test('shows revive and delete actions for archived flags', async () => {
+    setupApi();
+    testServerRoute(server, '/api/admin/search/features', {
+        features: [
+            {
+                name: 'activeFeature',
+                type: 'release',
+                createdBy: { id: 1, name: 'author' },
+            },
+            {
+                name: 'archivedFeature',
+                type: 'release',
+                archivedAt: '2024-01-01T00:00:00.000Z',
+                createdBy: { id: 1, name: 'author' },
+            },
+        ],
+        total: 2,
+    });
+
+    render(
+        <Routes>
+            <Route
+                path={'/projects/:projectId'}
+                element={
+                    <ProjectFeatureToggles
+                        environments={['development', 'production']}
+                    />
+                }
+            />
+        </Routes>,
+        {
+            route: '/projects/default',
+            permissions: [
+                { permission: UPDATE_FEATURE, project: 'default' },
+                { permission: DELETE_FEATURE, project: 'default' },
+            ],
+        },
+    );
+
+    const archivedFeature = await screen.findByText('archivedFeature');
+    const archivedRow = archivedFeature.closest('tr')!;
+
+    fireEvent.click(
+        within(archivedRow).getByRole('button', {
+            name: 'Feature flag actions',
+        }),
+    );
+
+    await screen.findByRole('menuitem', { name: 'Revive feature flag' });
+    screen.getByRole('menuitem', { name: 'Delete feature flag' });
+    expect(
+        screen.queryByRole('menuitem', { name: 'Archive' }),
+    ).not.toBeInTheDocument();
+    expect(
+        screen.queryByRole('menuitem', { name: 'Clone' }),
+    ).not.toBeInTheDocument();
 }, 10000);

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.test.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.test.tsx
@@ -3,7 +3,7 @@ import { render } from 'utils/testRenderer';
 import { Route, Routes } from 'react-router-dom';
 import { ProjectFeatureToggles } from './ProjectFeatureToggles.tsx';
 import { testServerRoute, testServerSetup } from 'utils/testServer';
-import { fireEvent, screen, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { BATCH_SELECTED_COUNT } from 'utils/testIds';
 import {
     DELETE_FEATURE,
@@ -377,4 +377,34 @@ test('shows revive and delete actions for archived flags', async () => {
     expect(
         screen.queryByRole('menuitem', { name: 'Clone' }),
     ).not.toBeInTheDocument();
+}, 10000);
+
+test('rewrites legacy archived view URLs to the archived lifecycle filter', async () => {
+    setupApi();
+    testServerRoute(server, '/api/admin/ui-config', {
+        flags: {
+            archiveInFlagsView: true,
+        },
+    });
+
+    render(
+        <Routes>
+            <Route
+                path={'/projects/:projectId'}
+                element={
+                    <ProjectFeatureToggles
+                        environments={['development', 'production']}
+                    />
+                }
+            />
+        </Routes>,
+        {
+            route: '/projects/default?archived=IS%3Atrue',
+        },
+    );
+
+    await waitFor(() => {
+        expect(window.location.href).not.toContain('archived=IS%3Atrue');
+        expect(window.location.href).toContain('lifecycle=IS%3Aarchived');
+    });
 }, 10000);

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -52,6 +52,7 @@ import { formatEnvironmentColumnId } from './formatEnvironmentColumnId.ts';
 import { ProjectFeaturesColumnsMenu } from './ProjectFeaturesColumnsMenu/ProjectFeaturesColumnsMenu.tsx';
 import { ProjectFeatureTogglesHeader } from './ProjectFeatureTogglesHeader/ProjectFeatureTogglesHeader.tsx';
 import { ProjectFlagsSearch } from './ProjectFlagsSearch/ProjectFlagsSearch.tsx';
+import { useUiFlag } from 'hooks/useUiFlag.ts';
 
 type ProjectFeatureTogglesProps = {
     environments: string[];
@@ -109,6 +110,7 @@ export const ProjectFeatureToggles = ({
     const [modalOpen, setModalOpen] = useState(false);
     const theme = useTheme();
     const isMediumScreen = useMediaQuery(theme.breakpoints.down('xl'));
+    const showArchivedLink = !useUiFlag('archiveInFlagsView');
 
     const {
         features,
@@ -503,11 +505,16 @@ export const ProjectFeatureToggles = ({
                         totalItems={total}
                         environmentsToExport={environments}
                         actions={
-                            <LinkToggle type='button' onClick={toggleArchived}>
-                                {showArchived
-                                    ? 'View active flags'
-                                    : 'View archived flags'}
-                            </LinkToggle>
+                            showArchivedLink && (
+                                <LinkToggle
+                                    type='button'
+                                    onClick={toggleArchived}
+                                >
+                                    {showArchived
+                                        ? 'View active flags'
+                                        : 'View archived flags'}
+                                </LinkToggle>
+                            )
                         }
                         title={
                             showArchived

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -111,7 +111,8 @@ export const ProjectFeatureToggles = ({
     const [modalOpen, setModalOpen] = useState(false);
     const theme = useTheme();
     const isMediumScreen = useMediaQuery(theme.breakpoints.down('xl'));
-    const showArchivedLink = !useUiFlag('archiveInFlagsView');
+    const archiveInFlagsView = useUiFlag('archiveInFlagsView');
+    const showArchivedLink = !archiveInFlagsView;
 
     const {
         features,
@@ -122,6 +123,17 @@ export const ProjectFeatureToggles = ({
         tableState,
         setTableState,
     } = useProjectFeatureSearch(projectId);
+
+    // The legacy archived view can still be reached through old URLs;
+    // rewrite them to the archived lifecycle filter, which has replaced it.
+    useEffect(() => {
+        if (archiveInFlagsView && tableState.archived) {
+            setTableState({
+                archived: undefined,
+                lifecycle: { operator: 'IS', values: ['archived'] },
+            });
+        }
+    }, [archiveInFlagsView, tableState.archived, setTableState]);
 
     const { onFlagTypeClick, onTagClick, onAvatarClick } =
         useProjectFeatureSearchActions(tableState, setTableState);

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -7,6 +7,7 @@ import { PaginatedTable } from 'component/common/Table';
 import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
 import { FavoriteIconHeader } from 'component/common/Table/FavoriteIconHeader/FavoriteIconHeader';
 import { ActionsCell } from '../ProjectFeatureToggles/ActionsCell/ActionsCell.tsx';
+import { ArchivedActionsCell } from '../ProjectFeatureToggles/ActionsCell/ArchivedActionsCell.tsx';
 import { useFavoriteFeaturesApi } from 'hooks/api/actions/useFavoriteFeaturesApi/useFavoriteFeaturesApi';
 import { MemoizedRowSelectCell } from '../ProjectFeatureToggles/RowSelectCell/RowSelectCell.tsx';
 import { BatchSelectionActionsBar } from 'component/common/BatchSelectionActionsBar/BatchSelectionActionsBar';
@@ -359,6 +360,22 @@ export const ProjectFeatureToggles = ({
                     tableState.archived ? (
                         <ArchivedFeatureActionCell
                             project={projectId}
+                            onRevive={() => {
+                                setShowFeatureReviveDialogue({
+                                    featureId: row.id,
+                                    open: true,
+                                });
+                            }}
+                            onDelete={() => {
+                                setShowFeatureDeleteDialogue({
+                                    featureId: row.id,
+                                    open: true,
+                                });
+                            }}
+                        />
+                    ) : row.original.archivedAt ? (
+                        <ArchivedActionsCell
+                            projectId={projectId}
                             onRevive={() => {
                                 setShowFeatureReviveDialogue({
                                     featureId: row.id,

--- a/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ArchivedActionsCell.tsx
+++ b/frontend/src/component/project/Project/ProjectFeatureToggles/ActionsCell/ArchivedActionsCell.tsx
@@ -1,0 +1,118 @@
+import { useId, useState, type FC, type MouseEvent } from 'react';
+import {
+    Box,
+    IconButton,
+    ListItemIcon,
+    ListItemText,
+    Menu,
+    MenuItem,
+    Tooltip,
+    Typography,
+    styled,
+} from '@mui/material';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import UndoIcon from '@mui/icons-material/Undo';
+import DeleteIcon from '@mui/icons-material/Delete';
+import {
+    DELETE_FEATURE,
+    UPDATE_FEATURE,
+} from 'component/providers/AccessProvider/permissions';
+import { useCheckProjectPermissions } from 'hooks/useHasAccess';
+
+const StyledBoxCell = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'center',
+    paddingRight: theme.spacing(2),
+}));
+
+interface IArchivedActionsCellProps {
+    projectId: string;
+    onRevive: () => void;
+    onDelete: () => void;
+}
+
+export const ArchivedActionsCell: FC<IArchivedActionsCellProps> = ({
+    projectId,
+    onRevive,
+    onDelete,
+}) => {
+    const checkAccess = useCheckProjectPermissions(projectId);
+    const canRevive = checkAccess(UPDATE_FEATURE);
+    const canDelete = checkAccess(DELETE_FEATURE);
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const open = Boolean(anchorEl);
+    const buttonId = useId();
+    const menuId = useId();
+
+    const handleClick = (event: MouseEvent<HTMLElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    return (
+        <StyledBoxCell>
+            <Tooltip title='Feature flag actions' arrow describeChild>
+                <IconButton
+                    aria-label='Feature flag actions'
+                    id={buttonId}
+                    data-loading
+                    aria-controls={open ? menuId : undefined}
+                    aria-haspopup='true'
+                    aria-expanded={open}
+                    onClick={handleClick}
+                    type='button'
+                >
+                    <MoreVertIcon />
+                </IconButton>
+            </Tooltip>
+            <Menu
+                id={menuId}
+                anchorEl={anchorEl}
+                open={open}
+                onClose={handleClose}
+                anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+                transformOrigin={{ horizontal: 'right', vertical: 'top' }}
+                slotProps={{
+                    list: {
+                        'aria-labelledby': buttonId,
+                    },
+                }}
+            >
+                <MenuItem
+                    disabled={!canRevive}
+                    onClick={() => {
+                        onRevive();
+                        handleClose();
+                    }}
+                >
+                    <ListItemIcon>
+                        <UndoIcon />
+                    </ListItemIcon>
+                    <ListItemText>
+                        <Typography variant='body2'>
+                            Revive feature flag
+                        </Typography>
+                    </ListItemText>
+                </MenuItem>
+                <MenuItem
+                    disabled={!canDelete}
+                    onClick={() => {
+                        onDelete();
+                        handleClose();
+                    }}
+                >
+                    <ListItemIcon>
+                        <DeleteIcon />
+                    </ListItemIcon>
+                    <ListItemText>
+                        <Typography variant='body2'>
+                            Delete feature flag
+                        </Typography>
+                    </ListItemText>
+                </MenuItem>
+            </Menu>
+        </StyledBoxCell>
+    );
+};


### PR DESCRIPTION
## About the changes

With `archiveInFlagsView` enabled, archived flags are reachable from the project flags table through the lifecycle selector's **Archived** stage, replacing the separate archived view. This PR makes that view behave correctly:

- **Row actions for archived flags.** Archived rows get a kebab menu (new `ArchivedActionsCell`) with the same actions as the archive table: **Revive** and **Delete**, wired to the same confirm dialogs (already rendered by `useRowActions`). The actions column branches per row on `archivedAt`, so this works in any view that mixes archived rows in. 
- **Legacy URL migration.** The "View archived flags" link is hidden when the flag is on, but old URLs (`?archived=IS%3Atrue`) still resurrected the legacy archived view — which, with the link hidden, had no way back out. Those URLs are now rewritten in place to `?lifecycle=IS%3Aarchived`.

### Testing

Two new component tests: archived rows show Revive/Delete (and not Archive/Clone) in the kebab; legacy `archived=IS%3Atrue` URLs get rewritten to the lifecycle filter. Existing tests cover the legacy view staying intact with the flag off.

<img width="1494" height="407" alt="image" src="https://github.com/user-attachments/assets/c5b43344-47d1-4864-b285-291e4b199708" />

Closes: dx-4672-project-overview-page
