### PR TITLE
refactor(frontend): move table consumers onto query-param specs

### DIFF
--- a/frontend/src/component/application/ApplicationList/PaginatedApplicationList.tsx
+++ b/frontend/src/component/application/ApplicationList/PaginatedApplicationList.tsx
@@ -13,11 +13,11 @@ import { LinkCell } from 'component/common/Table/cells/LinkCell/LinkCell';
 import { ApplicationUsageCell } from './ApplicationUsageCell/ApplicationUsageCell.tsx';
 import type { ApplicationSchema } from 'openapi';
 import {
-    encodeQueryParams,
-    NumberParam,
-    StringParam,
-    withDefault,
-} from 'use-query-params';
+    encodeSpecParams,
+    safeNumberQueryParam,
+    stringQueryParam,
+    withDefaultQueryParam,
+} from 'utils/queryParamSpec';
 import { DEFAULT_PAGE_LIMIT } from 'hooks/api/getters/useProjectApplications/useProjectApplications';
 import { usePersistentTableState } from 'hooks/usePersistentTableState';
 import { createColumnHelper, useReactTable } from '@tanstack/react-table';
@@ -57,11 +57,11 @@ const columnHelper = createColumnHelper<ApplicationSchema>();
 
 export const PaginatedApplicationList = () => {
     const stateConfig = {
-        offset: withDefault(NumberParam, 0),
-        limit: withDefault(NumberParam, DEFAULT_PAGE_LIMIT),
-        query: StringParam,
-        sortBy: withDefault(StringParam, 'appName'),
-        sortOrder: withDefault(StringParam, 'asc'),
+        offset: withDefaultQueryParam(safeNumberQueryParam, 0),
+        limit: withDefaultQueryParam(safeNumberQueryParam, DEFAULT_PAGE_LIMIT),
+        query: stringQueryParam,
+        sortBy: withDefaultQueryParam(stringQueryParam, 'appName'),
+        sortOrder: withDefaultQueryParam(stringQueryParam, 'asc'),
     };
     const [tableState, setTableState] = usePersistentTableState(
         `applications-table`,
@@ -72,7 +72,7 @@ export const PaginatedApplicationList = () => {
         total,
         loading,
     } = useApplications(
-        mapValues(encodeQueryParams(stateConfig, tableState), (value) =>
+        mapValues(encodeSpecParams(stateConfig, tableState), (value) =>
             value ? `${value}` : undefined,
         ),
     );

--- a/frontend/src/component/events/EventLog/useEventLogSearch.ts
+++ b/frontend/src/component/events/EventLog/useEventLogSearch.ts
@@ -1,5 +1,10 @@
-import { encodeQueryParams, StringParam, withDefault } from 'use-query-params';
-import { FilterItemParam } from 'utils/serializeQueryParams';
+import {
+    encodeSpecParams,
+    filterItemQueryParam,
+    safeNumberQueryParam,
+    stringQueryParam,
+    withDefaultQueryParam,
+} from 'utils/queryParamSpec';
 import { usePersistentTableState } from 'hooks/usePersistentTableState';
 import mapValues from 'lodash.mapvalues';
 import { useEventSearch } from 'hooks/api/getters/useEventSearch/useEventSearch';
@@ -7,7 +12,6 @@ import type { SearchEventsParams } from 'openapi';
 import type { FilterItemParamHolder } from 'component/filter/Filters/Filters';
 import { format, subYears } from 'date-fns';
 import { autocorrectDateRange } from 'component/filter/autocorrectDateRange';
-import { SafeNumberParam } from 'utils/safeNumberParam';
 import { DEFAULT_PAGE_LIMIT } from 'utils/paginationConfig';
 
 type Log =
@@ -18,16 +22,25 @@ type Log =
 const extraParameters = (logType: Log) => {
     switch (logType.type) {
         case 'global':
-            return { project: FilterItemParam, feature: FilterItemParam };
+            return {
+                project: filterItemQueryParam,
+                feature: filterItemQueryParam,
+            };
         case 'project':
             return {
-                feature: FilterItemParam,
-                project: withDefault(StringParam, `IS:${logType.projectId}`),
+                feature: filterItemQueryParam,
+                project: withDefaultQueryParam(
+                    stringQueryParam,
+                    `IS:${logType.projectId}`,
+                ),
             };
         case 'flag':
             return {
-                project: FilterItemParam,
-                feature: withDefault(StringParam, `IS:${logType.flagName}`),
+                project: filterItemQueryParam,
+                feature: withDefaultQueryParam(
+                    stringQueryParam,
+                    `IS:${logType.flagName}`,
+                ),
             };
     }
 };
@@ -54,22 +67,22 @@ export const useEventLogSearch = (
     refreshInterval = 15 * 1000,
 ) => {
     const stateConfig = {
-        offset: withDefault(SafeNumberParam, 0),
-        limit: withDefault(SafeNumberParam, DEFAULT_PAGE_LIMIT),
-        query: StringParam,
-        from: withDefault(FilterItemParam, {
+        offset: withDefaultQueryParam(safeNumberQueryParam, 0),
+        limit: withDefaultQueryParam(safeNumberQueryParam, DEFAULT_PAGE_LIMIT),
+        query: stringQueryParam,
+        from: withDefaultQueryParam(filterItemQueryParam, {
             values: [format(subYears(new Date(), 1), 'yyyy-MM-dd')],
             operator: 'IS',
         }),
-        to: withDefault(FilterItemParam, {
+        to: withDefaultQueryParam(filterItemQueryParam, {
             values: [format(new Date(), 'yyyy-MM-dd')],
             operator: 'IS',
         }),
-        createdBy: FilterItemParam,
-        type: FilterItemParam,
-        environment: FilterItemParam,
-        id: FilterItemParam,
-        groupId: FilterItemParam,
+        createdBy: filterItemQueryParam,
+        type: filterItemQueryParam,
+        environment: filterItemQueryParam,
+        id: filterItemQueryParam,
+        groupId: filterItemQueryParam,
         ...extraParameters(logType),
     };
 
@@ -113,7 +126,7 @@ export const useEventLogSearch = (
     })();
 
     const { events, total, refetch, loading, initialLoad } = useEventSearch(
-        mapValues(encodeQueryParams(stateConfig, tableState), (value) =>
+        mapValues(encodeSpecParams(stateConfig, tableState), (value) =>
             value ? `${value}` : undefined,
         ) as SearchEventsParams,
         {

--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.test.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.test.tsx
@@ -124,7 +124,11 @@ test('Filter table by project', async () => {
     anotherProjectCheckbox.click();
 
     await screen.findByText('No feature flags found matching your criteria.');
-    expect(window.location.href).toContain(
-        '?offset=0&columns=&project=IS%3Aproject-b',
-    );
+    // assert on the decoded param rather than the raw URL: the exact URL
+    // shape differs between use-query-params ('?offset=0&columns=&project=
+    // IS%3Aproject-b') and nuqs ('?project=IS:project-b'), but both decode
+    // identically, so this passes regardless of which library the
+    // query-state flag selects
+    const searchParams = new URLSearchParams(window.location.search);
+    expect(searchParams.get('project')).toBe('IS:project-b');
 }, 10000);

--- a/frontend/src/component/feature/FeatureToggleList/useGlobalFeatureSearch.ts
+++ b/frontend/src/component/feature/FeatureToggleList/useGlobalFeatureSearch.ts
@@ -1,34 +1,36 @@
 import { useCallback } from 'react';
-import { encodeQueryParams, StringParam, withDefault } from 'use-query-params';
 import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
 import {
-    BooleansStringParam,
-    FilterItemParam,
-} from 'utils/serializeQueryParams';
+    encodeSpecParams,
+    filterItemQueryParam,
+    safeNumberQueryParam,
+    strictBooleanQueryParam,
+    stringQueryParam,
+    withDefaultQueryParam,
+} from 'utils/queryParamSpec';
 import { usePersistentTableState } from 'hooks/usePersistentTableState';
 import mapValues from 'lodash.mapvalues';
 import type { SearchFeaturesParams } from 'openapi';
-import { SafeNumberParam } from 'utils/safeNumberParam';
 import { DEFAULT_PAGE_LIMIT } from 'utils/paginationConfig';
 
 export const useGlobalFeatureSearch = (pageLimit = DEFAULT_PAGE_LIMIT) => {
     const storageKey = 'features-list-table';
     const stateConfig = {
-        offset: withDefault(SafeNumberParam, 0),
-        limit: withDefault(SafeNumberParam, pageLimit),
-        query: StringParam,
-        favoritesFirst: withDefault(BooleansStringParam, true),
-        sortBy: withDefault(StringParam, 'createdAt'),
-        sortOrder: withDefault(StringParam, 'desc'),
-        project: FilterItemParam,
-        tag: FilterItemParam,
-        state: FilterItemParam,
-        segment: FilterItemParam,
-        createdAt: FilterItemParam,
-        type: FilterItemParam,
-        lifecycle: FilterItemParam,
-        createdBy: FilterItemParam,
-        favorite: FilterItemParam,
+        offset: withDefaultQueryParam(safeNumberQueryParam, 0),
+        limit: withDefaultQueryParam(safeNumberQueryParam, pageLimit),
+        query: stringQueryParam,
+        favoritesFirst: withDefaultQueryParam(strictBooleanQueryParam, true),
+        sortBy: withDefaultQueryParam(stringQueryParam, 'createdAt'),
+        sortOrder: withDefaultQueryParam(stringQueryParam, 'desc'),
+        project: filterItemQueryParam,
+        tag: filterItemQueryParam,
+        state: filterItemQueryParam,
+        segment: filterItemQueryParam,
+        createdAt: filterItemQueryParam,
+        type: filterItemQueryParam,
+        lifecycle: filterItemQueryParam,
+        createdBy: filterItemQueryParam,
+        favorite: filterItemQueryParam,
     };
     const [tableState, setTableState] = usePersistentTableState(
         `${storageKey}`,
@@ -54,7 +56,7 @@ export const useGlobalFeatureSearch = (pageLimit = DEFAULT_PAGE_LIMIT) => {
         refetch,
         initialLoad,
     } = useFeatureSearch(
-        mapValues(encodeQueryParams(stateConfig, apiTableState), (value) =>
+        mapValues(encodeSpecParams(stateConfig, apiTableState), (value) =>
             value ? `${value}` : undefined,
         ) as SearchFeaturesParams,
     );

--- a/frontend/src/component/insights/sections/LifecycleInsights.tsx
+++ b/frontend/src/component/insights/sections/LifecycleInsights.tsx
@@ -1,6 +1,6 @@
 import { usePersistentTableState } from 'hooks/usePersistentTableState';
 import type { FC } from 'react';
-import { FilterItemParam } from 'utils/serializeQueryParams';
+import { filterItemQueryParam } from 'utils/queryParamSpec';
 import { InsightsSection } from 'component/insights/sections/InsightsSection';
 import { LifecycleChart } from '../components/LifecycleChart/LifecycleChart.tsx';
 import { styled, useTheme } from '@mui/material';
@@ -102,7 +102,7 @@ const StatRow = styled('div')(({ theme }) => ({
 export const LifecycleInsights: FC = () => {
     const statePrefix = 'lifecycle-';
     const stateConfig = {
-        [`${statePrefix}project`]: FilterItemParam,
+        [`${statePrefix}project`]: filterItemQueryParam,
     };
     const [state, setState] = usePersistentTableState(
         'insights-lifecycle',

--- a/frontend/src/component/insights/sections/PerformanceInsights.tsx
+++ b/frontend/src/component/insights/sections/PerformanceInsights.tsx
@@ -4,8 +4,10 @@ import { useInsights } from 'hooks/api/getters/useInsights/useInsights';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { usePersistentTableState } from 'hooks/usePersistentTableState';
 import type { FC } from 'react';
-import { withDefault } from 'use-query-params';
-import { FilterItemParam } from 'utils/serializeQueryParams';
+import {
+    filterItemQueryParam,
+    withDefaultQueryParam,
+} from 'utils/queryParamSpec';
 import type { FilterItemParamHolder } from 'component/filter/Filters/Filters';
 import { WidgetTitle } from 'component/insights/components/WidgetTitle/WidgetTitle';
 import { FlagsChart } from 'component/insights/componentsChart/FlagsChart/FlagsChart';
@@ -65,12 +67,12 @@ export const PerformanceInsights: FC = () => {
     const fromKey = `${statePrefix}from`;
     const toKey = `${statePrefix}to`;
     const stateConfig = {
-        [`${statePrefix}project`]: FilterItemParam,
-        [fromKey]: withDefault(FilterItemParam, {
+        [`${statePrefix}project`]: filterItemQueryParam,
+        [fromKey]: withDefaultQueryParam(filterItemQueryParam, {
             values: [format(subMonths(new Date(), 1), 'yyyy-MM-dd')],
             operator: 'IS',
         }),
-        [toKey]: withDefault(FilterItemParam, {
+        [toKey]: withDefaultQueryParam(filterItemQueryParam, {
             values: [format(new Date(), 'yyyy-MM-dd')],
             operator: 'IS',
         }),

--- a/frontend/src/component/insights/sections/UserInsights.tsx
+++ b/frontend/src/component/insights/sections/UserInsights.tsx
@@ -3,8 +3,10 @@ import { format, subMonths } from 'date-fns';
 import { useInsights } from 'hooks/api/getters/useInsights/useInsights';
 import { usePersistentTableState } from 'hooks/usePersistentTableState';
 import type { FC } from 'react';
-import { withDefault } from 'use-query-params';
-import { FilterItemParam } from 'utils/serializeQueryParams';
+import {
+    filterItemQueryParam,
+    withDefaultQueryParam,
+} from 'utils/queryParamSpec';
 import type { FilterItemParamHolder } from 'component/filter/Filters/Filters';
 
 import { WidgetTitle } from 'component/insights/components/WidgetTitle/WidgetTitle';
@@ -26,12 +28,12 @@ export const UserInsights: FC = () => {
     const fromKey = `${statePrefix}from`;
     const toKey = `${statePrefix}to`;
     const stateConfig = {
-        [`${statePrefix}project`]: FilterItemParam,
-        [fromKey]: withDefault(FilterItemParam, {
+        [`${statePrefix}project`]: filterItemQueryParam,
+        [fromKey]: withDefaultQueryParam(filterItemQueryParam, {
             values: [format(subMonths(new Date(), 1), 'yyyy-MM-dd')],
             operator: 'IS',
         }),
-        [toKey]: withDefault(FilterItemParam, {
+        [toKey]: withDefaultQueryParam(filterItemQueryParam, {
             values: [format(new Date(), 'yyyy-MM-dd')],
             operator: 'IS',
         }),

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/useProjectFeatureSearch.ts
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/useProjectFeatureSearch.ts
@@ -1,18 +1,16 @@
-import {
-    ArrayParam,
-    encodeQueryParams,
-    StringParam,
-    withDefault,
-} from 'use-query-params';
 import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
 import {
-    BooleansStringParam,
-    FilterItemParam,
-} from 'utils/serializeQueryParams';
+    encodeSpecParams,
+    filterItemQueryParam,
+    safeNumberQueryParam,
+    strictBooleanQueryParam,
+    stringArrayQueryParam,
+    stringQueryParam,
+    withDefaultQueryParam,
+} from 'utils/queryParamSpec';
 import { usePersistentTableState } from 'hooks/usePersistentTableState';
 import mapValues from 'lodash.mapvalues';
 import type { SearchFeaturesParams } from 'openapi';
-import { SafeNumberParam } from 'utils/safeNumberParam';
 import { DEFAULT_PAGE_LIMIT } from 'utils/paginationConfig';
 
 type Attribute =
@@ -26,22 +24,22 @@ export const useProjectFeatureSearch = (
     refreshInterval = 15 * 1000,
 ) => {
     const stateConfig = {
-        offset: withDefault(SafeNumberParam, 0),
-        limit: withDefault(SafeNumberParam, DEFAULT_PAGE_LIMIT),
-        query: StringParam,
-        favoritesFirst: withDefault(BooleansStringParam, true),
-        sortBy: withDefault(StringParam, 'createdAt'),
-        sortOrder: withDefault(StringParam, 'desc'),
-        columns: ArrayParam,
-        tag: FilterItemParam,
-        state: FilterItemParam,
-        createdAt: FilterItemParam,
-        lastSeenAt: FilterItemParam,
-        type: FilterItemParam,
-        createdBy: FilterItemParam,
-        archived: FilterItemParam,
-        lifecycle: FilterItemParam,
-        favorite: FilterItemParam,
+        offset: withDefaultQueryParam(safeNumberQueryParam, 0),
+        limit: withDefaultQueryParam(safeNumberQueryParam, DEFAULT_PAGE_LIMIT),
+        query: stringQueryParam,
+        favoritesFirst: withDefaultQueryParam(strictBooleanQueryParam, true),
+        sortBy: withDefaultQueryParam(stringQueryParam, 'createdAt'),
+        sortOrder: withDefaultQueryParam(stringQueryParam, 'desc'),
+        columns: stringArrayQueryParam,
+        tag: filterItemQueryParam,
+        state: filterItemQueryParam,
+        createdAt: filterItemQueryParam,
+        lastSeenAt: filterItemQueryParam,
+        type: filterItemQueryParam,
+        createdBy: filterItemQueryParam,
+        archived: filterItemQueryParam,
+        lifecycle: filterItemQueryParam,
+        favorite: filterItemQueryParam,
     };
     const [tableState, setTableState] = usePersistentTableState(
         `${storageKey}-${projectId}`,
@@ -52,7 +50,7 @@ export const useProjectFeatureSearch = (
     const { features, total, refetch, loading, initialLoad } = useFeatureSearch(
         mapValues(
             {
-                ...encodeQueryParams(stateConfig, apiTableState),
+                ...encodeSpecParams(stateConfig, apiTableState),
                 project: `IS:${projectId}`,
             },
             (value) => (value ? `${value}` : undefined),

--- a/frontend/src/component/project/ProjectApplications/ProjectApplications.tsx
+++ b/frontend/src/component/project/ProjectApplications/ProjectApplications.tsx
@@ -9,11 +9,11 @@ import { SearchHighlightProvider } from 'component/common/Table/SearchHighlightC
 import { PaginatedTable, TablePlaceholder } from 'component/common/Table';
 import theme from 'themes/theme';
 import {
-    encodeQueryParams,
-    NumberParam,
-    StringParam,
-    withDefault,
-} from 'use-query-params';
+    encodeSpecParams,
+    safeNumberQueryParam,
+    stringQueryParam,
+    withDefaultQueryParam,
+} from 'utils/queryParamSpec';
 import { usePersistentTableState } from 'hooks/usePersistentTableState';
 import useLoading from 'hooks/useLoading';
 import { createColumnHelper, useReactTable } from '@tanstack/react-table';
@@ -59,11 +59,11 @@ export const ProjectApplications = () => {
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
     const stateConfig = {
-        offset: withDefault(NumberParam, 0),
-        limit: withDefault(NumberParam, DEFAULT_PAGE_LIMIT),
-        query: StringParam,
-        sortBy: withDefault(StringParam, 'createdAt'),
-        sortOrder: withDefault(StringParam, 'desc'),
+        offset: withDefaultQueryParam(safeNumberQueryParam, 0),
+        limit: withDefaultQueryParam(safeNumberQueryParam, DEFAULT_PAGE_LIMIT),
+        query: stringQueryParam,
+        sortBy: withDefaultQueryParam(stringQueryParam, 'createdAt'),
+        sortOrder: withDefaultQueryParam(stringQueryParam, 'desc'),
     };
     const [tableState, setTableState] = usePersistentTableState(
         `project-applications-table-${projectId}`,
@@ -75,7 +75,7 @@ export const ProjectApplications = () => {
         total,
         loading,
     } = useProjectApplications(
-        mapValues(encodeQueryParams(stateConfig, tableState), (value) =>
+        mapValues(encodeSpecParams(stateConfig, tableState), (value) =>
             value ? `${value}` : undefined,
         ),
         projectId,

--- a/frontend/src/component/project/ProjectList/hooks/useProjectsListState.ts
+++ b/frontend/src/component/project/ProjectList/hooks/useProjectsListState.ts
@@ -1,25 +1,21 @@
 import { usePersistentTableState } from 'hooks/usePersistentTableState';
 import {
-    createEnumParam,
-    type QueryParamConfig,
-    StringParam,
-    withDefault,
-} from 'use-query-params';
+    enumQueryParam,
+    stringQueryParam,
+    withDefaultQueryParam,
+} from 'utils/queryParamSpec';
 import { sortKeys } from '../ProjectsListSort/ProjectsListSort.jsx';
 
 export type ProjectsListView = 'cards' | 'list';
 
 const stateConfig = {
-    query: StringParam,
-    sortBy: withDefault(
-        createEnumParam([...sortKeys]),
-        sortKeys[0],
-    ) as QueryParamConfig<(typeof sortKeys)[number] | null | undefined>,
-    create: StringParam,
-    view: withDefault(
-        createEnumParam<ProjectsListView>(['cards', 'list']),
+    query: stringQueryParam,
+    sortBy: withDefaultQueryParam(enumQueryParam(sortKeys), sortKeys[0]),
+    create: stringQueryParam,
+    view: withDefaultQueryParam(
+        enumQueryParam<ProjectsListView>(['cards', 'list']),
         'cards',
-    ) as QueryParamConfig<ProjectsListView>,
+    ),
 } as const;
 
 export const useProjectsListState = () =>

--- a/frontend/src/hooks/usePersistentTableState.test.tsx
+++ b/frontend/src/hooks/usePersistentTableState.test.tsx
@@ -4,12 +4,17 @@ import { screen, waitFor } from '@testing-library/react';
 import { usePersistentTableState } from './usePersistentTableState.ts';
 import { Route, Routes } from 'react-router';
 import { createLocalStorage } from '../utils/createLocalStorage.ts';
-import { ArrayParam, NumberParam, StringParam } from 'use-query-params';
-import { FilterItemParam } from '../utils/serializeQueryParams.ts';
+import {
+    filterItemQueryParam,
+    safeNumberQueryParam,
+    stringArrayQueryParam,
+    stringQueryParam,
+    type QueryParamSpecMap,
+} from '../utils/queryParamSpec.ts';
 
 type TestComponentProps = {
     keyName: string;
-    queryParamsDefinition: Record<string, any>;
+    queryParamsDefinition: QueryParamSpecMap;
     nonPersistentParams?: string[];
 };
 
@@ -62,7 +67,7 @@ describe('usePersistentTableState', () => {
         render(
             <TestComponent
                 keyName='testKey'
-                queryParamsDefinition={{ query: StringParam }}
+                queryParamsDefinition={{ query: stringQueryParam }}
             />,
             { route: '/my-url?query=initialUrl' },
         );
@@ -79,7 +84,7 @@ describe('usePersistentTableState', () => {
         render(
             <TestComponent
                 keyName='testKey'
-                queryParamsDefinition={{ query: StringParam }}
+                queryParamsDefinition={{ query: stringQueryParam }}
             />,
             { route: '/my-url' },
         );
@@ -104,9 +109,9 @@ describe('usePersistentTableState', () => {
             <TestComponent
                 keyName='testKey'
                 queryParamsDefinition={{
-                    query: StringParam,
-                    filterItem: FilterItemParam,
-                    columns: ArrayParam,
+                    query: stringQueryParam,
+                    filterItem: filterItemQueryParam,
+                    columns: stringArrayQueryParam,
                 }}
             />,
             { route: '/my-url' },
@@ -126,7 +131,7 @@ describe('usePersistentTableState', () => {
         render(
             <TestComponent
                 keyName='testKey'
-                queryParamsDefinition={{ query: StringParam }}
+                queryParamsDefinition={{ query: stringQueryParam }}
             />,
             { route: '/my-url?query=initialUrl' },
         );
@@ -147,8 +152,8 @@ describe('usePersistentTableState', () => {
             <TestComponent
                 keyName='testKey'
                 queryParamsDefinition={{
-                    query: StringParam,
-                    other: StringParam,
+                    query: stringQueryParam,
+                    other: stringQueryParam,
                 }}
             />,
             { route: '/my-url' },
@@ -181,8 +186,8 @@ describe('usePersistentTableState', () => {
             <TestComponent
                 keyName='testKey'
                 queryParamsDefinition={{
-                    query: StringParam,
-                    offset: NumberParam,
+                    query: stringQueryParam,
+                    offset: safeNumberQueryParam,
                 }}
             />,
             { route: '/my-url' },
@@ -206,8 +211,8 @@ describe('usePersistentTableState', () => {
             <TestComponent
                 keyName='testKey'
                 queryParamsDefinition={{
-                    query: StringParam,
-                    offset: NumberParam,
+                    query: stringQueryParam,
+                    offset: safeNumberQueryParam,
                 }}
             />,
             { route: '/my-url?query=before&offset=10' },
@@ -232,7 +237,7 @@ describe('usePersistentTableState', () => {
             <TestComponent
                 keyName='testKey'
                 queryParamsDefinition={{
-                    query: StringParam,
+                    query: stringQueryParam,
                 }}
             />,
             { route: '/my-url?query=before&offset=10' },
@@ -256,9 +261,9 @@ describe('usePersistentTableState', () => {
             <TestComponent
                 keyName='testKey'
                 queryParamsDefinition={{
-                    query: StringParam,
-                    another: StringParam,
-                    ignore: StringParam,
+                    query: stringQueryParam,
+                    another: stringQueryParam,
+                    ignore: stringQueryParam,
                 }}
             />,
             { route: '/my-url?another=another&query=initialUrl' },

--- a/frontend/src/hooks/usePersistentTableState.ts
+++ b/frontend/src/hooks/usePersistentTableState.ts
@@ -3,18 +3,34 @@ import { useSearchParams } from 'react-router';
 import { createLocalStorage } from 'utils/createLocalStorage';
 import { encodeQueryParams, useQueryParams } from 'use-query-params';
 import type { QueryParamConfigMap } from 'serialize-query-params/src/types';
+import {
+    toUseQueryParamsConfig,
+    type DecodedSpecMap,
+    type QueryParamSpecMap,
+} from 'utils/queryParamSpec';
 import { reorderObject } from '../utils/reorderObject.js';
 import {
     isValidPaginationOption,
     DEFAULT_PAGE_LIMIT,
 } from 'utils/paginationConfig';
 
-const usePersistentSearchParams = <T extends QueryParamConfigMap>(
+export type TableStateUpdate<TSpecs extends QueryParamSpecMap> =
+    | Partial<DecodedSpecMap<TSpecs>>
+    | ((prev: DecodedSpecMap<TSpecs>) => Partial<DecodedSpecMap<TSpecs>>);
+
+export type TableStateSetter<TSpecs extends QueryParamSpecMap> = (
+    update: TableStateUpdate<TSpecs>,
+) => void;
+
+const usePersistentSearchParams = (
     key: string,
-    queryParamsDefinition: T,
+    queryParamsDefinition: QueryParamConfigMap,
 ) => {
     const [searchParams, setSearchParams] = useSearchParams();
-    const { value, setValue } = createLocalStorage(key, {});
+    const { value, setValue } = createLocalStorage<Record<string, unknown>>(
+        key,
+        {},
+    );
     useEffect(() => {
         const params = Object.fromEntries(searchParams.entries());
         if (Object.keys(params).length > 0) {
@@ -35,11 +51,26 @@ const usePersistentSearchParams = <T extends QueryParamConfigMap>(
     return setValue;
 };
 
-export const usePersistentTableState = <T extends QueryParamConfigMap>(
+/**
+ * Persistent (URL + localStorage) table state.
+ *
+ * Consumers declare params with the library-agnostic specs from
+ * `utils/queryParamSpec`. During the use-query-params → nuqs migration this
+ * hook converts those specs to a use-query-params config and runs
+ * use-query-params only; the nuqs side of each spec is dormant. PR4
+ * (nuqs-4-dual-run) turns this into a flag-gated dual-run.
+ */
+export const usePersistentTableState = <TSpecs extends QueryParamSpecMap>(
     key: string,
-    queryParamsDefinition: T,
-    excludedFromStorage: (keyof T)[] = ['offset'],
+    specs: TSpecs,
+    excludedFromStorage: (keyof TSpecs)[] = ['offset'],
 ) => {
+    const queryParamsDefinition = useMemo(
+        () => toUseQueryParamsConfig(specs),
+        [specs],
+    );
+    const excluded = excludedFromStorage as string[];
+
     const updateStoredParams = usePersistentSearchParams(
         key,
         queryParamsDefinition,
@@ -100,11 +131,14 @@ export const usePersistentTableState = <T extends QueryParamConfigMap>(
     useEffect(() => {
         const filteredTableState = Object.fromEntries(
             Object.entries(orderedTableState).filter(
-                ([key]) => !excludedFromStorage.includes(key),
+                ([key]) => !excluded.includes(key),
             ),
         );
         updateStoredParams(filteredTableState);
     }, [JSON.stringify(orderedTableState)]);
 
-    return [orderedTableState, setTableState] as const;
+    return [
+        orderedTableState as DecodedSpecMap<TSpecs>,
+        setTableState as TableStateSetter<TSpecs>,
+    ] as const;
 };


### PR DESCRIPTION
Second of the nuqs migration stack. Pure refactor, behavior-preserving: the 9 usePersistentTableState consumers now declare params via the library-agnostic specs from PR1 instead of raw use-query-params configs.

usePersistentTableState still runs use-query-params only — it converts the specs with toUseQueryParamsConfig and is otherwise unchanged. The nuqs side of each spec is constructed but not executed; the dual-run flip lands in PR4 (nuqs-4-dual-run).

No user-visible change: URLs, localStorage, and API params are identical.

## About the changes

Closes #

### Important files

## Discussion points

## OSS PR checklist

- [ ] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [ ] I have added tests or explained why tests are not needed.
- [ ] I have updated documentation where relevant.
