### PR TITLE
fix: keep stable legacy endpoints for a bit longer

### DIFF
--- a/src/lib/openapi/util/api-operation.ts
+++ b/src/lib/openapi/util/api-operation.ts
@@ -8,7 +8,7 @@ import type { OpenApiTag } from './openapi-tags.js';
  * - release.stable only: alpha before stable, stable after.
  * - release.alpha: explicitly opt out of cutoffs (remains alpha).
  * Note: legacy endpoints that omit release are temporarily tolerated in validPath,
- * which defers to calculateStability (stable until version 7.7.7, then alpha) until backfill is complete.
+ * which defers to calculateStability (stable until version 8.1.0, then alpha) until backfill is complete.
  */
 export type StabilityRelease =
     | { alpha: true }

--- a/src/lib/openapi/util/api-stability.test.ts
+++ b/src/lib/openapi/util/api-stability.test.ts
@@ -64,12 +64,14 @@ test.each([
     );
 });
 
-test(`${currentVersion} returns stable for legacy endpoints without cutoffs before the default threshold`, () => {
-    expect(calculateStability(undefined, currentVersion)).toBe('stable');
-});
-
-test(`${currentVersion} returns alpha when both cutoffs are omitted after the default threshold`, () => {
-    expect(calculateStability(undefined, '7.8.0')).toBe('alpha');
+test.each([
+    ['7.6.0', 'stable'],
+    ['8.0.0', 'stable'],
+    ['8.0.99', 'stable'],
+    ['8.1.0', 'alpha'],
+    ['8.2.0', 'alpha'],
+] as const)('%s returns %s for legacy endpoints without release milestones', (version, expected) => {
+    expect(calculateStability(undefined, version)).toBe(expected);
 });
 
 test.each([

--- a/src/lib/openapi/util/api-stability.ts
+++ b/src/lib/openapi/util/api-stability.ts
@@ -20,7 +20,7 @@ export function calculateStability(
         release && 'stable' in release ? semver.coerce(release.stable) : null;
     if (!betaVersion && !stableVersion) {
         // existing endpoints are stable, but until we backfill them they won't have these fields and therefore will be alpha, but because we don't want that, we default to stable for a period of time until we backfill all existing endpoints
-        if (semver.lt(current, '7.7.7')) {
+        if (semver.lt(current, '8.1.0')) {
             return 'stable';
         }
         return 'alpha';


### PR DESCRIPTION
## About the changes

Keeps legacy endpoints (without labeled release version) a bit longer
