### PR TITLE
feat: select theme preference from user profile menu

### DIFF
--- a/frontend/src/component/common/ThemeMode/ThemeMode.tsx
+++ b/frontend/src/component/common/ThemeMode/ThemeMode.tsx
@@ -1,5 +1,5 @@
-import UIContext from 'contexts/UIContext';
-import { useContext, type JSX } from 'react';
+import { useTheme } from '@mui/material/styles';
+import type { JSX } from 'react';
 import { ConditionallyRender } from '../ConditionallyRender/ConditionallyRender.tsx';
 
 interface IThemeModeProps {
@@ -8,11 +8,11 @@ interface IThemeModeProps {
 }
 
 export const ThemeMode = ({ darkmode, lightmode }: IThemeModeProps) => {
-    const { themeMode } = useContext(UIContext);
+    const theme = useTheme();
 
     return (
         <ConditionallyRender
-            condition={themeMode === 'dark'}
+            condition={theme.mode === 'dark'}
             show={darkmode}
             elseShow={lightmode}
         />

--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -18,6 +18,7 @@ import { DrawerMenu } from './DrawerMenu/DrawerMenu.tsx';
 import DarkModeOutlined from '@mui/icons-material/DarkModeOutlined';
 import LightModeOutlined from '@mui/icons-material/LightModeOutlined';
 import { useThemeMode } from 'hooks/useThemeMode';
+import { useUiFlag } from 'hooks/useUiFlag';
 import InviteLinkButton from './InviteLink/InviteLinkButton/InviteLinkButton.tsx';
 import { CommandBar } from 'component/commandBar/CommandBar';
 
@@ -75,7 +76,9 @@ const StyledIconButton = styled(IconButton)<{
 }));
 
 const Header = () => {
-    const { onSetThemeMode, themeMode } = useThemeMode();
+    const { onSetThemeMode } = useThemeMode();
+    const newProfileDropdown = useUiFlag('newProfileDropdown');
+    const showThemeButton = !newProfileDropdown;
     const theme = useTheme();
 
     const mediumScreen = useMediaQuery(theme.breakpoints.down('lg'));
@@ -126,25 +129,27 @@ const Header = () => {
                             })}
                         />
                         <InviteLinkButton />
-                        <Tooltip
-                            title={
-                                themeMode === 'dark'
-                                    ? 'Switch to light theme'
-                                    : 'Switch to dark theme'
-                            }
-                            arrow
-                        >
-                            <StyledIconButton
-                                onClick={onSetThemeMode}
-                                size='large'
+                        {showThemeButton && (
+                            <Tooltip
+                                title={
+                                    theme.mode === 'dark'
+                                        ? 'Switch to light theme'
+                                        : 'Switch to dark theme'
+                                }
+                                arrow
                             >
-                                <ConditionallyRender
-                                    condition={themeMode === 'dark'}
-                                    show={<DarkModeOutlined />}
-                                    elseShow={<LightModeOutlined />}
-                                />
-                            </StyledIconButton>
-                        </Tooltip>
+                                <StyledIconButton
+                                    onClick={onSetThemeMode}
+                                    size='large'
+                                >
+                                    <ConditionallyRender
+                                        condition={theme.mode === 'dark'}
+                                        show={<DarkModeOutlined />}
+                                        elseShow={<LightModeOutlined />}
+                                    />
+                                </StyledIconButton>
+                            </Tooltip>
+                        )}
                         <Tooltip title='Documentation' arrow>
                             <StyledIconButton
                                 component='a'

--- a/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
+++ b/frontend/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
@@ -1,5 +1,4 @@
 import CodeMirror from '@uiw/react-codemirror';
