### PR TITLE
chore: add TS safeguard around formatAssetPath trap

### DIFF
--- a/frontend/src/asset-types.d.ts
+++ b/frontend/src/asset-types.d.ts
@@ -1,0 +1,70 @@
+// Phantom type for raw Vite asset imports. Not assignable to `string` at
+// compile time, so `<img src={icon} />` is a TypeScript error.
+// Must go through `formatAssetPath(icon)` which returns `string`.
+// At runtime these are plain strings — this is a compile-time-only constraint.
+declare const _rawAssetUrlBrand: unique symbol;
+type RawAssetURL = { readonly [_rawAssetUrlBrand]: true };
+
+// Override vite/client asset declarations. This file is alphabetically before
+// vite-env.d.ts so TypeScript processes it first, making RawAssetURL win over
+// vite/client's `string` type for asset imports.
+declare module '*.apng' {
+    const src: RawAssetURL;
+    export default src;
+}
+declare module '*.bmp' {
+    const src: RawAssetURL;
+    export default src;
+}
+declare module '*.png' {
+    const src: RawAssetURL;
+    export default src;
+}
+declare module '*.jpg' {
+    const src: RawAssetURL;
+    export default src;
+}
+declare module '*.jpeg' {
+    const src: RawAssetURL;
+    export default src;
+}
+declare module '*.jfif' {
+    const src: RawAssetURL;
+    export default src;
+}
+declare module '*.pjpeg' {
+    const src: RawAssetURL;
+    export default src;
+}
+declare module '*.pjp' {
+    const src: RawAssetURL;
+    export default src;
+}
+declare module '*.gif' {
+    const src: RawAssetURL;
+    export default src;
+}
+declare module '*.svg' {
+    const src: RawAssetURL;
+    export default src;
+}
+declare module '*.ico' {
+    const src: RawAssetURL;
+    export default src;
+}
+declare module '*.webp' {
+    const src: RawAssetURL;
+    export default src;
+}
+declare module '*.avif' {
+    const src: RawAssetURL;
+    export default src;
+}
+declare module '*.cur' {
+    const src: RawAssetURL;
+    export default src;
+}
+declare module '*.jxl' {
+    const src: RawAssetURL;
+    export default src;
+}

--- a/frontend/src/asset-types.d.ts
+++ b/frontend/src/asset-types.d.ts
@@ -3,68 +3,68 @@
 // Must go through `formatAssetPath(icon)` which returns `string`.
 // At runtime these are plain strings — this is a compile-time-only constraint.
 declare const _rawAssetUrlBrand: unique symbol;
-type RawAssetURL = { readonly [_rawAssetUrlBrand]: true };
+type UnformattedAssetPath = { readonly [_rawAssetUrlBrand]: true };
 
 // Override vite/client asset declarations. This file is alphabetically before
-// vite-env.d.ts so TypeScript processes it first, making RawAssetURL win over
+// vite-env.d.ts so TypeScript processes it first, making UnformattedAssetPath win over
 // vite/client's `string` type for asset imports.
 declare module '*.apng' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }
 declare module '*.bmp' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }
 declare module '*.png' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }
 declare module '*.jpg' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }
 declare module '*.jpeg' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }
 declare module '*.jfif' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }
 declare module '*.pjpeg' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }
 declare module '*.pjp' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }
 declare module '*.gif' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }
 declare module '*.svg' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }
 declare module '*.ico' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }
 declare module '*.webp' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }
 declare module '*.avif' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }
 declare module '*.cur' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }
 declare module '*.jxl' {
-    const src: RawAssetURL;
+    const src: UnformattedAssetPath;
     export default src;
 }

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
@@ -15,7 +15,7 @@ const backendNames = new Set<SdkName>(serverSdks.map((s) => s.name));
 
 type SdkOption = {
     name: SdkName;
-    icon: string;
+    icon: RawAssetURL;
     group: string;
 };
 

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
@@ -15,7 +15,7 @@ const backendNames = new Set<SdkName>(serverSdks.map((s) => s.name));
 
 type SdkOption = {
     name: SdkName;
-    icon: RawAssetURL;
+    icon: UnformattedAssetPath;
     group: string;
 };
 

--- a/frontend/src/component/integrations/IntegrationList/IntegrationIcon/IntegrationIcon.tsx
+++ b/frontend/src/component/integrations/IntegrationList/IntegrationIcon/IntegrationIcon.tsx
@@ -29,7 +29,10 @@ const StyledAvatar = styled(Avatar)(({ theme }) => ({
     fontSize: '28px',
 }));
 
