### PR TITLE
chore: move avatar section from user profile button to dropdown

### DIFF
--- a/frontend/src/component/user/UserProfile/UserProfile.tsx
+++ b/frontend/src/component/user/UserProfile/UserProfile.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Box, Button, styled, Typography } from '@mui/material';
+import { Button, styled } from '@mui/material';
 import { UserProfileContent } from './UserProfileContent/UserProfileContent.tsx';
 import type { IUser } from 'interfaces/user';
 import { useId } from 'hooks/useId';
@@ -24,14 +24,6 @@ const StyledUserAvatar = styled(UserAvatar)(({ theme }) => ({
     marginRight: theme.spacing(1),
 }));
 
-const StyledSubtitle = styled(Typography)(({ theme }) => ({
-    color: theme.palette.text.secondary,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    maxWidth: theme.spacing(35),
-}));
-
 export const UserProfile = ({ profile }: IUserProfileProps) => {
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
     const showProfile = Boolean(anchorEl);
@@ -53,20 +45,8 @@ export const UserProfile = ({ profile }: IUserProfileProps) => {
                 <StyledUserAvatar
                     user={profile}
                     data-testid={HEADER_USER_AVATAR}
+                    disableTooltip
                 />
-                <Box sx={{ mr: 0.5, textAlign: 'left' }}>
-                    <Typography
-                        variant='body2'
-                        sx={{
-                            fontWeight: 'medium',
-                        }}
-                    >
-                        {profile.name || profile.username}
-                    </Typography>
-                    <StyledSubtitle variant='body2' title={profile.email}>
-                        {profile.email}
-                    </StyledSubtitle>
-                </Box>
                 {showProfile ? <ExpandLessIcon /> : <ExpandMoreIcon />}
             </Button>
 
@@ -74,6 +54,7 @@ export const UserProfile = ({ profile }: IUserProfileProps) => {
                 id={modalId}
                 anchorEl={anchorEl}
                 onClose={() => setAnchorEl(null)}
+                profile={profile}
             />
         </StyledProfileContainer>
     );

--- a/frontend/src/component/user/UserProfile/UserProfileContent/UserProfileContent.tsx
+++ b/frontend/src/component/user/UserProfile/UserProfileContent/UserProfileContent.tsx
@@ -3,6 +3,9 @@ import type { SxProps, Theme } from '@mui/material';
 import { basePath } from 'utils/formatPath';
 import OpenInNew from '@mui/icons-material/OpenInNew';
 import { Link as RouterLink } from 'react-router';
+import { UserAvatar } from 'component/common/UserAvatar/UserAvatar';
+import { Truncator } from 'component/common/Truncator/Truncator';
+import type { IUser } from 'interfaces/user';
 
 const menuItemSx: SxProps<Theme> = {
     display: 'flex',
@@ -10,6 +13,28 @@ const menuItemSx: SxProps<Theme> = {
     gap: (theme) => theme.spacing(0.5),
     paddingBlock: (theme) => theme.spacing(1.5),
 };
+
+const StyledHeader = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(1, 2, 1),
+}));
+
+const StyledUserAvatar = styled(UserAvatar)(({ theme }) => ({
+    width: theme.spacing(3.5),
+    height: theme.spacing(3.5),
+    margin: 0,
+}));
+
+const StyledTruncator = styled(Truncator)(({ theme }) => ({
+    maxWidth: theme.spacing(28),
+    fontSize: theme.typography.body2.fontSize,
+}));
+
+const StyledEmail = styled(StyledTruncator)(({ theme }) => ({
+    color: theme.palette.text.secondary,
+}));
 
 const StyledOpenInNew = styled(OpenInNew)(({ theme }) => ({
     fontSize: theme.spacing(2),
@@ -21,12 +46,14 @@ interface IUserProfileContentProps {
     id: string;
     anchorEl: HTMLElement | null;
     onClose: () => void;
+    profile: IUser;
 }
 
 export const UserProfileContent = ({
     id,
     anchorEl,
     onClose,
+    profile,
 }: IUserProfileContentProps) => (
     <Menu
         id={id}
@@ -44,6 +71,16 @@ export const UserProfileContent = ({
             },
         }}
     >
+        <StyledHeader>
+            <StyledUserAvatar user={profile} disableTooltip />
+            <div>
+                <StyledTruncator title={profile.name}>
+                    {profile.name || profile.username}
+                </StyledTruncator>
+                <StyledEmail title={profile.email}>{profile.email}</StyledEmail>
+            </div>
+        </StyledHeader>
+
         <MenuItem
             component={RouterLink}
             to='/profile'


### PR DESCRIPTION

Moves the profile details section of the user profile menu in the dropdown.


<img width="320" height="292" alt="Screenshot 2026-06-11 at 17 27 58" src="https://github.com/user-attachments/assets/3e2a9239-20f3-4fa8-882b-51206087ddf2" />
