### PR TITLE
chore: SelectSdk dropdown improvements

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.test.tsx
@@ -15,16 +15,6 @@ describe('SelectSdk', () => {
         expect(screen.getByText('Frontend SDKs')).toBeInTheDocument();
     });
 
-    it('clearing the selection does not call onChange', async () => {
-        const user = userEvent.setup();
-        const onChange = vi.fn();
-        render(<SelectSdk value='Node.js' onChange={onChange} />);
-
-        await user.click(screen.getByLabelText('Clear'));
-
-        expect(onChange).not.toHaveBeenCalled();
-    });
-
     it('selecting an sdk passes its name to onChange', async () => {
         const user = userEvent.setup();
         const onChange = vi.fn();

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
@@ -90,7 +90,10 @@ export const SelectSdk = ({ value, onChange }: SelectSdkProps) => {
                             input: {
                                 ...params.slotProps?.input,
                                 startAdornment: icon && (
-                                    <StyledSdkIcon src={formatAssetPath(option.icon)} alt='' />
+                                    <StyledSdkIcon
+                                        src={formatAssetPath(icon)}
+                                        alt=''
+                                    />
                                 ),
                             },
                         }}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
@@ -90,7 +90,7 @@ export const SelectSdk = ({ value, onChange }: SelectSdkProps) => {
                             input: {
                                 ...params.slotProps?.input,
                                 startAdornment: icon && (
-                                    <StyledSdkIcon src={icon} alt='' />
+                                    <StyledSdkIcon src={formatAssetPath(option.icon)} alt='' />
                                 ),
                             },
                         }}

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
@@ -18,7 +18,7 @@ type SdkOption = {
     group: string;
 };
 
-const StyledAutocomplete = styled(Autocomplete<SdkOption>)(({ theme }) => ({
+const StyledAutocompleteWrapper = styled('div')(({ theme }) => ({
     minWidth: theme.spacing(20),
     maxWidth: theme.spacing(32.5),
 }));
@@ -34,6 +34,7 @@ const StyledSdkIcon = styled('img')(({ theme }) => ({
     height: theme.spacing(2.5),
     flexShrink: 0,
     borderRadius: theme.shape.borderRadiusSmall,
+    marginLeft: theme.spacing(0.5),
 }));
 
 const StyledSdkName = styled('span')({
@@ -53,27 +54,45 @@ export const SelectSdk = ({ value, onChange }: SelectSdkProps) => {
                 a.group.localeCompare(b.group) || a.name.localeCompare(b.name),
         );
 
+    const icon = options.find((opt) => opt.name === value)?.icon;
+
     return (
-        <StyledAutocomplete
-            options={options}
-            value={options.find((opt) => opt.name === value) ?? null}
-            groupBy={(option) => option.group}
-            getOptionLabel={(option) => option.name}
-            isOptionEqualToValue={(option, val) => option.name === val.name}
-            onChange={(_, newValue) => {
-                if (newValue?.name) {
-                    onChange(newValue.name);
-                }
-            }}
-            renderOption={({ key, ...props }, option) => (
-                <StyledOptionRow key={key} {...props}>
-                    <StyledSdkIcon src={option.icon} alt='' />
-                    <StyledSdkName>{option.name}</StyledSdkName>
-                </StyledOptionRow>
-            )}
-            renderInput={(params) => (
-                <TextField {...params} label='SDK' size='small' />
-            )}
-        />
+        <StyledAutocompleteWrapper>
+            <Autocomplete
+                disableClearable
+                options={options}
+                value={options.find((opt) => opt.name === value)}
+                groupBy={(option) => option.group}
+                getOptionLabel={(option) => option.name}
+                isOptionEqualToValue={(option, val) => option.name === val.name}
+                onChange={(_, newValue) => {
+                    if (newValue?.name) {
+                        onChange(newValue.name);
+                    }
+                }}
+                renderOption={({ key, ...props }, option) => (
+                    <StyledOptionRow key={key} {...props}>
+                        <StyledSdkIcon src={option.icon} alt='' />
+                        <StyledSdkName>{option.name}</StyledSdkName>
+                    </StyledOptionRow>
+                )}
+                renderInput={(params) => (
+                    <TextField
+                        {...params}
+                        label='SDK'
+                        size='small'
+                        slotProps={{
+                            ...params.slotProps,
+                            input: {
+                                ...params.slotProps?.input,
+                                startAdornment: icon && (
+                                    <StyledSdkIcon src={icon} alt='' />
+                                ),
+                            },
+                        }}
+                    />
+                )}
+            />
+        </StyledAutocompleteWrapper>
     );
 };

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
@@ -4,6 +4,7 @@ import {
     serverSdks,
     type SdkName,
 } from 'component/onboarding/dialog/sharedTypes';
+import { formatAssetPath } from 'utils/formatPath';
 
 interface SelectSdkProps {
     value: SdkName;
@@ -72,7 +73,10 @@ export const SelectSdk = ({ value, onChange }: SelectSdkProps) => {
                 }}
                 renderOption={({ key, ...props }, option) => (
                     <StyledOptionRow key={key} {...props}>
-                        <StyledSdkIcon src={option.icon} alt='' />
+                        <StyledSdkIcon
+                            src={formatAssetPath(option.icon)}
+                            alt=''
+                        />
                         <StyledSdkName>{option.name}</StyledSdkName>
                     </StyledOptionRow>
                 )}


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-649/improve-selectsdk-dropdown

Adds two improvements for the new SelectSdk dropdown:

- It shouldn't have the clear button: You always want it to have a value
- It should show the icon of the selected SDK

<img width="298" height="612" alt="image" src="https://github.com/user-attachments/assets/a8deb65a-6fdf-4cf2-92b4-9a5bf118b1ea" />
