### PR TITLE
chore: remove react-router-dom import

### DIFF
--- a/frontend/src/component/user/UserProfile/UserProfileContent/LegacyUserProfileContent.tsx
+++ b/frontend/src/component/user/UserProfile/UserProfileContent/LegacyUserProfileContent.tsx
@@ -3,7 +3,7 @@ import { Button, Link, Paper, styled } from '@mui/material';
 import { basePath } from 'utils/formatPath';
 import type { IUser } from 'interfaces/user';
 import OpenInNew from '@mui/icons-material/OpenInNew';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 
 const StyledPaper = styled(Paper)(({ theme }) => ({
     display: 'flex',


### PR DESCRIPTION
Was merged before my react router dom removal pr landed and thus broke the build after it.