-const integrations: Record<string, { icon: RawAssetURL; title: string }> = {
+const integrations: Record<
+    string,
+    { icon: UnformattedAssetPath; title: string }
+> = {
     datadog: { title: 'Datadog', icon: dataDogIcon },
     'new-relic': { title: 'New Relic', icon: newRelicIcon },
     jira: { title: 'Jira', icon: jiraIcon },

--- a/frontend/src/component/integrations/IntegrationList/IntegrationIcon/IntegrationIcon.tsx
+++ b/frontend/src/component/integrations/IntegrationList/IntegrationIcon/IntegrationIcon.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react';
 import { Avatar, styled } from '@mui/material';
 import DeviceHub from '@mui/icons-material/DeviceHub';
 import { formatAssetPath } from 'utils/formatPath';
@@ -30,10 +29,7 @@ const StyledAvatar = styled(Avatar)(({ theme }) => ({
     fontSize: '28px',
 }));
 
-const integrations: Record<
-    string,
-    { icon: RawAssetURL | ReactNode; title: string }
-> = {
+const integrations: Record<string, { icon: RawAssetURL; title: string }> = {
     datadog: { title: 'Datadog', icon: dataDogIcon },
     'new-relic': { title: 'New Relic', icon: newRelicIcon },
     jira: { title: 'Jira', icon: jiraIcon },
@@ -59,22 +55,11 @@ export const IntegrationIcon = ({ name }: IIntegrationIconProps) => {
         );
     }
 
-    if (typeof integration.icon === 'string') {
-        return (
-            <StyledAvatar
-                src={formatAssetPath(integration.icon)}
-                alt={`${capitalizeFirst(integration.title)} icon`}
-                variant='rounded'
-            />
-        );
-    }
-
     return (
         <StyledAvatar
+            src={formatAssetPath(integration.icon)}
             alt={`${capitalizeFirst(integration.title)} icon`}
             variant='rounded'
-        >
-            {integration.icon as ReactNode}
-        </StyledAvatar>
+        />
     );
 };

--- a/frontend/src/component/integrations/IntegrationList/IntegrationIcon/IntegrationIcon.tsx
+++ b/frontend/src/component/integrations/IntegrationList/IntegrationIcon/IntegrationIcon.tsx
@@ -32,7 +32,7 @@ const StyledAvatar = styled(Avatar)(({ theme }) => ({
 
 const integrations: Record<
     string,
-    { icon: string | ReactNode; title: string }
+    { icon: RawAssetURL | ReactNode; title: string }
 > = {
     datadog: { title: 'Datadog', icon: dataDogIcon },
     'new-relic': { title: 'New Relic', icon: newRelicIcon },
@@ -74,7 +74,7 @@ export const IntegrationIcon = ({ name }: IIntegrationIconProps) => {
             alt={`${capitalizeFirst(integration.title)} icon`}
             variant='rounded'
         >
-            {integration.icon}
+            {integration.icon as ReactNode}
         </StyledAvatar>
     );
 };

--- a/frontend/src/component/integrations/ViewIntegration/JiraIntegration/JiraImageContainer.tsx
+++ b/frontend/src/component/integrations/ViewIntegration/JiraIntegration/JiraImageContainer.tsx
@@ -26,7 +26,7 @@ export const StyledImg = styled('img')({
 interface JiraIntegrationProps {
     title: string;
     description: string;
-    src: RawAssetURL;
+    src: UnformattedAssetPath;
 }
 
 export const JiraImageContainer: FC<JiraIntegrationProps> = ({

--- a/frontend/src/component/integrations/ViewIntegration/JiraIntegration/JiraImageContainer.tsx
+++ b/frontend/src/component/integrations/ViewIntegration/JiraIntegration/JiraImageContainer.tsx
@@ -26,7 +26,7 @@ export const StyledImg = styled('img')({
 interface JiraIntegrationProps {
     title: string;
     description: string;
-    src: string;
+    src: RawAssetURL | string;
 }
 
 export const JiraImageContainer: FC<JiraIntegrationProps> = ({

--- a/frontend/src/component/integrations/ViewIntegration/JiraIntegration/JiraImageContainer.tsx
+++ b/frontend/src/component/integrations/ViewIntegration/JiraIntegration/JiraImageContainer.tsx
@@ -26,7 +26,7 @@ export const StyledImg = styled('img')({
 interface JiraIntegrationProps {
     title: string;
     description: string;
-    src: RawAssetURL | string;
+    src: RawAssetURL;
 }
 
 export const JiraImageContainer: FC<JiraIntegrationProps> = ({

--- a/frontend/src/component/onboarding/dialog/ConnectSdkDialog/SelectSdk/SelectSdk.tsx
+++ b/frontend/src/component/onboarding/dialog/ConnectSdkDialog/SelectSdk/SelectSdk.tsx
@@ -65,7 +65,7 @@ const SelectLabel = styled('span')(({ theme }) => ({
 }));
 
 interface ISdkListProps {
-    sdks: { name: SdkName; icon: string }[];
+    sdks: { name: SdkName; icon: RawAssetURL }[];
     type: SdkType;
     selectedSdkName: string | undefined;
     onSelect: (sdk: Sdk) => void;

--- a/frontend/src/component/onboarding/dialog/ConnectSdkDialog/SelectSdk/SelectSdk.tsx
+++ b/frontend/src/component/onboarding/dialog/ConnectSdkDialog/SelectSdk/SelectSdk.tsx
@@ -65,7 +65,7 @@ const SelectLabel = styled('span')(({ theme }) => ({
 }));
 
 interface ISdkListProps {
-    sdks: { name: SdkName; icon: RawAssetURL }[];
+    sdks: { name: SdkName; icon: UnformattedAssetPath }[];
     type: SdkType;
     selectedSdkName: string | undefined;
     onSelect: (sdk: Sdk) => void;

--- a/frontend/src/utils/formatPath.test.ts
+++ b/frontend/src/utils/formatPath.test.ts
@@ -5,6 +5,10 @@ import {
     formatApiPath,
 } from 'utils/formatPath';
 
+// Cast helpers: in tests we pass string literals; in production these are
+// always RawAssetURL values coming from Vite's static asset imports.
+const asset = (path: string) => path as unknown as RawAssetURL;
+
 test('formatBasePath', () => {
     expect(parseBasePath()).toEqual('');
     expect(parseBasePath('')).toEqual('');
@@ -17,19 +21,19 @@ test('formatBasePath', () => {
 });
 
 test('formatAssetPath', () => {
-    expect(formatAssetPath('')).toEqual('');
-    expect(formatAssetPath('/')).toEqual('');
-    expect(formatAssetPath('a')).toEqual('/a');
-    expect(formatAssetPath('/a')).toEqual('/a');
-    expect(formatAssetPath('/a/')).toEqual('/a');
-    expect(formatAssetPath('a/b/')).toEqual('/a/b');
-    expect(formatAssetPath('', '')).toEqual('');
-    expect(formatAssetPath('/', '/')).toEqual('');
-    expect(formatAssetPath('a', 'x')).toEqual('/x/a');
-    expect(formatAssetPath('/a', '/x')).toEqual('/x/a');
-    expect(formatAssetPath('/a/', '/x/')).toEqual('/x/a');
-    expect(formatAssetPath('a/b/', 'x/y/')).toEqual('/x/y/a/b');
-    expect(formatAssetPath('//a//b//', '//x//y//')).toEqual('/x/y/a/b');
+    expect(formatAssetPath(asset(''))).toEqual('');
+    expect(formatAssetPath(asset('/'))).toEqual('');
+    expect(formatAssetPath(asset('a'))).toEqual('/a');
+    expect(formatAssetPath(asset('/a'))).toEqual('/a');
+    expect(formatAssetPath(asset('/a/'))).toEqual('/a');
+    expect(formatAssetPath(asset('a/b/'))).toEqual('/a/b');
+    expect(formatAssetPath(asset(''), '')).toEqual('');
+    expect(formatAssetPath(asset('/'), '/')).toEqual('');
+    expect(formatAssetPath(asset('a'), 'x')).toEqual('/x/a');
+    expect(formatAssetPath(asset('/a'), '/x')).toEqual('/x/a');
+    expect(formatAssetPath(asset('/a/'), '/x/')).toEqual('/x/a');
+    expect(formatAssetPath(asset('a/b/'), 'x/y/')).toEqual('/x/y/a/b');
+    expect(formatAssetPath(asset('//a//b//'), '//x//y//')).toEqual('/x/y/a/b');
 });
 
 test('formatApiPath', () => {

--- a/frontend/src/utils/formatPath.test.ts
+++ b/frontend/src/utils/formatPath.test.ts
@@ -6,8 +6,8 @@ import {
 } from 'utils/formatPath';
 
 // Cast helpers: in tests we pass string literals; in production these are
-// always RawAssetURL values coming from Vite's static asset imports.
-const asset = (path: string) => path as unknown as RawAssetURL;
+// always UnformattedAssetPath values coming from Vite's static asset imports.
+const asset = (path: string) => path as unknown as UnformattedAssetPath;
 
 test('formatBasePath', () => {
     expect(parseBasePath()).toEqual('');

--- a/frontend/src/utils/formatPath.ts
+++ b/frontend/src/utils/formatPath.ts
@@ -2,8 +2,11 @@ export const formatApiPath = (path: string, base = basePath): string => {
     return joinPaths(base, path);
 };
 
-export const formatAssetPath = (path: RawAssetURL, base = basePath): string => {
-    // RawAssetURL is a phantom compile-time type; at runtime it's always a string.
+export const formatAssetPath = (
+    path: UnformattedAssetPath,
+    base = basePath,
+): string => {
+    // UnformattedAssetPath is a phantom compile-time type; at runtime it's always a string.
     const pathStr = path as unknown as string;
     if (import.meta.env.DEV && import.meta.env.BASE_URL !== '/') {
         // Vite will automatically add BASE_URL to imported assets.

--- a/frontend/src/utils/formatPath.ts
+++ b/frontend/src/utils/formatPath.ts
@@ -2,13 +2,18 @@ export const formatApiPath = (path: string, base = basePath): string => {
     return joinPaths(base, path);
 };
 
-export const formatAssetPath = (path: string, base = basePath): string => {
+export const formatAssetPath = (
+    path: RawAssetURL | string,
+    base = basePath,
+): string => {
+    // RawAssetURL is a phantom compile-time type; at runtime it's always a string.
+    const pathStr = path as unknown as string;
     if (import.meta.env.DEV && import.meta.env.BASE_URL !== '/') {
         // Vite will automatically add BASE_URL to imported assets.
-        return joinPaths(path);
+        return joinPaths(pathStr);
     }
 
-    return joinPaths(base, path);
+    return joinPaths(base, pathStr);
 };
 
 // Parse the basePath value from the HTML meta tag.

--- a/frontend/src/utils/formatPath.ts
+++ b/frontend/src/utils/formatPath.ts
@@ -2,10 +2,7 @@ export const formatApiPath = (path: string, base = basePath): string => {
     return joinPaths(base, path);
 };
 
-export const formatAssetPath = (
-    path: RawAssetURL | string,
-    base = basePath,
-): string => {
+export const formatAssetPath = (path: RawAssetURL, base = basePath): string => {
     // RawAssetURL is a phantom compile-time type; at runtime it's always a string.
     const pathStr = path as unknown as string;
     if (import.meta.env.DEV && import.meta.env.BASE_URL !== '/') {


### PR DESCRIPTION
https://linear.app/unleash/issue/SA-660/add-a-ts-safeguard-around-the-formatassetpath-trap

Adds a TS safeguard around the `formatAssetPath` trap.

This "trap" is that you should remember to use `formatAssetPath` when you're handling raw imports of static assets. Otherwise, even though they will work locally, they will break for cloud instances.

The trick we used is to type these imports as `RawAssetURL`, requiring you to handle them accordingly.

Some implementation details:
- `asset-types.d.ts` must stay alphabetically before `vite-env.d.ts` — TypeScript processes it first, so `RawAssetURL` wins over vite/client's `string` declaration for image imports
- Zero runtime overhead — `RawAssetURL` is a phantom type that only exists at compile time; at runtime these are plain strings as Vite always provides
- 4 existing files had `icon: string` / `src: string` annotations that needed updating to `RawAssetURL` — their code was already correct (calling `formatAssetPath`), just the types were no longer precise

### TS warning you

<img width="781" height="221" alt="image" src="https://github.com/user-attachments/assets/beb76b65-c978-4e27-ba5c-2f2d7286b573" />

### Works with `formatAssetPath`
<img width="335" height="92" alt="image" src="https://github.com/user-attachments/assets/1c399102-5b74-4452-a657-f0b37b4aa929" />
