### PR TITLE
chore: show theme sub menu on hover

### DIFF
--- a/frontend/src/component/user/UserProfile/UserProfileContent/UserProfileContent.tsx
+++ b/frontend/src/component/user/UserProfile/UserProfileContent/UserProfileContent.tsx
@@ -83,6 +83,7 @@ const ThemeSubmenu = ({ onCloseAll }: { onCloseAll: () => void }) => {
         <>
             <MenuItem
                 onClick={(event) => setAnchorEl(event.currentTarget)}
+                onMouseEnter={(event) => setAnchorEl(event.currentTarget)}
                 sx={menuItemSx}
                 aria-haspopup='true'
                 aria-expanded={open}
@@ -101,6 +102,7 @@ const ThemeSubmenu = ({ onCloseAll }: { onCloseAll: () => void }) => {
                 transformOrigin={{ vertical: 'top', horizontal: 'left' }}
                 slotProps={{
                     paper: {
+                        onMouseLeave: () => setAnchorEl(null),
                         sx: {
                             minWidth: (theme) => theme.spacing(15),
                             borderRadius: (theme) =>


### PR DESCRIPTION
Shows theme selection sub menu (in the user profile menu) on hover.
When hovering away from the submenu, the submenu is not shown anymore.


https://github.com/user-attachments/assets/90dc503b-761e-4ab2-bcb9-7017291fbe54

