### PR TITLE
chore: hide documentation from top header if flag enabled

### DIFF
--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -20,6 +20,7 @@ import LightModeOutlined from '@mui/icons-material/LightModeOutlined';
 import { useThemeMode } from 'hooks/useThemeMode';
 import InviteLinkButton from './InviteLink/InviteLinkButton/InviteLinkButton.tsx';
 import { CommandBar } from 'component/commandBar/CommandBar';
+import { useUiFlag } from 'hooks/useUiFlag.ts';
 
 const HeaderComponent = styled(AppBar)(({ theme }) => ({
     backgroundColor: theme.palette.background.application,
@@ -82,6 +83,7 @@ const Header = () => {
     const smallScreen = useMediaQuery(theme.breakpoints.down('md'));
     const [openDrawer, setOpenDrawer] = useState(false);
     const toggleDrawer = () => setOpenDrawer((prev) => !prev);
+    const hideTopmenuDocumentation = useUiFlag('hideTopmenuDocumentation');
 
     if (mediumScreen) {
         return (
@@ -145,21 +147,23 @@ const Header = () => {
                                 />
                             </StyledIconButton>
                         </Tooltip>
-                        <Tooltip title='Documentation' arrow>
-                            <StyledIconButton
-                                component='a'
-                                nativeButton={false}
-                                href='https://docs.getunleash.io/'
-                                target='_blank'
-                                rel='noopener noreferrer'
-                                size='large'
-                                sx={(theme) => ({
-                                    marginRight: theme.spacing(1),
-                                })}
-                            >
-                                <MenuBookIcon />
-                            </StyledIconButton>
-                        </Tooltip>
+                        {!hideTopmenuDocumentation && (
+                            <Tooltip title='Documentation' arrow>
+                                <StyledIconButton
+                                    component='a'
+                                    nativeButton={false}
+                                    href='https://docs.getunleash.io/'
+                                    target='_blank'
+                                    rel='noopener noreferrer'
+                                    size='large'
+                                    sx={(theme) => ({
+                                        marginRight: theme.spacing(1),
+                                    })}
+                                >
+                                    <MenuBookIcon />
+                                </StyledIconButton>
+                            </Tooltip>
+                        )}
                         <Divider
                             orientation='vertical'
                             variant='middle'

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -99,6 +99,7 @@ export type UiFlags = {
     newModalDesign?: boolean;
     archiveInFlagsView?: boolean;
     newProfileDropdown?: boolean;
+    hideTopmenuDocumentation?: boolean;
 };
 
 export interface IVersionInfo {

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -77,7 +77,8 @@ export type IFlagKey =
     | 'newModalDesign'
     | 'archiveInFlagsView'
     | 'allowDeprecatedApiTokenMiddleware'
-    | 'newProfileDropdown';
+    | 'newProfileDropdown'
+    | 'hideTopmenuDocumentation';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -345,6 +346,10 @@ const flags: IFlags = {
     ),
     newProfileDropdown: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_NEW_PROFILE_DROPDOWN,
+        false,
+    ),
+    hideTopmenuDocumentation: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_HIDE_TOPMENU_DOCUMENTATION,
         false,
     ),
 };

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -58,6 +58,7 @@ process.nextTick(async () => {
                         allowDeprecatedApiTokenMiddleware: false,
                         archiveInFlagsView: true,
                         newProfileDropdown: true,
+                        hideTopmenuDocumentation: false,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
Hides the documentation icon from the header if the `hideTopmenuDocumentation` feature flag is enabled (this way we can easily hide the button once the help center is done.

Flag enabled:

<img width="528" height="86" alt="Screenshot 2026-06-12 at 13 44 55" src="https://github.com/user-attachments/assets/9c9ae023-96de-4854-91e9-92c4819bab24" />

Flag not enabled: 

<img width="528" height="86" alt="Screenshot 2026-06-12 at 13 45 41" src="https://github.com/user-attachments/assets/e5265225-0cc4-4f6f-900b-6c6940c6e14e" />
