### PR TITLE
refactor: one sdk icons list

### DIFF
--- a/frontend/src/component/integrations/IntegrationList/AvailableIntegrations/SDKs.ts
+++ b/frontend/src/component/integrations/IntegrationList/AvailableIntegrations/SDKs.ts
@@ -1,12 +1,53 @@
+import android from 'assets/icons/sdks/Logo-android.svg';
+import dotnet from 'assets/icons/sdks/Logo-net.svg';
+import flutter from 'assets/icons/sdks/Logo-flutter.svg';
+import go from 'assets/icons/sdks/Logo-go.svg';
+import java from 'assets/icons/sdks/Logo-java.svg';
+import javascript from 'assets/icons/sdks/Logo-javascript.svg';
+import nextjs from 'assets/icons/sdks/Logo-nextjs.svg';
+import node from 'assets/icons/sdks/Logo-node.svg';
+import php from 'assets/icons/sdks/Logo-php.svg';
+import python from 'assets/icons/sdks/Logo-python.svg';
+import react from 'assets/icons/sdks/Logo-react.svg';
+import reactnative from 'assets/icons/sdks/Logo-reactnative.svg';
+import ruby from 'assets/icons/sdks/Logo-ruby.svg';
+import rust from 'assets/icons/sdks/Logo-rust.svg';
+import svelte from 'assets/icons/sdks/Logo-svelte.svg';
+import swift from 'assets/icons/sdks/Logo-swift.svg';
+import vue from 'assets/icons/sdks/Logo-vue.svg';
+
+export const SDK_ICONS = {
+    android: { icon: android, title: 'Android' },
+    dotnet: { icon: dotnet, title: '.NET' },
+    flutter: { icon: flutter, title: 'Flutter' },
+    go: { icon: go, title: 'Go' },
+    java: { icon: java, title: 'Java' },
+    javascript: { icon: javascript, title: 'JavaScript' },
+    nextjs: { icon: nextjs, title: 'Next.js' },
+    node: { icon: node, title: 'Node.js' },
+    php: { icon: php, title: 'PHP' },
+    python: { icon: python, title: 'Python' },
+    react: { icon: react, title: 'React' },
+    reactnative: { icon: reactnative, title: 'React Native' },
+    ruby: { icon: ruby, title: 'Ruby' },
+    rust: { icon: rust, title: 'Rust' },
+    svelte: { icon: svelte, title: 'Svelte' },
+    swift: { icon: swift, title: 'Swift' },
+    vue: { icon: vue, title: 'Vue' },
+} as const;
+
+export type OfficialSdkName = keyof typeof SDK_ICONS;
+export type SdkName = (typeof SDK_ICONS)[OfficialSdkName]['title'];
+
 export interface Sdk {
-    name: string;
+    name: OfficialSdkName;
     displayName: string;
     description: string;
     documentationUrl: string;
     type: 'server' | 'client';
 }
 
