### PR TITLE
chore: enforce release definition

### DIFF
--- a/src/lib/services/openapi-service.ts
+++ b/src/lib/services/openapi-service.ts
@@ -8,10 +8,7 @@ import {
     removeJsonSchemaProps,
     type SchemaId,
 } from '../openapi/index.js';
-import type {
-    ApiOperation,
-    StabilityRelease,
-} from '../openapi/util/api-operation.js';
+import type { ApiOperation } from '../openapi/util/api-operation.js';
 import type { Logger } from '../logger.js';
 import { validateSchema } from '../openapi/validate.js';
 import type { IFlagResolver } from '../types/index.js';
@@ -36,11 +33,6 @@ type OpenApiMiddleware = IExpressOpenApi & {
         router?: unknown,
         basePath?: string,
     ) => OpenApiDocument;
-};
-
-// Allow legacy operations that omit the release field until we backfill them.
-type LegacyApiOperation = Omit<ApiOperation, 'release'> & {
-    release?: StabilityRelease;
 };
 
 export class OpenApiService {
@@ -70,7 +62,7 @@ export class OpenApiService {
         ) as OpenApiMiddleware;
     }
 
-    validPath(op: ApiOperation | LegacyApiOperation): RequestHandler {
+    validPath(op: ApiOperation): RequestHandler {
         // extract enterpriseOnly and release to avoid leaking into the OpenAPI spec
         const { enterpriseOnly, release, ...openapiSpec } = op;
         const { baseUriPath = '' } = this.config.server ?? {};


### PR DESCRIPTION
## About the changes

Picks up the remaining tasks from https://github.com/Unleash/unleash/blob/main/contributing/ADRs/back-end/api-version-tracking.md by making release mandatory. Now this forces us to actively plan for the release version and specify that in the schema definition.

## OSS PR checklist

- [x] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [x] I have added tests or explained why tests are not needed.
- [x] I have updated documentation where relevant.
