### PR TITLE
chore: add release versions to endpoints

### DIFF
--- a/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
@@ -103,6 +103,7 @@ export default class FeatureController extends Controller {
             permission: NONE,
             middleware: [
                 openApiService.validPath({
+                    release: { stable: '4.14.0' },
                     operationId: 'getClientFeature',
                     summary: 'Get a single feature flag',
                     description:
@@ -125,6 +126,7 @@ export default class FeatureController extends Controller {
                     summary: 'Get all flags (SDK)',
                     description:
                         'Returns the SDK configuration for all feature flags that are available to the provided API key. Used by SDKs to configure local evaluation',
+                    release: { stable: '4.14.0' },
                     operationId: 'getAllClientFeatures',
                     tags: ['Client'],
                     responses: {

--- a/src/lib/features/constraints/constraints-controller.ts
+++ b/src/lib/features/constraints/constraints-controller.ts
@@ -39,6 +39,7 @@ export default class ConstraintsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Features'],
+                    release: { stable: '4.13.0' },
                     operationId: 'validateConstraint',
                     requestBody: createRequestSchema('constraintSchema'),
                     summary: 'Validate constraint',

--- a/src/lib/features/context/context.ts
+++ b/src/lib/features/context/context.ts
@@ -77,7 +77,9 @@ export class ContextController extends Controller {
         this.openApiService = openApiService;
         this.transactionalContextService = transactionalContextService;
         const prefix = mode === 'global' ? '' : '/:projectId/context';
-        const rootLevelContextFieldsRelease = undefined; // this represents the legacy behavior
+        const rootLevelContextFieldsRelease = {
+            stable: '7.4.1' as const,
+        };
         const projectLevelContextFieldsRelease = {
             beta: '7.4.0' as const, // project context fields introduced in 7.4.0
         };

--- a/src/lib/features/dependent-features/dependent-features-controller.ts
+++ b/src/lib/features/dependent-features/dependent-features-controller.ts
@@ -88,6 +88,7 @@ export default class DependentFeaturesController extends Controller {
                     summary: 'Add a feature dependency.',
                     description:
                         'Add a dependency to a parent feature. Each environment will resolve corresponding dependency independently.',
+                    release: { stable: '5.5.0' },
                     operationId: 'addFeatureDependency',
                     requestBody: createRequestSchema(
                         'createDependentFeatureSchema',
@@ -111,6 +112,7 @@ export default class DependentFeaturesController extends Controller {
                     tags: ['Dependencies'],
                     summary: 'Deletes a feature dependency.',
                     description: 'Remove a dependency to a parent feature.',
+                    release: { stable: '5.5.0' },
                     operationId: 'deleteFeatureDependency',
                     responses: {
                         200: emptyResponse,
@@ -131,6 +133,7 @@ export default class DependentFeaturesController extends Controller {
                     tags: ['Dependencies'],
                     summary: 'Deletes feature dependencies.',
                     description: 'Remove dependencies to all parent features.',
+                    release: { stable: '5.5.0' },
                     operationId: 'deleteFeatureDependencies',
                     responses: {
                         200: emptyResponse,
@@ -151,6 +154,7 @@ export default class DependentFeaturesController extends Controller {
                     summary: 'List parent options.',
                     description:
                         'List available parents who have no transitive dependencies.',
+                    release: { stable: '5.5.0' },
                     operationId: 'listParentOptions',
                     responses: {
                         200: createResponseSchema('parentFeatureOptionsSchema'),
@@ -171,6 +175,7 @@ export default class DependentFeaturesController extends Controller {
                     summary: 'List parent feature variants.',
                     description:
                         'List available parent variants across all strategy variants and feature environment variants.',
+                    release: { stable: '5.11.0' },
                     operationId: 'listParentVariantOptions',
                     responses: {
                         200: createResponseSchema('parentVariantOptionsSchema'),
@@ -191,6 +196,7 @@ export default class DependentFeaturesController extends Controller {
                     summary: 'Check dependencies exist.',
                     description:
                         'Check if any dependencies exist in this Unleash instance',
+                    release: { stable: '5.6.0' },
                     operationId: 'checkDependenciesExist',
                     responses: {
                         200: createResponseSchema('dependenciesExistSchema'),

--- a/src/lib/features/environments/environments-controller.ts
+++ b/src/lib/features/environments/environments-controller.ts
@@ -60,6 +60,7 @@ export class EnvironmentsController extends Controller {
                     summary: 'Get all environments',
                     description:
                         'Retrieves all environments that exist in this Unleash instance.',
+                    release: { stable: '4.13.0' },
                     operationId: 'getAllEnvironments',
                     responses: {
                         200: createResponseSchema('environmentsSchema'),
@@ -77,6 +78,7 @@ export class EnvironmentsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Environments'],
+                    release: { stable: '4.12.0' },
                     operationId: 'getEnvironment',
                     summary: 'Get the environment with `name`',
                     description:
@@ -97,6 +99,7 @@ export class EnvironmentsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Environments'],
+                    release: { stable: '4.18.0' },
                     operationId: 'getProjectEnvironments',
                     summary: 'Get the environments available to a project',
                     description:
@@ -120,6 +123,7 @@ export class EnvironmentsController extends Controller {
                     summary: 'Update environment sort orders',
                     description:
                         'Updates sort orders for the named environments. Environments not specified are unaffected.',
+                    release: { stable: '4.13.0' },
                     operationId: 'updateSortOrder',
                     requestBody: createRequestSchema('sortOrderSchema'),
                     responses: {
@@ -142,6 +146,7 @@ export class EnvironmentsController extends Controller {
                     summary: 'Toggle the environment with `name` on',
                     description:
                         'Makes it possible to enable this environment for a project. An environment must first be globally enabled using this endpoint before it can be enabled for a project',
+                    release: { stable: '4.12.0' },
                     operationId: 'toggleEnvironmentOn',
                     responses: {
                         204: emptyResponse,
@@ -163,6 +168,7 @@ export class EnvironmentsController extends Controller {
                     summary: 'Toggle the environment with `name` off',
                     description:
                         'Removes this environment from the list of available environments for projects to use',
+                    release: { stable: '4.12.0' },
                     operationId: 'toggleEnvironmentOff',
                     responses: {
                         204: emptyResponse,

--- a/src/lib/features/events/event-search-controller.ts
+++ b/src/lib/features/events/event-search-controller.ts
@@ -59,6 +59,7 @@ export default class EventSearchController extends Controller {
             permission: NONE,
             middleware: [
                 openApiService.validPath({
+                    release: { stable: '4.14.3' },
                     operationId: 'searchEvents',
                     tags: ['Events'],
                     summary: 'Search for events',

--- a/src/lib/features/export-import-toggles/export-import-controller.ts
+++ b/src/lib/features/export-import-toggles/export-import-controller.ts
@@ -56,6 +56,7 @@ class ExportImportController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Import/Export'],
+                    release: { stable: '4.20.0' },
                     operationId: 'exportFeatures',
                     requestBody: createRequestSchema('exportQuerySchema'),
                     responses: {
@@ -76,6 +77,7 @@ class ExportImportController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Import/Export'],
+                    release: { stable: '4.21.0' },
                     operationId: 'validateImport',
                     requestBody: createRequestSchema('importTogglesSchema'),
                     responses: {
@@ -97,6 +99,7 @@ class ExportImportController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Import/Export'],
+                    release: { stable: '4.21.0' },
                     operationId: 'importToggles',
                     requestBody: createRequestSchema('importTogglesSchema'),
                     responses: {

--- a/src/lib/features/feature-search/feature-search-controller.ts
+++ b/src/lib/features/feature-search/feature-search-controller.ts
@@ -63,6 +63,7 @@ export default class FeatureSearchController extends Controller {
                     tags: ['Search'],
                     summary: 'Search and filter features',
                     description: 'Search and filter by selected fields.',
+                    release: { stable: '5.6.0' },
                     operationId: 'searchFeatures',
                     // top level array needs to be mutable according to openapi library
                     parameters: [...featureSearchQueryParameters],

--- a/src/lib/features/feature-toggle/archive-feature-toggle-controller.ts
+++ b/src/lib/features/feature-toggle/archive-feature-toggle-controller.ts
@@ -49,6 +49,7 @@ export default class ArchiveController extends Controller {
                     description:
                         'This endpoint archives the specified feature.',
                     summary: 'Archives a feature',
+                    release: { stable: '4.13.0' },
                     operationId: 'deleteFeature',
                     responses: {
                         200: emptyResponse,
@@ -70,6 +71,7 @@ export default class ArchiveController extends Controller {
                     description:
                         'This endpoint revives the specified feature from archive.',
                     summary: 'Revives a feature',
+                    release: { stable: '4.13.0' },
                     operationId: 'reviveFeature',
                     responses: {
                         200: emptyResponse,

--- a/src/lib/features/feature-toggle/feature-toggle-controller.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-controller.ts
@@ -152,6 +152,7 @@ export default class ProjectFeaturesController extends Controller {
                     description:
                         'Information about the enablement status and strategies for a feature flag in specified environment.',
                     tags: ['Features'],
+                    release: { stable: '4.13.0' },
                     operationId: 'getFeatureEnvironment',
                     responses: {
                         200: createResponseSchema('featureEnvironmentSchema'),
@@ -173,6 +174,7 @@ export default class ProjectFeaturesController extends Controller {
                     description:
                         'Disable a feature flag in the specified environment.',
                     tags: ['Features'],
+                    release: { stable: '4.13.0' },
                     operationId: 'toggleFeatureEnvironmentOff',
                     responses: {
                         200: createResponseSchema('featureSchema'),
@@ -194,6 +196,7 @@ export default class ProjectFeaturesController extends Controller {
                     description:
                         'Enable a feature flag in the specified environment.',
                     tags: ['Features'],
+                    release: { stable: '4.13.0' },
                     operationId: 'toggleFeatureEnvironmentOn',
                     responses: {
                         200: createResponseSchema('featureSchema'),
@@ -214,6 +217,7 @@ export default class ProjectFeaturesController extends Controller {
                     summary: 'Bulk enable a list of features',
                     description:
                         'This endpoint enables multiple feature flags.',
+                    release: { stable: '5.1.0' },
                     operationId: 'bulkToggleFeaturesEnvironmentOn',
                     requestBody: createRequestSchema(
                         'bulkToggleFeaturesSchema',
@@ -237,6 +241,7 @@ export default class ProjectFeaturesController extends Controller {
                     summary: 'Bulk disable a list of features',
                     description:
                         'This endpoint disables multiple feature flags.',
+                    release: { stable: '5.1.0' },
                     operationId: 'bulkToggleFeaturesEnvironmentOff',
                     requestBody: createRequestSchema(
                         'bulkToggleFeaturesSchema',
@@ -258,6 +263,7 @@ export default class ProjectFeaturesController extends Controller {
                 openApiService.validPath({
                     tags: ['Features'],
                     summary: 'Get feature flag strategies',
+                    release: { stable: '4.14.0' },
                     operationId: 'getFeatureStrategies',
                     description:
                         'Get strategies defined for a feature flag in the specified environment.',
@@ -280,6 +286,7 @@ export default class ProjectFeaturesController extends Controller {
                     summary: 'Add a strategy to a feature flag',
                     description:
                         'Add a strategy to a feature flag in the specified environment.',
+                    release: { stable: '4.14.0' },
                     operationId: 'addFeatureStrategy',
                     requestBody: createRequestSchema(
                         'createFeatureStrategySchema',
@@ -303,6 +310,7 @@ export default class ProjectFeaturesController extends Controller {
                     summary: 'Get a strategy configuration',
                     description:
                         'Get a strategy configuration for an environment in a feature flag.',
+                    release: { stable: '4.14.0' },
                     operationId: 'getFeatureStrategy',
                     responses: {
                         200: createResponseSchema('featureStrategySchema'),
@@ -320,6 +328,7 @@ export default class ProjectFeaturesController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Features'],
+                    release: { stable: '4.14.0' },
                     operationId: 'setStrategySortOrder',
                     summary: 'Set strategy sort order',
                     description:
@@ -346,6 +355,7 @@ export default class ProjectFeaturesController extends Controller {
                     summary: 'Update a strategy',
                     description:
                         'Replace strategy configuration for a feature flag in the specified environment.',
+                    release: { stable: '4.14.0' },
                     operationId: 'updateFeatureStrategy',
                     requestBody: createRequestSchema(
                         'updateFeatureStrategySchema',
@@ -369,6 +379,7 @@ export default class ProjectFeaturesController extends Controller {
                     summary: 'Change specific properties of a strategy',
                     description:
                         'Change specific properties of a strategy configuration in a feature flag.',
+                    release: { stable: '4.14.0' },
                     operationId: 'patchFeatureStrategy',
                     requestBody: createRequestSchema('patchesSchema'),
                     responses: {
@@ -391,6 +402,7 @@ export default class ProjectFeaturesController extends Controller {
                     summary: 'Delete a strategy from a feature flag',
                     description:
                         'Delete a strategy configuration from a feature flag in the specified environment.',
+                    release: { stable: '4.14.0' },
                     operationId: 'deleteFeatureStrategy',
                     responses: {
                         200: emptyResponse,
@@ -411,6 +423,7 @@ export default class ProjectFeaturesController extends Controller {
                     description:
                         'A list of all features for the specified project.',
                     tags: ['Features'],
+                    release: { stable: '4.12.0' },
                     operationId: 'getFeatures',
                     responses: {
                         200: createResponseSchema('projectFeaturesSchema'),
@@ -431,6 +444,7 @@ export default class ProjectFeaturesController extends Controller {
                     description:
                         'Create a new feature flag in a specified project.',
                     tags: ['Features'],
+                    release: { stable: '4.12.0' },
                     operationId: 'createFeature',
                     requestBody: createRequestSchema('createFeatureSchema'),
                     responses: {
@@ -453,6 +467,7 @@ export default class ProjectFeaturesController extends Controller {
                     description:
                         'Creates a copy of the specified feature flag. The copy can be created in any project.',
                     tags: ['Features'],
+                    release: { stable: '4.12.0' },
                     operationId: 'cloneFeature',
                     requestBody: createRequestSchema('cloneFeatureSchema'),
                     responses: {
@@ -470,6 +485,7 @@ export default class ProjectFeaturesController extends Controller {
             permission: NONE,
             middleware: [
                 openApiService.validPath({
+                    release: { stable: '4.12.0' },
                     operationId: 'getFeature',
                     tags: ['Features'],
                     summary: 'Get a feature',
@@ -495,6 +511,7 @@ export default class ProjectFeaturesController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Features'],
+                    release: { stable: '4.12.0' },
                     operationId: 'updateFeature',
                     summary: 'Update a feature flag',
                     description:
@@ -516,6 +533,7 @@ export default class ProjectFeaturesController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Features'],
+                    release: { stable: '4.12.0' },
                     operationId: 'patchFeature',
                     summary: 'Modify a feature flag',
                     description:
@@ -538,6 +556,7 @@ export default class ProjectFeaturesController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Features'],
+                    release: { stable: '4.12.0' },
                     operationId: 'archiveFeature',
                     summary: 'Archive a feature flag',
                     description:
@@ -562,6 +581,7 @@ export default class ProjectFeaturesController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Features'],
+                    release: { stable: '4.22.0' },
                     operationId: 'staleFeatures',
                     summary: 'Mark features as stale / not stale',
                     description: `This endpoint marks the provided list of features as either [stale](https://docs.getunleash.io/concepts/technical-debt#stale-and-potentially-stale-flags) or not stale depending on the request body you send. Any provided features that don't exist are ignored.`,
@@ -582,6 +602,7 @@ export default class ProjectFeaturesController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Tags'],
+                    release: { stable: '4.22.0' },
                     operationId: 'addTagToFeatures',
                     summary: 'Adds a tag to the specified features',
                     description:

--- a/src/lib/features/feature-toggle/legacy/feature-toggle-legacy-controller.ts
+++ b/src/lib/features/feature-toggle/legacy/feature-toggle-legacy-controller.ts
@@ -53,6 +53,7 @@ class FeatureController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Features'],
+                    release: { stable: '4.12.0' },
                     operationId: 'validateFeature',
                     summary: 'Validate a feature flag name.',
                     requestBody: createRequestSchema('validateFeatureSchema'),
@@ -77,6 +78,7 @@ class FeatureController extends Controller {
                     description:
                         'Retrieves all the tags for a feature name. If the feature does not exist it returns an empty list.',
                     tags: ['Features'],
+                    release: { stable: '4.12.0' },
                     operationId: 'listTags',
                     responses: {
                         200: createResponseSchema('tagsSchema'),
@@ -97,6 +99,7 @@ class FeatureController extends Controller {
                     description:
                         'Adds a tag to a feature if the feature and tag type exist in the system. The operation is idempotent, so adding an existing tag will result in a successful response.',
                     tags: ['Features'],
+                    release: { stable: '4.12.0' },
                     operationId: 'addTag',
                     requestBody: createRequestSchema('tagSchema'),
                     responses: {
@@ -118,6 +121,7 @@ class FeatureController extends Controller {
                     description:
                         'Receives a list of tags to add and a list of tags to remove that are mandatory but can be empty. All tags under addedTags are first added to the feature and then all tags under removedTags are removed from the feature.',
                     tags: ['Features'],
+                    release: { stable: '4.22.0' },
                     operationId: 'updateTags',
                     requestBody: createRequestSchema('updateTagsSchema'),
                     responses: {
@@ -140,6 +144,7 @@ class FeatureController extends Controller {
                     description:
                         'Removes a tag from a feature. If the feature exists but the tag does not, it returns a successful response.',
                     tags: ['Features'],
+                    release: { stable: '4.12.0' },
                     operationId: 'removeTag',
                     responses: {
                         200: emptyResponse,

--- a/src/lib/features/frontend-api/frontend-api-controller.ts
+++ b/src/lib/features/frontend-api/frontend-api-controller.ts
@@ -73,6 +73,7 @@ export default class FrontendAPIController extends Controller {
             middleware: [
                 this.services.openApiService.validPath({
                     tags: ['Frontend API'],
+                    release: { stable: '4.15.0' },
                     operationId: 'getFrontendFeatures',
                     responses: {
                         200: createResponseSchema('frontendApiFeaturesSchema'),
@@ -94,6 +95,7 @@ export default class FrontendAPIController extends Controller {
             middleware: [
                 this.services.openApiService.validPath({
                     tags: ['Frontend API'],
+                    release: { stable: '6.7.2' },
                     operationId: 'getFrontendApiFeaturesWithPost',
                     requestBody: createRequestSchema(
                         'frontendApiFeaturesPostSchema',
@@ -127,6 +129,7 @@ export default class FrontendAPIController extends Controller {
                     tags: ['Frontend API'],
                     summary: 'Register client usage metrics',
                     description: `Registers usage metrics. Stores information about how many times each flag was evaluated to enabled and disabled within a time frame. If provided, this operation will also store data on how many times each feature flag's variants were displayed to the end user. If the Frontend API is disabled 404 is returned.`,
+                    release: { stable: '4.15.0' },
                     operationId: 'registerFrontendMetrics',
                     requestBody: createRequestSchema('clientMetricsSchema'),
                     responses: {
@@ -156,6 +159,7 @@ export default class FrontendAPIController extends Controller {
                     summary: 'Register a client SDK',
                     description:
                         'This is for future use. Currently Frontend client registration is not supported. Returning 200 for clients that expect this status code. If the Frontend API is disabled 404 is returned.',
+                    release: { stable: '4.15.0' },
                     operationId: 'registerFrontendClient',
                     requestBody: createRequestSchema('frontendApiClientSchema'),
                     responses: {

--- a/src/lib/features/maintenance/maintenance-controller.ts
+++ b/src/lib/features/maintenance/maintenance-controller.ts
@@ -50,6 +50,7 @@ export default class MaintenanceController extends Controller {
                     description:
                         'Lets administrators put Unleash into a mostly read-only mode. While Unleash is in maintenance mode, users can not change any configuration settings',
                     tags: ['Maintenance'],
+                    release: { stable: '4.20.0' },
                     operationId: 'toggleMaintenance',
                     responses: {
                         204: emptyResponse,
@@ -70,6 +71,7 @@ export default class MaintenanceController extends Controller {
                     description:
                         'Tells you whether maintenance mode is enabled or disabled',
                     tags: ['Maintenance'],
+                    release: { stable: '4.20.0' },
                     operationId: 'getMaintenance',
                     responses: {
                         200: createResponseSchema('maintenanceSchema'),

--- a/src/lib/features/metrics/client-metrics/client-metrics.ts
+++ b/src/lib/features/metrics/client-metrics/client-metrics.ts
@@ -59,6 +59,7 @@ class ClientMetricsController extends Controller {
             permission: NONE,
             middleware: [
                 openApiService.validPath({
+                    release: { stable: '4.14.0' },
                     operationId: 'getRawFeatureMetrics',
                     tags: ['Metrics'],
                     summary: 'Get feature metrics',
@@ -79,6 +80,7 @@ class ClientMetricsController extends Controller {
             permission: NONE,
             middleware: [
                 openApiService.validPath({
+                    release: { stable: '4.14.0' },
                     operationId: 'getFeatureUsageSummary',
                     tags: ['Metrics'],
                     summary: `Last hour of usage and a list of applications that have reported seeing this feature flag`,

--- a/src/lib/features/metrics/custom/custom-metrics-controller.ts
+++ b/src/lib/features/metrics/custom/custom-metrics-controller.ts
@@ -40,6 +40,7 @@ export default class CustomMetricsController extends Controller {
                     tags: ['Metrics'],
                     summary: 'Get stored custom metrics',
                     description: `Retrieves the stored custom metrics data.`,
+                    release: { stable: '7.0.0' },
                     operationId: 'getCustomMetrics',
                     responses: {
                         200: emptyResponse,
@@ -58,6 +59,7 @@ export default class CustomMetricsController extends Controller {
                     tags: ['Metrics'],
                     summary: 'Get metrics in Prometheus format',
                     description: `Exposes all custom metrics in Prometheus text format for scraping.`,
+                    release: { stable: '7.0.0' },
                     operationId: 'getPrometheusMetrics',
                     responses: {
                         200: {

--- a/src/lib/features/metrics/instance/metrics.ts
+++ b/src/lib/features/metrics/instance/metrics.ts
@@ -83,6 +83,7 @@ export default class ClientMetricsController extends Controller {
                     tags: ['Client'],
                     summary: 'Register client usage metrics',
                     description: `Registers usage metrics. Stores information about how many times each flag was evaluated to enabled and disabled within a time frame. If provided, this operation will also store data on how many times each feature flag's variants were displayed to the end user.`,
+                    release: { stable: '4.14.0' },
                     operationId: 'registerClientMetrics',
                     requestBody: createRequestSchema('clientMetricsSchema'),
                     responses: {
@@ -111,6 +112,7 @@ export default class ClientMetricsController extends Controller {
                     tags: ['Unleash Edge'],
                     summary: 'Send metrics in bulk',
                     description: `This operation accepts batched metrics from any client. Metrics will be inserted into Unleash's metrics storage`,
+                    release: { stable: '5.9.0' },
                     operationId: 'clientBulkMetrics',
                     requestBody: createRequestSchema('bulkMetricsSchema'),
                     responses: {
@@ -131,6 +133,7 @@ export default class ClientMetricsController extends Controller {
                     tags: ['Client'],
                     summary: 'Send custom metrics',
                     description: `This operation accepts custom metrics from clients. These metrics will be exposed via Prometheus in Unleash.`,
+                    release: { stable: '7.0.0' },
                     operationId: 'clientCustomMetrics',
                     requestBody: createRequestSchema('customMetricsSchema'),
                     responses: {

--- a/src/lib/features/metrics/instance/register.ts
+++ b/src/lib/features/metrics/instance/register.ts
@@ -53,6 +53,7 @@ export default class RegisterController extends Controller {
                     summary: 'Register a client SDK',
                     description:
                         'Register a client SDK with Unleash. SDKs call this endpoint on startup to tell Unleash about their existence. Used to track custom strategies in use as well as SDK versions.',
+                    release: { stable: '4.14.0' },
                     operationId: 'registerClientApplication',
                     requestBody: createRequestSchema('clientApplicationSchema'),
                     responses: { 202: emptyResponse },

--- a/src/lib/features/metrics/unknown-flags/unknown-flags-controller.ts
+++ b/src/lib/features/metrics/unknown-flags/unknown-flags-controller.ts
@@ -36,6 +36,7 @@ export default class UnknownFlagsController extends Controller {
             permission: NONE,
             middleware: [
                 openApiService.validPath({
+                    release: { stable: '7.0.0' },
                     operationId: 'getUnknownFlags',
                     tags: ['Unknown Flags'],
                     summary: 'Get unknown flags',

--- a/src/lib/features/playground/playground.ts
+++ b/src/lib/features/playground/playground.ts
@@ -49,6 +49,7 @@ export default class PlaygroundController extends Controller {
             permission: NONE,
             middleware: [
                 openApiService.validPath({
+                    release: { stable: '4.14.0' },
                     operationId: 'getPlayground',
                     tags: ['Playground'],
                     responses: {
@@ -71,6 +72,7 @@ export default class PlaygroundController extends Controller {
             permission: NONE,
             middleware: [
                 openApiService.validPath({
+                    release: { stable: '5.2.0' },
                     operationId: 'getAdvancedPlayground',
                     tags: ['Playground'],
                     responses: {

--- a/src/lib/features/project-environments/project-environments-controller.ts
+++ b/src/lib/features/project-environments/project-environments-controller.ts
@@ -69,6 +69,7 @@ export default class ProjectEnvironmentsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Projects'],
+                    release: { stable: '4.13.0' },
                     operationId: 'addEnvironmentToProject',
                     summary: 'Add an environment to a project.',
                     description:
@@ -93,6 +94,7 @@ export default class ProjectEnvironmentsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Projects'],
+                    release: { stable: '4.13.0' },
                     operationId: 'removeEnvironmentFromProject',
                     summary: 'Remove an environment from a project.',
                     description:
@@ -113,6 +115,7 @@ export default class ProjectEnvironmentsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Projects'],
+                    release: { stable: '5.1.0' },
                     operationId: 'addDefaultStrategyToProjectEnvironment',
                     summary: 'Set environment-default strategy',
                     description:

--- a/src/lib/features/project-insights/project-insights-controller.ts
+++ b/src/lib/features/project-insights/project-insights-controller.ts
@@ -40,6 +40,7 @@ export default class ProjectInsightsController extends Controller {
                 this.openApiService.validPath({
                     deprecated: true,
                     tags: ['Projects'],
+                    release: { stable: '5.11.0' },
                     operationId: 'getProjectInsights',
                     summary: 'Get an overview of a project insights.',
                     description:

--- a/src/lib/features/project/project-controller.ts
+++ b/src/lib/features/project/project-controller.ts
@@ -72,6 +72,7 @@ export default class ProjectController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Projects'],
+                    release: { stable: '4.13.0' },
                     operationId: 'getProjects',
                     summary: 'Get a list of all projects.',
                     description:
@@ -102,6 +103,7 @@ export default class ProjectController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Projects'],
+                    release: { stable: '4.20.0' },
                     operationId: 'getProjectOverview',
                     summary: 'Get an overview of a project.',
                     description:
@@ -124,6 +126,7 @@ export default class ProjectController extends Controller {
                 this.openApiService.validPath({
                     deprecated: true,
                     tags: ['Projects'],
+                    release: { stable: '5.5.0' },
                     operationId: 'getProjectDora',
                     summary: 'Get an overview project dora metrics.',
                     description:
@@ -144,6 +147,7 @@ export default class ProjectController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Projects'],
+                    release: { stable: '5.10.0' },
                     operationId: 'getProjectApplications',
                     summary: 'Get a list of all applications for a project.',
                     description:
@@ -165,6 +169,7 @@ export default class ProjectController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Projects'],
+                    release: { stable: '6.1.0' },
                     operationId: 'getProjectFlagCreators',
                     summary: 'Get a list of all flag creators for a project.',
                     description:
@@ -185,6 +190,7 @@ export default class ProjectController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Projects'],
+                    release: { stable: '6.0.0' },
                     operationId: 'getOutdatedProjectSdks',
                     summary: 'Get outdated project SDKs',
                     description:

--- a/src/lib/features/segment/segment-controller.ts
+++ b/src/lib/features/segment/segment-controller.ts
@@ -85,6 +85,7 @@ export class SegmentsController extends Controller {
                     description:
                         'Uses the name provided in the body of the request to validate if the given name exists or not',
                     tags: ['Segments'],
+                    release: { stable: '5.5.0' },
                     operationId: 'validateSegment',
                     requestBody: createRequestSchema('nameSchema'),
                     responses: {
@@ -103,6 +104,7 @@ export class SegmentsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Segments'],
+                    release: { stable: '5.5.0' },
                     operationId: 'getSegmentsByStrategyId',
                     summary: 'Get strategy segments',
                     description:
@@ -125,6 +127,7 @@ export class SegmentsController extends Controller {
                     description:
                         'Sets the segments of the strategy specified to be exactly the ones passed in the payload. Any segments that were used by the strategy before will be removed if they are not in the provided list of segments.',
                     tags: ['Strategies'],
+                    release: { stable: '5.5.0' },
                     operationId: 'updateFeatureStrategySegments',
                     requestBody: createRequestSchema(
                         'updateFeatureStrategySegmentsSchema',
@@ -147,6 +150,7 @@ export class SegmentsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Segments'],
+                    release: { stable: '5.5.0' },
                     operationId: 'getStrategiesBySegmentId',
                     summary: 'Get strategies that reference segment',
                     description:
@@ -192,6 +196,7 @@ export class SegmentsController extends Controller {
                         },
                     ],
                     tags: ['Segments'],
+                    release: { stable: '5.5.0' },
                     operationId: 'removeSegment',
                     responses: {
                         204: emptyResponse,
@@ -212,6 +217,7 @@ export class SegmentsController extends Controller {
                     description:
                         'Updates the content of the segment with the provided payload. Requires `name` and `constraints` to be present. If `project` is not present, it will be set to `null`. Any other fields not specified will be left untouched.',
                     tags: ['Segments'],
+                    release: { stable: '5.5.0' },
                     operationId: 'updateSegment',
                     parameters: [
                         {
@@ -243,6 +249,7 @@ export class SegmentsController extends Controller {
                     summary: 'Get a segment',
                     description: 'Retrieves a segment based on its ID.',
                     tags: ['Segments'],
+                    release: { stable: '5.5.0' },
                     operationId: 'getSegment',
                     parameters: [
                         {
@@ -274,6 +281,7 @@ export class SegmentsController extends Controller {
                     description:
                         'Creates a new segment using the payload provided',
                     tags: ['Segments'],
+                    release: { stable: '5.5.0' },
                     operationId: 'createSegment',
                     requestBody: createRequestSchema('upsertSegmentSchema'),
                     responses: {
@@ -297,6 +305,7 @@ export class SegmentsController extends Controller {
                     description:
                         'Retrieves all segments that exist in this Unleash instance.',
                     tags: ['Segments'],
+                    release: { stable: '5.5.0' },
                     operationId: 'getSegments',
                     responses: {
                         200: createResponseSchema('segmentsSchema'),

--- a/src/lib/features/tag-type/tag-type.ts
+++ b/src/lib/features/tag-type/tag-type.ts
@@ -58,6 +58,7 @@ class TagTypeController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Tags'],
+                    release: { stable: '4.13.0' },
                     operationId: 'getTagTypes',
                     summary: 'Get all tag types',
                     description: 'Get a list of all available tag types.',
@@ -76,6 +77,7 @@ class TagTypeController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Tags'],
+                    release: { stable: '4.13.0' },
                     operationId: 'createTagType',
                     summary: 'Create a tag type',
                     description: 'Create a new tag type.',
@@ -95,6 +97,7 @@ class TagTypeController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Tags'],
+                    release: { stable: '4.13.0' },
                     operationId: 'validateTagType',
                     summary: 'Validate a tag type',
                     description:
@@ -115,6 +118,7 @@ class TagTypeController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Tags'],
+                    release: { stable: '4.13.0' },
                     operationId: 'getTagType',
                     summary: 'Get a tag type',
                     description: 'Get a tag type by name.',
@@ -133,6 +137,7 @@ class TagTypeController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Tags'],
+                    release: { stable: '4.13.0' },
                     operationId: 'updateTagType',
                     summary: 'Update a tag type',
                     description:
@@ -154,6 +159,7 @@ class TagTypeController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Tags'],
+                    release: { stable: '4.13.0' },
                     operationId: 'deleteTagType',
                     summary: 'Delete a tag type',
                     description:

--- a/src/lib/features/ui-observability-controller/ui-observability-controller.ts
+++ b/src/lib/features/ui-observability-controller/ui-observability-controller.ts
@@ -32,6 +32,7 @@ export class UiObservabilityController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Admin UI'],
+                    release: { stable: '5.10.0' },
                     operationId: 'uiObservability',
                     summary: 'Accepts errors from the UI client',
                     description:

--- a/src/lib/routes/admin-api/addon.ts
+++ b/src/lib/routes/admin-api/addon.ts
@@ -83,6 +83,7 @@ class AddonController extends Controller {
                     description:
                         'Retrieve all addons and providers that are defined on this Unleash instance.',
                     tags: ['Addons'],
+                    release: { stable: '4.14.0' },
                     operationId: 'getAddons',
                     responses: {
                         ...getStandardResponses(401),
@@ -103,6 +104,7 @@ class AddonController extends Controller {
                     description:
                         'Create an addon instance. The addon must use one of the providers available on this Unleash instance.',
                     tags: ['Addons'],
+                    release: { stable: '4.14.0' },
                     operationId: 'createAddon',
                     requestBody: createRequestSchema('addonCreateUpdateSchema'),
                     responses: {
@@ -124,6 +126,7 @@ class AddonController extends Controller {
                     description:
                         'Retrieve information about the addon whose ID matches the ID in the request URL.',
                     tags: ['Addons'],
+                    release: { stable: '4.14.0' },
                     operationId: 'getAddon',
                     responses: {
                         200: createResponseSchema('addonSchema'),
@@ -145,6 +148,7 @@ class AddonController extends Controller {
 
 Note: passing \`null\` as a value for the description property will set it to an empty string.`,
                     tags: ['Addons'],
+                    release: { stable: '4.14.0' },
                     operationId: 'updateAddon',
                     requestBody: createRequestSchema('addonCreateUpdateSchema'),
                     responses: {
@@ -167,6 +171,7 @@ Note: passing \`null\` as a value for the description property will set it to an
                     description:
                         'Delete the addon specified by the ID in the request path.',
                     tags: ['Addons'],
+                    release: { stable: '4.14.0' },
                     operationId: 'deleteAddon',
                     responses: {
                         200: emptyResponse,
@@ -184,6 +189,7 @@ Note: passing \`null\` as a value for the description property will set it to an
             middleware: [
                 openApiService.validPath({
                     tags: ['Addons'],
+                    release: { stable: '6.1.0' },
                     operationId: 'getIntegrationEvents',
                     summary:
                         'Get integration events for a specific integration configuration.',

--- a/src/lib/routes/admin-api/api-token.ts
+++ b/src/lib/routes/admin-api/api-token.ts
@@ -160,6 +160,7 @@ export class ApiTokenController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['API tokens'],
+                    release: { stable: '4.14.0' },
                     operationId: 'getAllApiTokens',
                     summary: 'Get API tokens',
                     description:
@@ -180,6 +181,7 @@ export class ApiTokenController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['API tokens'],
+                    release: { stable: '5.4.0' },
                     operationId: 'getApiTokensByName',
                     summary: 'Get API tokens by name',
                     description:
@@ -204,6 +206,7 @@ export class ApiTokenController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['API tokens'],
+                    release: { stable: '4.14.0' },
                     operationId: 'createApiToken',
                     requestBody: createRequestSchema('createApiTokenSchema'),
                     summary: 'Create API token',
@@ -230,6 +233,7 @@ export class ApiTokenController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['API tokens'],
+                    release: { stable: '4.14.0' },
                     operationId: 'updateApiToken',
                     summary: 'Update API token',
                     description:
@@ -259,6 +263,7 @@ export class ApiTokenController extends Controller {
                     summary: 'Delete API token',
                     description:
                         "Deletes an existing API token. The `token` path parameter is the token's `secret`. If the token does not exist, this endpoint returns a 200 OK, but does nothing.",
+                    release: { stable: '4.14.0' },
                     operationId: 'deleteApiToken',
                     responses: {
                         200: emptyResponse,

--- a/src/lib/routes/admin-api/event.ts
+++ b/src/lib/routes/admin-api/event.ts
@@ -55,6 +55,7 @@ export default class EventController extends Controller {
             middleware: [
                 openApiService.validPath({
                     deprecated: true,
+                    release: { stable: '4.14.0' },
                     operationId: 'getEvents',
                     tags: ['Events'],
                     responses: {
@@ -87,6 +88,7 @@ export default class EventController extends Controller {
             middleware: [
                 openApiService.validPath({
                     deprecated: true,
+                    release: { stable: '4.14.0' },
                     operationId: 'getEventsForToggle',
                     tags: ['Events'],
                     responses: {
@@ -109,6 +111,7 @@ export default class EventController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Events'],
+                    release: { stable: '6.2.0' },
                     operationId: 'getEventCreators',
                     summary: 'Get a list of all users that have created events',
                     description:

--- a/src/lib/routes/admin-api/favorites.ts
+++ b/src/lib/routes/admin-api/favorites.ts
@@ -37,6 +37,7 @@ export default class FavoritesController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Features'],
+                    release: { stable: '4.18.0' },
                     operationId: 'addFavoriteFeature',
                     summary: 'Add feature to favorites',
                     description:
@@ -57,6 +58,7 @@ export default class FavoritesController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Features'],
+                    release: { stable: '4.18.0' },
                     operationId: 'removeFavoriteFeature',
                     summary: 'Remove feature from favorites',
                     description:
@@ -80,6 +82,7 @@ export default class FavoritesController extends Controller {
                     summary: 'Add project to favorites',
                     description:
                         'This endpoint marks the project in the url as favorite',
+                    release: { stable: '4.18.0' },
                     operationId: 'addFavoriteProject',
                     responses: {
                         200: emptyResponse,
@@ -100,6 +103,7 @@ export default class FavoritesController extends Controller {
                     summary: 'Remove project from favorites',
                     description:
                         'This endpoint removes the project in the url from favorites',
+                    release: { stable: '4.18.0' },
                     operationId: 'removeFavoriteProject',
                     responses: {
                         200: emptyResponse,

--- a/src/lib/routes/admin-api/feature-type.ts
+++ b/src/lib/routes/admin-api/feature-type.ts
@@ -49,6 +49,7 @@ export class FeatureTypeController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Feature Types'],
+                    release: { stable: '4.13.0' },
                     operationId: 'getAllFeatureTypes',
                     summary: 'Get all feature types',
                     description:
@@ -69,6 +70,7 @@ export class FeatureTypeController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Feature Types'],
+                    release: { stable: '5.3.0' },
                     operationId: 'updateFeatureTypeLifetime',
                     summary: 'Update feature type lifetime',
                     description: `Updates the lifetime configuration for the specified [feature flag type](https://docs.getunleash.io/concepts/feature-flags#feature-flag-types). The expected lifetime is an integer representing the number of days before Unleash marks a feature flag of that type as potentially stale. If set to \`null\` or \`0\`, then feature flags of that particular type will never be marked as potentially stale.

--- a/src/lib/routes/admin-api/instance-admin.ts
+++ b/src/lib/routes/admin-api/instance-admin.ts
@@ -41,6 +41,7 @@ class InstanceAdminController extends Controller {
                     summary: 'Instance usage statistics',
                     description:
                         'Provides statistics about various features of Unleash to allow for reporting of usage for self-hosted customers. The response contains data such as the number of users, groups, features, strategies, versions, etc.',
+                    release: { stable: '5.2.0' },
                     operationId: 'getInstanceAdminStatsCsv',
                     responses: {
                         200: createCsvResponseSchema(
@@ -60,6 +61,7 @@ class InstanceAdminController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Instance Admin'],
+                    release: { stable: '4.17.0' },
                     operationId: 'getInstanceAdminStats',
                     summary: 'Instance usage statistics',
                     description:

--- a/src/lib/routes/admin-api/metrics.ts
+++ b/src/lib/routes/admin-api/metrics.ts
@@ -79,6 +79,7 @@ class MetricsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Metrics'],
+                    release: { stable: '4.14.0' },
                     operationId: 'createApplication',
                     summary:
                         'Create an application to connect reported metrics',
@@ -101,6 +102,7 @@ class MetricsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Metrics'],
+                    release: { stable: '4.14.0' },
                     operationId: 'deleteApplication',
                     summary: 'Delete an application',
                     description: `Delete the application specified in the request URL. Returns 200 OK if the application was successfully deleted or if it didn't exist`,
@@ -123,6 +125,7 @@ class MetricsController extends Controller {
                     description:
                         'Returns all applications registered with Unleash. Applications can be created via metrics reporting or manual creation',
                     parameters: [...applicationsQueryParameters],
+                    release: { stable: '4.14.0' },
                     operationId: 'getApplications',
                     responses: {
                         200: createResponseSchema('applicationsSchema'),
@@ -138,6 +141,7 @@ class MetricsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Metrics'],
+                    release: { stable: '4.14.0' },
                     operationId: 'getApplication',
                     summary: 'Get application data',
                     description:
@@ -157,6 +161,7 @@ class MetricsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Metrics'],
+                    release: { stable: '5.10.0' },
                     operationId: 'getApplicationOverview',
                     summary: 'Get application overview',
                     description:
@@ -176,6 +181,7 @@ class MetricsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Metrics'],
+                    release: { stable: '5.10.0' },
                     operationId: 'getApplicationEnvironmentInstances',
                     summary: 'Get application environment instances (Last 24h)',
                     description:
@@ -197,6 +203,7 @@ class MetricsController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Metrics'],
+                    release: { stable: '5.11.0' },
                     operationId: 'getOutdatedSdks',
                     summary: 'Get outdated SDKs',
                     description:

--- a/src/lib/routes/admin-api/project/api-token.ts
+++ b/src/lib/routes/admin-api/project/api-token.ts
@@ -85,6 +85,7 @@ export class ProjectApiTokenController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Projects'],
+                    release: { stable: '4.21.0' },
                     operationId: 'getProjectApiTokens',
                     summary: 'Get api tokens for project.',
                     description:
@@ -105,6 +106,7 @@ export class ProjectApiTokenController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Projects'],
+                    release: { stable: '4.21.0' },
                     operationId: 'createProjectApiToken',
                     requestBody: createRequestSchema(
                         'createProjectApiTokenSchema',
@@ -129,6 +131,7 @@ export class ProjectApiTokenController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Projects'],
+                    release: { stable: '4.21.0' },
                     operationId: 'deleteProjectApiToken',
                     summary: 'Delete a project API token.',
                     description: `This operation deletes the API token specified in the request URL. If the token doesn't exist, returns an OK response (status code 200).`,

--- a/src/lib/routes/admin-api/project/health-report.ts
+++ b/src/lib/routes/admin-api/project/health-report.ts
@@ -43,6 +43,7 @@ export default class ProjectHealthReport extends Controller {
                 openApiService.validPath({
                     tags: ['Projects'],
                     deprecated: true,
+                    release: { stable: '4.13.0' },
                     operationId: 'getProjectHealthReport',
                     summary: 'Get a health report for a project.',
                     description:

--- a/src/lib/routes/admin-api/project/project-archive.ts
+++ b/src/lib/routes/admin-api/project/project-archive.ts
@@ -70,6 +70,7 @@ export default class ProjectArchiveController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Archive'],
+                    release: { stable: '4.22.0' },
                     operationId: 'deleteFeatures',
                     description:
                         'This endpoint deletes the specified features, that are in archive.',
@@ -92,6 +93,7 @@ export default class ProjectArchiveController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Archive'],
+                    release: { stable: '4.22.0' },
                     operationId: 'reviveFeatures',
                     description:
                         'This endpoint revives the specified features.',
@@ -113,6 +115,7 @@ export default class ProjectArchiveController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Features'],
+                    release: { stable: '5.6.0' },
                     operationId: 'validateArchiveFeatures',
                     description:
                         'This endpoint return info about the archive features impact.',
@@ -136,6 +139,7 @@ export default class ProjectArchiveController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Features'],
+                    release: { stable: '4.22.0' },
                     operationId: 'archiveFeatures',
                     description:
                         "This endpoint archives the specified features. Any features that are already archived or that don't exist are ignored. All existing features (whether already archived or not) that are provided must belong to the specified project.",

--- a/src/lib/routes/admin-api/project/variants.ts
+++ b/src/lib/routes/admin-api/project/variants.ts
@@ -67,6 +67,7 @@ export default class VariantsController extends Controller {
                     summary: 'Get variants for a feature in an environment',
                     description: `Returns the variants for a feature in a specific environment. If the feature has no variants it will return an empty array of variants`,
                     tags: ['Features'],
+                    release: { stable: '4.18.0' },
                     operationId: 'getEnvironmentFeatureVariants',
                     responses: {
                         200: createResponseSchema('featureVariantsSchema'),
@@ -85,6 +86,7 @@ export default class VariantsController extends Controller {
                     summary: "Patch a feature's variants in an environment",
                     description: `Apply a list of patches to the features environments in the specified environment. The patch objects should conform to the [JSON-patch format (RFC 6902)](https://www.rfc-editor.org/rfc/rfc6902).`,
                     tags: ['Features'],
+                    release: { stable: '4.18.0' },
                     operationId: 'patchEnvironmentsFeatureVariants',
                     requestBody: createRequestSchema('patchesSchema'),
                     responses: {
@@ -112,6 +114,7 @@ The backend will validate the input for the following invariants:
 
 The backend will also distribute remaining weight up to 1000 after adding the variants with \`weightType: fix\` together amongst the variants of \`weightType: variable\``,
                     tags: ['Features'],
+                    release: { stable: '4.18.0' },
                     operationId: 'overwriteEnvironmentFeatureVariants',
                     requestBody: createRequestSchema('variantsSchema'),
                     responses: {
@@ -129,6 +132,7 @@ The backend will also distribute remaining weight up to 1000 after adding the va
             middleware: [
                 openApiService.validPath({
                     tags: ['Features'],
+                    release: { stable: '4.20.0' },
                     operationId: 'overwriteFeatureVariantsOnEnvironments',
                     summary:
                         'Create (overwrite) variants for a feature flag in multiple environments',

--- a/src/lib/routes/admin-api/public-signup.ts
+++ b/src/lib/routes/admin-api/public-signup.ts
@@ -62,6 +62,7 @@ export class PublicSignupController extends Controller {
                     tags: ['Public signup tokens'],
                     summary: 'Get public signup tokens',
                     description: 'Retrieves all existing public signup tokens.',
+                    release: { stable: '4.16.0' },
                     operationId: 'getAllPublicSignupTokens',
                     responses: {
                         200: createResponseSchema('publicSignupTokensSchema'),
@@ -78,6 +79,7 @@ export class PublicSignupController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Public signup tokens'],
+                    release: { stable: '4.16.0' },
                     operationId: 'createPublicSignupToken',
                     summary: 'Create a public signup token',
                     description:
@@ -106,6 +108,7 @@ export class PublicSignupController extends Controller {
                     summary: 'Retrieve a token',
                     description:
                         "Get information about a specific token. The `:token` part of the URL should be the token's secret.",
+                    release: { stable: '4.16.0' },
                     operationId: 'getPublicSignupToken',
                     responses: {
                         200: createResponseSchema('publicSignupTokenSchema'),
@@ -123,6 +126,7 @@ export class PublicSignupController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Public signup tokens'],
+                    release: { stable: '4.16.0' },
                     operationId: 'updatePublicSignupToken',
                     summary: 'Update a public signup token',
                     description:

--- a/src/lib/routes/admin-api/strategy.ts
+++ b/src/lib/routes/admin-api/strategy.ts
@@ -61,6 +61,7 @@ class StrategyController extends Controller {
                     description:
                         'Retrieves all strategy types ([predefined](https://docs.getunleash.io/concepts/activation-strategies "predefined strategies") and [custom strategies](https://docs.getunleash.io/concepts/activation-strategies#custom-strategies)) that are defined on this Unleash instance.',
                     tags: ['Strategies'],
+                    release: { stable: '4.14.0' },
                     operationId: 'getAllStrategies',
                     responses: {
                         200: createResponseSchema('strategiesSchema'),
@@ -82,6 +83,7 @@ class StrategyController extends Controller {
                         'Retrieves the definition of the strategy specified in the URL',
 
                     tags: ['Strategies'],
+                    release: { stable: '4.12.0' },
                     operationId: 'getStrategy',
                     responses: {
                         200: createResponseSchema('strategySchema'),
@@ -102,6 +104,7 @@ class StrategyController extends Controller {
                     summary: 'Delete a strategy',
                     description: 'Deletes the specified strategy definition',
                     tags: ['Strategies'],
+                    release: { stable: '4.14.0' },
                     operationId: 'removeStrategy',
                     responses: {
                         200: emptyResponse,
@@ -119,6 +122,7 @@ class StrategyController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Strategies'],
+                    release: { stable: '4.14.0' },
                     operationId: 'createStrategy',
                     summary: 'Create a strategy',
                     description:
@@ -143,6 +147,7 @@ class StrategyController extends Controller {
                     summary: 'Update a strategy type',
                     description:
                         'Updates the specified strategy type. Any properties not specified in the request body are left untouched.',
+                    release: { stable: '4.12.0' },
                     operationId: 'updateStrategy',
                     requestBody: createRequestSchema('updateStrategySchema'),
                     responses: {
@@ -164,6 +169,7 @@ class StrategyController extends Controller {
                     tags: ['Strategies'],
                     summary: 'Deprecate a strategy',
                     description: 'Marks the specified strategy as deprecated.',
+                    release: { stable: '4.14.0' },
                     operationId: 'deprecateStrategy',
                     responses: {
                         200: emptyResponse,
@@ -182,6 +188,7 @@ class StrategyController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Strategies'],
+                    release: { stable: '4.14.0' },
                     operationId: 'reactivateStrategy',
                     summary: 'Reactivate a strategy',
                     description:

--- a/src/lib/routes/admin-api/tag.ts
+++ b/src/lib/routes/admin-api/tag.ts
@@ -56,6 +56,7 @@ class TagController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Tags'],
+                    release: { stable: '4.14.0' },
                     operationId: 'getTags',
                     summary: 'List all tags.',
                     description: 'List all tags available in Unleash.',
@@ -74,6 +75,7 @@ class TagController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Tags'],
+                    release: { stable: '4.14.0' },
                     operationId: 'createTag',
                     summary: 'Create a new tag.',
                     description: 'Create a new tag with the specified data.',
@@ -96,6 +98,7 @@ class TagController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Tags'],
+                    release: { stable: '4.14.0' },
                     operationId: 'getTagsByType',
                     summary: 'List all tags of a given type.',
                     description:
@@ -115,6 +118,7 @@ class TagController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Tags'],
+                    release: { stable: '4.14.0' },
                     operationId: 'getTag',
                     summary: 'Get a tag by type and value.',
                     description:
@@ -135,6 +139,7 @@ class TagController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Tags'],
+                    release: { stable: '4.14.0' },
                     operationId: 'deleteTag',
                     summary: 'Delete a tag.',
                     description:

--- a/src/lib/routes/admin-api/telemetry.ts
+++ b/src/lib/routes/admin-api/telemetry.ts
@@ -32,6 +32,7 @@ class TelemetryController extends Controller {
                     summary: 'Get telemetry settings',
                     description:
                         'Provides the configured settings for [telemetry information collection](https://docs.getunleash.io/privacy-and-compliance/data-privacy)',
+                    release: { stable: '5.3.0' },
                     operationId: 'getTelemetrySettings',
                     responses: {
                         200: createResponseSchema('telemetrySettingsSchema'),

--- a/src/lib/routes/admin-api/user-admin.ts
+++ b/src/lib/routes/admin-api/user-admin.ts
@@ -128,6 +128,7 @@ export default class UserAdminController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '4.14.0' },
                     operationId: 'validateUserPassword',
                     summary: 'Validate password for a user',
                     description:
@@ -149,6 +150,7 @@ export default class UserAdminController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '4.14.0' },
                     operationId: 'changeUserPassword',
                     summary: 'Change password for a user',
                     description: 'Change password for a user as an admin',
@@ -180,6 +182,7 @@ export default class UserAdminController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '4.14.0' },
                     operationId: 'resetUserPassword',
                     summary: 'Reset user password',
                     description: 'Reset user password as an admin',
@@ -200,6 +203,7 @@ export default class UserAdminController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '4.14.0' },
                     operationId: 'getUsers',
                     summary:
                         'Get all users and [root roles](https://docs.getunleash.io/concepts/rbac#predefined-roles)',
@@ -221,6 +225,7 @@ export default class UserAdminController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '4.14.0' },
                     operationId: 'searchUsers',
                     summary: 'Search users',
                     description:
@@ -250,6 +255,7 @@ export default class UserAdminController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '4.14.0' },
                     operationId: 'getBaseUsersAndGroups',
                     summary: 'Get basic user and group information',
                     description:
@@ -318,6 +324,7 @@ export default class UserAdminController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '5.1.0' },
                     operationId: 'getAdminCount',
                     summary: 'Get total count of admin accounts',
                     description:
@@ -338,6 +345,7 @@ export default class UserAdminController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '4.14.0' },
                     operationId: 'createUser',
                     summary: 'Create a new user',
                     description: 'Creates a new user with the given root role.',
@@ -367,6 +375,7 @@ export default class UserAdminController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '4.14.0' },
                     operationId: 'getUser',
                     summary: 'Get user',
                     description: 'Will return a single user by id',
@@ -397,6 +406,7 @@ export default class UserAdminController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '4.14.0' },
                     operationId: 'updateUser',
                     summary: 'Update a user',
                     description:
@@ -430,6 +440,7 @@ export default class UserAdminController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '6.7.0' },
                     operationId: 'deleteScimUsers',
                     summary: 'Delete all SCIM users',
                     description: 'Deletes all users managed by SCIM',
@@ -450,6 +461,7 @@ export default class UserAdminController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '4.14.0' },
                     operationId: 'deleteUser',
                     summary: 'Delete a user',
                     description: 'Deletes the user with the given userId',

--- a/src/lib/routes/admin-api/user-feedback.ts
+++ b/src/lib/routes/admin-api/user-feedback.ts
@@ -43,6 +43,7 @@ class UserFeedbackController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Admin UI'],
+                    release: { stable: '4.14.0' },
                     operationId: 'createFeedback',
                     summary: 'Send Unleash feedback',
                     description:
@@ -64,6 +65,7 @@ class UserFeedbackController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Admin UI'],
+                    release: { stable: '4.14.0' },
                     operationId: 'updateFeedback',
                     summary: 'Update Unleash feedback',
                     description:

--- a/src/lib/routes/admin-api/user-splash.ts
+++ b/src/lib/routes/admin-api/user-splash.ts
@@ -36,6 +36,7 @@ class UserSplashController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Admin UI'],
+                    release: { stable: '4.13.0' },
                     operationId: 'updateSplashSettings',
                     summary: 'Update splash settings',
                     description:

--- a/src/lib/routes/admin-api/user/pat.ts
+++ b/src/lib/routes/admin-api/user/pat.ts
@@ -58,6 +58,7 @@ export default class PatController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Personal access tokens'],
+                    release: { stable: '4.16.0' },
                     operationId: 'getPats',
                     summary:
                         'Get all personal access tokens (PATs) for the current user.',
@@ -78,6 +79,7 @@ export default class PatController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Personal access tokens'],
+                    release: { stable: '4.16.0' },
                     operationId: 'createPat',
                     summary:
                         'Create a new personal access token (PAT) for the current user.',
@@ -101,6 +103,7 @@ export default class PatController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Personal access tokens'],
+                    release: { stable: '4.16.0' },
                     operationId: 'deletePat',
                     summary:
                         'Delete a personal access token (PAT) for the current user.',

--- a/src/lib/routes/admin-api/user/user.ts
+++ b/src/lib/routes/admin-api/user/user.ts
@@ -103,6 +103,7 @@ class UserController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '4.14.0' },
                     operationId: 'getMe',
                     summary: 'Get your own user details',
                     description:
@@ -123,6 +124,7 @@ class UserController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '4.16.0' },
                     operationId: 'getProfile',
                     summary: 'Get your own user profile',
                     description:
@@ -143,6 +145,7 @@ class UserController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '4.14.0' },
                     operationId: 'changeMyPassword',
                     summary: 'Change your own password',
                     description:
@@ -170,6 +173,7 @@ class UserController extends Controller {
             middleware: [
                 this.openApiService.validPath({
                     tags: ['Users'],
+                    release: { stable: '5.10.0' },
                     operationId: 'getUserRoles',
                     summary: 'Get roles for currently logged in user',
                     parameters: [

--- a/src/lib/routes/auth/reset-password-controller.ts
+++ b/src/lib/routes/auth/reset-password-controller.ts
@@ -59,6 +59,7 @@ class ResetPasswordController extends Controller {
                     description:
                         'If the token is valid returns the user that owns the token',
                     tags: ['Auth'],
+                    release: { stable: '4.14.0' },
                     operationId: 'validateToken',
                     responses: {
                         200: createResponseSchema('tokenUserSchema'),
@@ -78,6 +79,7 @@ class ResetPasswordController extends Controller {
                     summary: `Changes a user password`,
                     description:
                         'Allows users with a valid reset token to reset their password without remembering their old password',
+                    release: { stable: '4.14.0' },
                     operationId: 'changePassword',
                     requestBody: createRequestSchema('changePasswordSchema'),
                     responses: {
@@ -98,6 +100,7 @@ class ResetPasswordController extends Controller {
                     summary: 'Validates password',
                     description:
                         'Verifies that the password adheres to the [Unleash password guidelines](https://docs.getunleash.io/using-unleash/deploy/configuring-unleash#securing-unleash)',
+                    release: { stable: '4.14.0' },
                     operationId: 'validatePassword',
                     requestBody: createRequestSchema('validatePasswordSchema'),
                     responses: {
@@ -118,6 +121,7 @@ class ResetPasswordController extends Controller {
                     summary: 'Reset password',
                     description:
                         'Requests a password reset email for the user. This email can be used to reset the password for a user that has forgotten their password',
+                    release: { stable: '4.14.0' },
                     operationId: 'sendResetPasswordEmail',
                     requestBody: createRequestSchema('emailSchema'),
                     responses: {

--- a/src/lib/routes/auth/simple-password-provider.ts
+++ b/src/lib/routes/auth/simple-password-provider.ts
@@ -41,6 +41,7 @@ export class SimplePasswordProvider extends Controller {
                     summary: 'Log in',
                     description:
                         'Logs in the user and creates an active session',
+                    release: { stable: '4.14.0' },
                     operationId: 'login',
                     requestBody: createRequestSchema('loginSchema'),
                     responses: {

--- a/src/lib/routes/edge-api/index.ts
+++ b/src/lib/routes/edge-api/index.ts
@@ -52,6 +52,7 @@ export default class EdgeController extends Controller {
                     summary: 'Check which tokens are valid',
                     description:
                         'This operation accepts a list of tokens to validate. Unleash will validate each token you provide. For each valid token you provide, Unleash will return the token along with its type and which projects it has access to.',
+                    release: { stable: '4.15.0' },
                     operationId: 'getValidTokens',
                     requestBody: createRequestSchema('tokenStringListSchema'),
                     responses: {

--- a/src/lib/routes/health-check.ts
+++ b/src/lib/routes/health-check.ts
@@ -22,6 +22,7 @@ export class HealthCheckController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Operational'],
+                    release: { stable: '4.14.0' },
                     operationId: 'getHealth',
                     summary: 'Get instance operational status',
                     description:

--- a/src/lib/routes/public-invite.ts
+++ b/src/lib/routes/public-invite.ts
@@ -48,6 +48,7 @@ export class PublicInviteController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Public signup tokens'],
+                    release: { stable: '4.16.0' },
                     operationId: 'validatePublicSignupToken',
                     summary: `Validate signup token`,
                     description: `Check whether the provided public sign-up token exists, has not expired and is enabled`,
@@ -67,6 +68,7 @@ export class PublicInviteController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Public signup tokens'],
+                    release: { stable: '4.16.0' },
                     operationId: 'addPublicSignupTokenUser',
                     summary: 'Add a user via a signup token',
                     description:

--- a/src/lib/routes/ready-check.ts
+++ b/src/lib/routes/ready-check.ts
@@ -40,6 +40,7 @@ export class ReadyCheckController extends Controller {
             middleware: [
                 openApiService.validPath({
                     tags: ['Operational'],
+                    release: { stable: '7.3.0' },
                     operationId: 'getReady',
                     summary: 'Get instance readiness status',
                     description:

--- a/src/lib/ui-config/ui-config-controller.ts
+++ b/src/lib/ui-config/ui-config-controller.ts
@@ -55,6 +55,7 @@ class UiConfigController extends Controller {
                     summary: 'Get UI configuration',
                     description:
                         'Retrieves the full configuration used to set up the Unleash Admin UI.',
+                    release: { stable: '4.15.0' },
                     operationId: 'getUiConfig',
                     responses: {
                         200: createResponseSchema('uiConfigSchema'),
@@ -74,6 +75,7 @@ class UiConfigController extends Controller {
                     summary: 'Sets allowed CORS origins',
                     description:
                         'Sets Cross-Origin Resource Sharing headers for Frontend SDK API.',
+                    release: { stable: '6.6.0' },
                     operationId: 'setCors',
                     requestBody: createRequestSchema('setCorsSchema'),
                     responses: { 204: emptyResponse },

--- a/src/lib/users/inactive/inactive-users-controller.ts
+++ b/src/lib/users/inactive/inactive-users-controller.ts
@@ -54,6 +54,7 @@ export class InactiveUsersController extends Controller {
             permission: ADMIN,
             middleware: [
                 openApiService.validPath({
+                    release: { stable: '5.10.0' },
                     operationId: 'getInactiveUsers',
                     summary: 'Gets inactive users',
                     description: `Gets all inactive users. An inactive user is a user that has not logged in in the last ${this.userInactivityThresholdInDays} days`,
@@ -71,6 +72,7 @@ export class InactiveUsersController extends Controller {
             permission: ADMIN,
             middleware: [
                 openApiService.validPath({
+                    release: { stable: '5.10.0' },
                     operationId: 'deleteInactiveUsers',
                     summary: 'Deletes inactive users',
                     description: `Deletes all inactive users. An inactive user is a user that has not logged in in the last ${this.userInactivityThresholdInDays} days`,


### PR DESCRIPTION
## About the changes
Adds API release versions for OpenAPI docs. It adds `"x-stability-level": "stable"` to these endpoints in the openapi schema.

## OSS PR checklist

- [x] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [x] I have added tests or explained why tests are not needed.
- [x] I have updated documentation where relevant.