-import { useContext } from 'react';
 import { json } from '@codemirror/lang-json';
 import {
     type Dispatch,
@@ -12,7 +11,6 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 import { duotoneDark, duotoneLight } from '@uiw/codemirror-theme-duotone';
 import Check from '@mui/icons-material/Check';
 import ErrorIcon from '@mui/icons-material/Error';
-import UIContext from 'contexts/UIContext';
 
 interface IPlaygroundEditorProps {
     context: string | undefined;
@@ -88,7 +86,6 @@ export const PlaygroundEditor: FC<IPlaygroundEditorProps> = ({
     setContext,
     error,
 }) => {
-    const { themeMode } = useContext(UIContext);
     const theme = useTheme();
     const onCodeFieldChange = useCallback(
         (context: string | undefined) => {
@@ -123,7 +120,7 @@ export const PlaygroundEditor: FC<IPlaygroundEditorProps> = ({
             <CodeMirror
                 value={context}
                 minHeight={codeInputMinHeight}
-                theme={themeMode === 'dark' ? duotoneDark : duotoneLight}
+                theme={theme.mode === 'dark' ? duotoneDark : duotoneLight}
                 extensions={[json()]}
                 onChange={onCodeFieldChange}
                 style={{

--- a/frontend/src/component/project/Project/ProjectStatus/ProjectActivity.tsx
+++ b/frontend/src/component/project/Project/ProjectStatus/ProjectActivity.tsx
@@ -2,9 +2,8 @@ import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { useProjectStatus } from 'hooks/api/getters/useProjectStatus/useProjectStatus';
 import { ActivityCalendar, type ThemeInput } from 'react-activity-calendar';
 import type { ProjectActivitySchema } from 'openapi';
-import { styled, Tooltip } from '@mui/material';
+import { styled, Tooltip, useTheme } from '@mui/material';
 import theme from 'themes/theme';
-import { useThemeMode } from 'hooks/useThemeMode';
 
 const StyledContainer = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -78,7 +77,7 @@ const transformData = (inputData: ProjectActivitySchema): Output[] => {
 export const ProjectActivity = () => {
     const projectId = useRequiredPathParam('projectId');
     const { data } = useProjectStatus(projectId);
-    const { themeMode } = useThemeMode();
+    const activeTheme = useTheme();
 
     const explicitTheme: ThemeInput = {
         light: ['#f1f0fc', '#ceccfd', '#8982ff', '#6c65e5', '#615bc2'],
@@ -93,7 +92,7 @@ export const ProjectActivity = () => {
             {data.activityCountByDate.length > 0 ? (
                 <StyledContainer>
                     <ActivityCalendar
-                        colorScheme={themeMode}
+                        colorScheme={activeTheme.mode}
                         theme={explicitTheme}
                         data={fullData}
                         maxLevel={4}

--- a/frontend/src/component/providers/UIProvider/UIProvider.tsx
+++ b/frontend/src/component/providers/UIProvider/UIProvider.tsx
@@ -6,19 +6,8 @@ import UIContext, {
 import type { IToast } from 'interfaces/toast';
 import { getLocalStorageItem } from 'utils/storage';
 
-const resolveMode = (): themeMode => {
-    const value = getLocalStorageItem('unleash-theme');
-    if (value) {
-        return value as themeMode;
-    }
-
-    const osDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
-
-    if (osDark) {
-        return 'dark';
-    }
-    return 'light';
-};
+const resolveMode = (): themeMode =>
+    getLocalStorageItem<themeMode>('unleash-theme') ?? 'system';
 
 const UIProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
     const [toastData, setToast] = useState<IToast>(createEmptyToast());

--- a/frontend/src/component/user/UserProfile/UserProfileContent/UserProfileContent.tsx
+++ b/frontend/src/component/user/UserProfile/UserProfileContent/UserProfileContent.tsx
@@ -93,7 +93,10 @@ const ThemeSubmenu = ({ onCloseAll }: { onCloseAll: () => void }) => {
             <Menu
                 anchorEl={anchorEl}
                 open={open}
-                onClose={() => setAnchorEl(null)}
+                onClose={() => {
+                    setAnchorEl(null);
+                    onCloseAll();
+                }}
                 anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
                 transformOrigin={{ vertical: 'top', horizontal: 'left' }}
                 slotProps={{
@@ -110,7 +113,7 @@ const ThemeSubmenu = ({ onCloseAll }: { onCloseAll: () => void }) => {
                     <MenuItem
                         key={option.value}
                         onClick={() => handleSelect(option.value)}
-                        sx={{ menuItemSx }}
+                        sx={menuItemSx}
                     >
                         <StyledCheckSlot>
                             {themeMode === option.value ? <Check /> : null}

--- a/frontend/src/component/user/UserProfile/UserProfileContent/UserProfileContent.tsx
+++ b/frontend/src/component/user/UserProfile/UserProfileContent/UserProfileContent.tsx
@@ -1,10 +1,15 @@
+import { useState } from 'react';
 import { Menu, MenuItem, styled } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material';
 import { basePath } from 'utils/formatPath';
 import OpenInNew from '@mui/icons-material/OpenInNew';
+import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
+import Check from '@mui/icons-material/Check';
 import { Link as RouterLink } from 'react-router';
 import { UserAvatar } from 'component/common/UserAvatar/UserAvatar';
 import { Truncator } from 'component/common/Truncator/Truncator';
+import { useThemeMode } from 'hooks/useThemeMode';
+import type { themeMode } from 'contexts/UIContext';
 import type { IUser } from 'interfaces/user';
 
 const menuItemSx: SxProps<Theme> = {
@@ -42,6 +47,82 @@ const StyledOpenInNew = styled(OpenInNew)(({ theme }) => ({
     alignSelf: 'flex-end',
 }));
 
+const StyledChevron = styled(KeyboardArrowRight)(({ theme }) => ({
+    marginLeft: 'auto',
+    fontSize: theme.spacing(2.5),
+    color: theme.palette.text.secondary,
+}));
+
+const StyledCheckSlot = styled('span')(({ theme }) => ({
+    display: 'inline-flex',
+    width: theme.spacing(2.5),
+    color: theme.palette.primary.main,
+    '& svg': {
+        fontSize: theme.spacing(2),
+    },
+}));
+
+const THEME_OPTIONS: { label: string; value: themeMode }[] = [
+    { label: 'Dark', value: 'dark' },
+    { label: 'Light', value: 'light' },
+    { label: 'System', value: 'system' },
+];
+
+const ThemeSubmenu = ({ onCloseAll }: { onCloseAll: () => void }) => {
+    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+    const { themeMode, setThemeMode } = useThemeMode();
+    const open = Boolean(anchorEl);
+
+    const handleSelect = (mode: themeMode) => {
+        setThemeMode(mode);
+        setAnchorEl(null);
+        onCloseAll();
+    };
+
+    return (
+        <>
+            <MenuItem
+                onClick={(event) => setAnchorEl(event.currentTarget)}
+                sx={menuItemSx}
+                aria-haspopup='true'
+                aria-expanded={open}
+            >
+                Theme
+                <StyledChevron />
+            </MenuItem>
+            <Menu
+                anchorEl={anchorEl}
+                open={open}
+                onClose={() => setAnchorEl(null)}
+                anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+                slotProps={{
+                    paper: {
+                        sx: {
+                            minWidth: (theme) => theme.spacing(15),
+                            borderRadius: (theme) =>
+                                theme.shape.borderRadiusSmall,
+                        },
+                    },
+                }}
+            >
+                {THEME_OPTIONS.map((option) => (
+                    <MenuItem
+                        key={option.value}
+                        onClick={() => handleSelect(option.value)}
+                        sx={{ menuItemSx }}
+                    >
+                        <StyledCheckSlot>
+                            {themeMode === option.value ? <Check /> : null}
+                        </StyledCheckSlot>
+                        {option.label}
+                    </MenuItem>
+                ))}
+            </Menu>
+        </>
+    );
+};
+
 interface IUserProfileContentProps {
     id: string;
     anchorEl: HTMLElement | null;
@@ -67,6 +148,7 @@ export const UserProfileContent = ({
                 sx: {
                     minWidth: (theme) => theme.spacing(34),
                     borderRadius: (theme) => theme.shape.borderRadiusSmall,
+                    marginTop: (theme) => theme.spacing(1),
                 },
             },
         }}
@@ -89,6 +171,8 @@ export const UserProfileContent = ({
         >
             Profile settings
         </MenuItem>
+
+        <ThemeSubmenu onCloseAll={onClose} />
 
         <MenuItem
             component='a'

--- a/frontend/src/contexts/UIContext.ts
+++ b/frontend/src/contexts/UIContext.ts
@@ -10,7 +10,7 @@ interface IUIContext {
     themeMode: themeMode;
 }
 
-export type themeMode = 'light' | 'dark';
+export type themeMode = 'light' | 'dark' | 'system';
 
 export const createEmptyToast = (): IToast => {
     return {

--- a/frontend/src/hooks/useThemeMode.test.tsx
+++ b/frontend/src/hooks/useThemeMode.test.tsx
@@ -1,0 +1,132 @@
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getLocalStorageItem } from 'utils/storage';
+import UIContext, {
+    createEmptyToast,
+    type themeMode,
+} from 'contexts/UIContext';
+import { lightTheme } from 'themes/theme';
+import { darkTheme } from 'themes/dark-theme';
+import { useThemeMode } from './useThemeMode';
+
+// jsdom doesn't implement matchMedia (which MUI's useMediaQuery relies on),
+// so provide a settable stand-in to drive the OS preference
+const setOsPrefersDark = (prefersDark: boolean) => {
+    window.matchMedia = ((query: string) => ({
+        matches: prefersDark,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+};
+
+const renderUseThemeMode = (initialMode: themeMode) =>
+    renderHook(() => useThemeMode(), {
+        wrapper: ({ children }: { children: ReactNode }) => {
+            const [themeMode, setThemeMode] = useState<themeMode>(initialMode);
+            return (
+                <UIContext.Provider
+                    value={{
+                        toastData: createEmptyToast(),
+                        setToast: () => {},
+                        showFeedback: false,
+                        setShowFeedback: () => {},
+                        themeMode,
+                        setThemeMode,
+                    }}
+                >
+                    {children}
+                </UIContext.Provider>
+            );
+        },
+    });
+
+beforeEach(() => {
+    localStorage.clear();
+    setOsPrefersDark(false);
+});
+
+describe('resolveTheme', () => {
+    it('returns the light theme for the light mode', () => {
+        expect(renderUseThemeMode('light').result.current.resolveTheme()).toBe(
+            lightTheme,
+        );
+    });
+
+    it('returns the dark theme for the dark mode', () => {
+        expect(renderUseThemeMode('dark').result.current.resolveTheme()).toBe(
+            darkTheme,
+        );
+    });
+
+    it('follows a light OS preference when set to system', () => {
+        setOsPrefersDark(false);
+
+        expect(renderUseThemeMode('system').result.current.resolveTheme()).toBe(
+            lightTheme,
+        );
+    });
+
+    it('follows a dark OS preference when set to system', () => {
+        setOsPrefersDark(true);
+
+        expect(renderUseThemeMode('system').result.current.resolveTheme()).toBe(
+            darkTheme,
+        );
+    });
+});
+
+describe('setThemeMode', () => {
+    it('updates the mode and persists it', () => {
+        const { result } = renderUseThemeMode('light');
+
+        act(() => result.current.setThemeMode('system'));
+
+        expect(result.current.themeMode).toBe('system');
+        expect(getLocalStorageItem('unleash-theme')).toBe('system');
+    });
+});
+
+describe('onSetThemeMode', () => {
+    it('toggles light to dark and persists', () => {
+        const { result } = renderUseThemeMode('light');
+
+        act(() => result.current.onSetThemeMode());
+
+        expect(result.current.themeMode).toBe('dark');
+        expect(getLocalStorageItem('unleash-theme')).toBe('dark');
+    });
+
+    it('toggles dark to light and persists', () => {
+        const { result } = renderUseThemeMode('dark');
+
+        act(() => result.current.onSetThemeMode());
+
+        expect(result.current.themeMode).toBe('light');
+        expect(getLocalStorageItem('unleash-theme')).toBe('light');
+    });
+
+    it('toggles system on a light OS to dark', () => {
+        setOsPrefersDark(false);
+        const { result } = renderUseThemeMode('system');
+
+        act(() => result.current.onSetThemeMode());
+
+        expect(result.current.themeMode).toBe('dark');
+    });
+
+    it('toggles system on a dark OS to light', () => {
+        setOsPrefersDark(true);
+        const { result } = renderUseThemeMode('system');
+
+        act(() => result.current.onSetThemeMode());
+
+        expect(result.current.themeMode).toBe('light');
+    });
+});

--- a/frontend/src/hooks/useThemeMode.ts
+++ b/frontend/src/hooks/useThemeMode.ts
@@ -1,5 +1,6 @@
 import UIContext, { type themeMode } from 'contexts/UIContext';
 import { useContext } from 'react';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import { setLocalStorageItem } from 'utils/storage';
 import { lightTheme } from 'themes/theme';
 import { darkTheme } from 'themes/dark-theme';
@@ -8,25 +9,37 @@ import type { Theme } from '@mui/material/styles';
 interface IUseThemeModeOutput {
     resolveTheme: () => Theme;
     onSetThemeMode: () => void;
+    setThemeMode: (mode: themeMode) => void;
     themeMode: themeMode;
 }
 
 export const useThemeMode = (): IUseThemeModeOutput => {
-    const { themeMode, setThemeMode } = useContext(UIContext);
+    const { themeMode, setThemeMode: setContextThemeMode } =
+        useContext(UIContext);
+    const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
     const key = 'unleash-theme';
 
-    const resolveTheme = () => (themeMode === 'light' ? lightTheme : darkTheme);
+    const resolvedMode: 'light' | 'dark' =
+        themeMode === 'system'
+            ? prefersDarkMode
+                ? 'dark'
+                : 'light'
+            : themeMode;
 
-    const onSetThemeMode = () => {
-        setThemeMode((prev: themeMode) => {
-            if (prev === 'light') {
-                setLocalStorageItem(key, 'dark');
-                return 'dark';
-            }
-            setLocalStorageItem(key, 'light');
-            return 'light';
-        });
+    const resolveTheme = (): Theme =>
+        resolvedMode === 'dark' ? darkTheme : lightTheme;
+
+    const setThemeMode = (mode: themeMode) => {
+        setLocalStorageItem(key, mode);
+        setContextThemeMode(mode);
     };
 
-    return { resolveTheme, onSetThemeMode, themeMode };
+    // toggle relative to what's currently shown, so it also works from 'system'
+    const onSetThemeMode = () => {
+        const next = resolvedMode === 'dark' ? 'light' : 'dark';
+        setLocalStorageItem(key, next);
+        setContextThemeMode(next);
+    };
+
+    return { resolveTheme, onSetThemeMode, setThemeMode, themeMode };
 };


### PR DESCRIPTION
Moves the theme selection to the user profile menu and adds "System" as an option (gated behind `newProfileDropdown` FF).

https://github.com/user-attachments/assets/afac6125-d07f-4873-ba7c-0750b28420ba

- **Theme submenu** (`UserProfileContent.tsx`) — adds a `Theme` item in the profile dropdown with a Light/Dark/System nested menu, checkmark on the active selection.
- **`'system'` theme mode** (`UIContext.ts`) — extends `themeMode` from `'light' | 'dark'` to `'light' | 'dark' | 'system'`.
- **Theme resolution** (`useThemeMode.ts`) — `resolveTheme()` now resolves `system` to the OS preference via `prefers-color-scheme`; adds a `setThemeMode(mode)` setter for the menu. `themeMode` keeps its existing meaning/name.
- **Header** (`Header.tsx`) — hides the top-bar theme toggle when the new dropdown owns the theme control (flag on).
- **Playground editor** (`PlaygroundEditor.tsx`) — CodeMirror theme now follows the resolved `theme.mode`, so it tracks `system`.
- **Theme-dependent logo/assets** (`ThemeMode.tsx`) — the `ThemeMode` helper (sidebar logo, splash images, etc.) now reads the resolved `theme.mode` instead of the raw preference, so they render correctly under `system`.
