### PR TITLE
chore: redirect /archive to flags page 

### DIFF
--- a/frontend/src/component/archive/FeaturesArchiveTable.test.tsx
+++ b/frontend/src/component/archive/FeaturesArchiveTable.test.tsx
@@ -1,0 +1,64 @@
+import { expect, test } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { render } from 'utils/testRenderer';
+import { testServerRoute, testServerSetup } from 'utils/testServer';
+import { FeaturesArchiveTable } from './FeaturesArchiveTable';
+
+const server = testServerSetup();
+
+const setupApi = (archiveInFlagsView: boolean) => {
+    testServerRoute(server, '/api/admin/ui-config', {
+        flags: { archiveInFlagsView },
+    });
+};
+
+test('redirects to the lifecycle-archived overview when archiveInFlagsView is on', async () => {
+    setupApi(true);
+
+    render(<FeaturesArchiveTable />, { route: '/archive' });
+
+    await waitFor(() => {
+        expect(window.location.pathname).toBe('/search');
+    });
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get('lifecycle')).toBe('IS:archived');
+});
+
+test('maps the archive search term to the overview query param', async () => {
+    setupApi(true);
+
+    render(<FeaturesArchiveTable />, { route: '/archive?search=myflag' });
+
+    await waitFor(() => {
+        expect(window.location.pathname).toBe('/search');
+    });
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get('lifecycle')).toBe('IS:archived');
+    expect(params.get('query')).toBe('myflag');
+    expect(params.get('search')).toBeNull();
+});
+
+test('preserves other query params on redirect', async () => {
+    setupApi(true);
+
+    render(<FeaturesArchiveTable />, {
+        route: '/archive?sortBy=createdAt&sortOrder=desc',
+    });
+
+    await waitFor(() => {
+        expect(window.location.pathname).toBe('/search');
+    });
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get('lifecycle')).toBe('IS:archived');
+    expect(params.get('sortBy')).toBe('createdAt');
+    expect(params.get('sortOrder')).toBe('desc');
+});
+
+test('renders the archive table without redirecting when the flag is off', async () => {
+    setupApi(false);
+
+    render(<FeaturesArchiveTable />, { route: '/archive' });
+
+    await screen.findByText('None of the feature flags were archived yet.');
+    expect(window.location.pathname).toBe('/archive');
+});

--- a/frontend/src/component/archive/FeaturesArchiveTable.tsx
+++ b/frontend/src/component/archive/FeaturesArchiveTable.tsx
@@ -2,7 +2,8 @@ import { ArchiveTable } from 'component/archive/ArchiveTable/ArchiveTable';
 import { usePageTitle } from 'hooks/usePageTitle';
 import { createLocalStorage } from 'utils/createLocalStorage';
 import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
-import { useSearchParams } from 'react-router-dom';
+import { Navigate, useSearchParams } from 'react-router-dom';
+import { useUiFlag } from 'hooks/useUiFlag';
 
 const defaultSort: { id: string; desc?: boolean } = { id: 'createdAt' };
 const { value, setValue } = createLocalStorage(
@@ -11,17 +12,29 @@ const { value, setValue } = createLocalStorage(
 );
 
 export const FeaturesArchiveTable = () => {
+    const archiveInFlagsView = useUiFlag('archiveInFlagsView');
     usePageTitle('Archive');
     const [searchParams] = useSearchParams();
+    const search = searchParams.get('search');
 
     const {
         features: archivedFeatures,
         loading,
         refetch,
     } = useFeatureSearch({
-        query: searchParams.get('search') || undefined,
+        query: search || undefined,
         archived: 'IS:true',
     });
+
+    if (archiveInFlagsView) {
+        const params = new URLSearchParams(searchParams);
+        if (search) {
+            params.set('query', search);
+            params.delete('search');
+        }
+        params.set('lifecycle', 'IS:archived');
+        return <Navigate to={`/search?${params.toString()}`} replace />;
+    }
 
     return (
         <ArchiveTable


### PR DESCRIPTION
- Redirects from /archive to the archived view of flags list page when `archiveInFlagsView` is enabled. 
- Carries the existing query params over to the redirect, remapping the
  archive's `search` term to the list's `query` param.

https://github.com/user-attachments/assets/eaa23bbc-73d1-4377-9e19-255907f472ae

https://github.com/user-attachments/assets/b6f994ba-f4e8-407e-a9a4-6aa1474dd58c

