### PR TITLE
chore: hide archived badge on archived flag rows

### DIFF
--- a/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
+++ b/frontend/src/component/common/Table/cells/FeatureOverviewCell/FeatureOverviewCell.tsx
@@ -17,6 +17,7 @@ import { getLocalizedDateString } from '../../../util.ts';
 import { Tag } from 'component/common/Tag/Tag';
 import { formatTag } from 'utils/format-tag';
 import { Truncator } from 'component/common/Truncator/Truncator';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 interface IFeatureNameCellProps {
     row: {
@@ -323,6 +324,7 @@ export const PrimaryFeatureInfo: FC<{
     onFavorite,
 }) => {
     const { featureTypes } = useFeatureTypes();
+    const showArchivedBadge = !useUiFlag('archiveInFlagsView');
     const IconComponent = getFeatureTypeIcons(type);
     const typeName = featureTypes.find(
         (featureType) => featureType.id === type,
@@ -391,7 +393,7 @@ export const PrimaryFeatureInfo: FC<{
                     </HtmlTooltip>
                 }
             />
-            {archivedAt && (
+            {archivedAt && showArchivedBadge && (
                 <HtmlTooltip arrow title={archivedDate} describeChild>
                     <Badge tabIndex={0} color='neutral'>
                         Archived


### PR DESCRIPTION
Hide archive badge in the new lifecycle view.

<img width="1504" height="296" alt="image" src="https://github.com/user-attachments/assets/e4aa92ac-f011-447e-bf45-9cfcbb175066" />