-export const OFFICIAL_SDKS: Sdk[] = [
+export const OFFICIAL_SDKS = [
     {
         name: 'go',
         displayName: 'GO SDK',
@@ -126,6 +167,4 @@ export const OFFICIAL_SDKS: Sdk[] = [
         documentationUrl: 'https://docs.getunleash.io/sdks/react-native',
         type: 'client',
     },
-];
-
-export type OfficialSdkName = (typeof OFFICIAL_SDKS)[number]['name'];
+] as const satisfies Sdk[];

--- a/frontend/src/component/integrations/IntegrationList/IntegrationIcon/IntegrationIcon.tsx
+++ b/frontend/src/component/integrations/IntegrationList/IntegrationIcon/IntegrationIcon.tsx
@@ -3,7 +3,7 @@ import { Avatar, styled } from '@mui/material';
 import DeviceHub from '@mui/icons-material/DeviceHub';
 import { formatAssetPath } from 'utils/formatPath';
 import { capitalizeFirst } from 'utils/capitalizeFirst';
-import type { OfficialSdkName } from '../AvailableIntegrations/SDKs.ts';
+import { SDK_ICONS } from '../AvailableIntegrations/SDKs.ts';
 
 import dataDogIcon from 'assets/icons/datadog.svg';
 import newRelicIcon from 'assets/icons/new-relic.svg';
@@ -15,23 +15,6 @@ import slackIcon from 'assets/icons/slack.svg';
 import teamsIcon from 'assets/icons/teams.svg';
 import webhooksIcon from 'assets/icons/webhooks.svg';
 import unleashIcon from 'assets/icons/unleash-integration.svg';
-import android from 'assets/icons/sdks/Logo-android.svg';
-import dotnet from 'assets/icons/sdks/Logo-net.svg';
-import flutter from 'assets/icons/sdks/Logo-flutter.svg';
-import go from 'assets/icons/sdks/Logo-go.svg';
-import swift from 'assets/icons/sdks/Logo-swift.svg';
-import java from 'assets/icons/sdks/Logo-java.svg';
-import javascript from 'assets/icons/sdks/Logo-javascript.svg';
-import nextjs from 'assets/icons/sdks/Logo-nextjs.svg';
-import node from 'assets/icons/sdks/Logo-node.svg';
-import php from 'assets/icons/sdks/Logo-php.svg';
-import python from 'assets/icons/sdks/Logo-python.svg';
-import react from 'assets/icons/sdks/Logo-react.svg';
-import reactnative from 'assets/icons/sdks/Logo-reactnative.svg';
-import ruby from 'assets/icons/sdks/Logo-ruby.svg';
-import rust from 'assets/icons/sdks/Logo-rust.svg';
-import svelte from 'assets/icons/sdks/Logo-svelte.svg';
-import vue from 'assets/icons/sdks/Logo-vue.svg';
 
 interface IIntegrationIconProps {
     name: string;
@@ -46,27 +29,6 @@ const StyledAvatar = styled(Avatar)(({ theme }) => ({
     height: theme.spacing(4),
     fontSize: '28px',
 }));
-
-// Typed against OfficialSdkName so TypeScript catches missing entries when a new SDK is added.
-const sdks: Record<OfficialSdkName, { title: string; icon: string }> = {
-    android: { title: 'Android', icon: android },
-    dotnet: { title: 'Dotnet', icon: dotnet },
-    flutter: { title: 'Flutter', icon: flutter },
-    go: { title: 'Go', icon: go },
-    java: { title: 'Java', icon: java },
-    javascript: { title: 'Javascript', icon: javascript },
-    nextjs: { title: 'Next.js', icon: nextjs },
-    node: { title: 'Node', icon: node },
-    php: { title: 'PHP', icon: php },
-    python: { title: 'Python', icon: python },
-    react: { title: 'React', icon: react },
-    reactnative: { title: 'React Native', icon: reactnative },
-    ruby: { title: 'Ruby', icon: ruby },
-    rust: { title: 'Rust', icon: rust },
-    svelte: { title: 'Svelte', icon: svelte },
-    swift: { title: 'Swift', icon: swift },
-    vue: { title: 'Vue', icon: vue },
-};
 
 const integrations: Record<
     string,
@@ -83,7 +45,7 @@ const integrations: Record<
     teams: { title: 'Teams', icon: teamsIcon },
     webhook: { title: 'Webhook', icon: webhooksIcon },
     unleash: { title: 'Unleash', icon: unleashIcon },
-    ...sdks,
+    ...SDK_ICONS,
 };
 
 export const IntegrationIcon = ({ name }: IIntegrationIconProps) => {

--- a/frontend/src/component/onboarding/dialog/sharedTypes.ts
+++ b/frontend/src/component/onboarding/dialog/sharedTypes.ts
@@ -1,65 +1,25 @@
-import node from '../../../assets/icons/sdks/Logo-node.svg';
-import go from '../../../assets/icons/sdks/Logo-go.svg';
-import ruby from '../../../assets/icons/sdks/Logo-ruby.svg';
-import php from '../../../assets/icons/sdks/Logo-php.svg';
-import rust from '../../../assets/icons/sdks/Logo-rust.svg';
-import dotnet from '../../../assets/icons/sdks/Logo-net.svg';
-import java from '../../../assets/icons/sdks/Logo-java.svg';
-import python from '../../../assets/icons/sdks/Logo-python.svg';
-import javascript from '../../../assets/icons/sdks/Logo-javascript.svg';
-import react from '../../../assets/icons/sdks/Logo-react.svg';
-import vue from '../../../assets/icons/sdks/Logo-vue.svg';
-import svelte from '../../../assets/icons/sdks/Logo-svelte.svg';
-import swift from '../../../assets/icons/sdks/Logo-swift.svg';
-import android from '../../../assets/icons/sdks/Logo-android.svg';
-import flutter from '../../../assets/icons/sdks/Logo-flutter.svg';
-import nextjs from '../../../assets/icons/sdks/Logo-nextjs.svg';
-import reactnative from '../../../assets/icons/sdks/Logo-reactnative.svg';
+import {
+    OFFICIAL_SDKS,
+    SDK_ICONS,
+    type SdkName,
+} from '../../integrations/IntegrationList/AvailableIntegrations/SDKs.ts';
 
+export type { SdkName };
 export type SdkType = 'client' | 'frontend';
 export type Sdk = { name: SdkName; type: SdkType };
-export type ServerSdkName =
-    | 'Node.js'
-    | 'Go'
-    | '.NET'
-    | 'Ruby'
-    | 'PHP'
-    | 'Rust'
-    | 'Java'
-    | 'Python';
-export type ClientSdkName =
-    | 'JavaScript'
-    | 'React'
-    | 'React Native'
-    | 'Vue'
-    | 'Svelte'
-    | 'Swift'
-    | 'Android'
-    | 'Flutter'
-    | 'Next.js';
-export type SdkName = ServerSdkName | ClientSdkName;
 
-export const serverSdks: { name: ServerSdkName; icon: string }[] = [
-    { name: 'Node.js', icon: node },
-    { name: 'Go', icon: go },
-    { name: 'Ruby', icon: ruby },
-    { name: 'PHP', icon: php },
-    { name: 'Rust', icon: rust },
-    { name: '.NET', icon: dotnet },
-    { name: 'Java', icon: java },
-    { name: 'Python', icon: python },
-];
-export const clientSdks: { name: ClientSdkName; icon: string }[] = [
-    { name: 'JavaScript', icon: javascript },
-    { name: 'React', icon: react },
-    { name: 'Vue', icon: vue },
-    { name: 'Svelte', icon: svelte },
-    { name: 'Swift', icon: swift },
-    { name: 'Android', icon: android },
-    { name: 'Flutter', icon: flutter },
-    { name: 'Next.js', icon: nextjs },
-    { name: 'React Native', icon: reactnative },
-];
+export const serverSdks = OFFICIAL_SDKS.filter(
+    (sdk) => sdk.type === 'server',
+).map(({ name }) => ({
+    name: SDK_ICONS[name].title,
+    icon: SDK_ICONS[name].icon,
+}));
 
-export const allSdks: { name: ClientSdkName | ServerSdkName; icon: string }[] =
-    [...serverSdks, ...clientSdks];
+export const clientSdks = OFFICIAL_SDKS.filter(
+    (sdk) => sdk.type === 'client',
+).map(({ name }) => ({
+    name: SDK_ICONS[name].title,
+    icon: SDK_ICONS[name].icon,
+}));
+
+export const allSdks = [...serverSdks, ...clientSdks];


### PR DESCRIPTION
## About the changes

I noticed that we have two list of SDKs and it's icons used in onboarding and Integrations. 
This task is not a full solution, but I want to remove at least some duplication and make it easier to discover that onboarding and integrations sdks list should be changed together when we add another official sdk. 

This is a kind of follow-up for https://github.com/Unleash/unleash/pull/12280

### Important files

## Discussion points

## OSS PR checklist

- [x] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [x] I have added tests or explained why tests are not needed.
- [x] I have updated documentation where relevant.
