### PR TITLE
feat(frontend): add query-state comparison machinery (inert)

### DIFF
--- a/frontend/src/hooks/useQueryStateComparison.test.ts
+++ b/frontend/src/hooks/useQueryStateComparison.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { StringParam } from 'use-query-params';
+import { createParser } from 'nuqs';
+import { useQueryStateComparison } from './useQueryStateComparison.ts';
+import { recordQueryStateDivergence } from '../utils/recordQueryStateDivergence.ts';
+import {
+    stringQueryParam,
+    type QueryParamSpec,
+} from '../utils/queryParamSpec.ts';
+
+vi.mock('../utils/recordQueryStateDivergence.ts', () => ({
+    recordQueryStateDivergence: vi.fn(),
+}));
+
+// Direct unit test of the comparison hook: it receives both libraries'
+// already-decoded state and the specs, so we can exercise it without a
+// router or the dual-run facade (that integration path is tested in PR4).
+const standardSpecs = { query: stringQueryParam };
+
+/** Decodes the same but serializes differently, to force encode divergence. */
+const encodeDivergentSpec: QueryParamSpec<string | null | undefined> = {
+    uqp: StringParam,
+    nuqs: createParser({
+        parse: (value) => value,
+        serialize: (value) => `${value}!`,
+    }),
+};
+
+describe('useQueryStateComparison', () => {
+    beforeEach(() => {
+        vi.mocked(recordQueryStateDivergence).mockClear();
+    });
+
+    it('does nothing when disabled, even if the states differ', () => {
+        renderHook(() =>
+            useQueryStateComparison({
+                enabled: false,
+                source: 'test',
+                specs: standardSpecs,
+                uqpState: { query: 'a' },
+                nuqsState: { query: 'b' },
+            }),
+        );
+
+        expect(recordQueryStateDivergence).not.toHaveBeenCalled();
+    });
+
+    it('does not report when both libraries agree', () => {
+        renderHook(() =>
+            useQueryStateComparison({
+                enabled: true,
+                source: 'test',
+                specs: standardSpecs,
+                uqpState: { query: 'a' },
+                nuqsState: { query: 'a' },
+            }),
+        );
+
+        expect(recordQueryStateDivergence).not.toHaveBeenCalled();
+    });
+
+    it('treats undefined and null as the same (absent)', () => {
+        renderHook(() =>
+            useQueryStateComparison({
+                enabled: true,
+                source: 'test',
+                specs: standardSpecs,
+                uqpState: { query: undefined },
+                nuqsState: { query: null },
+            }),
+        );
+
+        expect(recordQueryStateDivergence).not.toHaveBeenCalled();
+    });
+
+    it('reports decode divergence with the diverging keys only', () => {
+        renderHook(() =>
+            useQueryStateComparison({
+                enabled: true,
+                source: 'test',
+                specs: { query: stringQueryParam, stable: stringQueryParam },
+                uqpState: { query: 'a', stable: 'same' },
+                nuqsState: { query: 'b', stable: 'same' },
+            }),
+        );
+
+        expect(recordQueryStateDivergence).toHaveBeenCalledWith({
+            source: 'test',
+            kind: 'decode',
+            keys: ['query'],
+        });
+    });
+
+    it('reports encode divergence when the decoded states agree', () => {
+        renderHook(() =>
+            useQueryStateComparison({
+                enabled: true,
+                source: 'test',
+                specs: { query: encodeDivergentSpec },
+                uqpState: { query: 'a' },
+                nuqsState: { query: 'a' },
+            }),
+        );
+
+        expect(recordQueryStateDivergence).toHaveBeenCalledWith({
+            source: 'test',
+            kind: 'encode',
+            keys: ['query'],
+        });
+    });
+});

--- a/frontend/src/hooks/useQueryStateComparison.ts
+++ b/frontend/src/hooks/useQueryStateComparison.ts
@@ -1,0 +1,116 @@
+import { useEffect, useRef } from 'react';
+import { recordQueryStateDivergence } from 'utils/recordQueryStateDivergence';
+import { encodeParams } from 'utils/nuqsParams.ts';
+import {
+    encodeSpecParams,
+    toNuqsParsers,
+    type QueryParamSpecMap,
+} from 'utils/queryParamSpec';
+
+/**
+ * Normalizes a decoded query-param value so the two libraries' outputs can
+ * be compared: `undefined` and `null` both mean "absent", and object key
+ * order is irrelevant.
+ */
+const normalize = (value: unknown): unknown => {
+    if (value === undefined) {
+        return null;
+    }
+    if (Array.isArray(value)) {
+        return value.map(normalize);
+    }
+    if (value !== null && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.keys(value)
+                .sort()
+                .map((key) => [
+                    key,
+                    normalize((value as Record<string, unknown>)[key]),
+                ]),
+        );
+    }
+    return value;
+};
+
+const stableSerialize = (value: unknown): string =>
+    JSON.stringify(normalize(value)) ?? 'null';
+
+const divergingKeys = (
+    first: Record<string, unknown>,
+    second: Record<string, unknown>,
+): string[] => {
+    const keys = new Set([...Object.keys(first), ...Object.keys(second)]);
+    return [...keys].filter(
+        (key) => stableSerialize(first[key]) !== stableSerialize(second[key]),
+    );
+};
+
+/** Drops absent entries so "key missing" and "key: undefined/null" compare equal. */
+const presentEntries = (record: Record<string, unknown>) =>
+    Object.fromEntries(
+        Object.entries(record).filter(([, value]) => value != null),
+    );
+
+type ComparisonArgs<TSpecs extends QueryParamSpecMap> = {
+    enabled: boolean;
+    /** Consumer identifier for divergence reports, e.g. the storage key. */
+    source: string;
+    specs: TSpecs;
+    uqpState: Record<string, unknown>;
+    nuqsState: Record<string, unknown>;
+};
+
+/**
+ * Shadow comparison for the dual-run query-param facades: checks that both
+ * libraries decode the current URL to the same state, and (when they do)
+ * that they encode that state back to the same wire format. Divergence is
+ * reported through `recordQueryStateDivergence` with param keys only,
+ * never values.
+ */
+export const useQueryStateComparison = <TSpecs extends QueryParamSpecMap>({
+    enabled,
+    source,
+    specs,
+    uqpState,
+    nuqsState,
+}: ComparisonArgs<TSpecs>) => {
+    const uqpSerialized = stableSerialize(uqpState);
+    const nuqsSerialized = stableSerialize(nuqsState);
+
+    // The effect should re-run only when the serialized state changes, not
+    // on every render (specs/uqpState/nuqsState are fresh objects each
+    // render). We read the latest values through a ref so they stay out of
+    // the dependency list while remaining current — the serialized strings
+    // are the real triggers.
+    const latest = useRef({ specs, uqpState, nuqsState });
+    latest.current = { specs, uqpState, nuqsState };
+
+    useEffect(() => {
+        if (!enabled) {
+            return;
+        }
+        const { specs, uqpState, nuqsState } = latest.current;
+        if (uqpSerialized !== nuqsSerialized) {
+            recordQueryStateDivergence({
+                source,
+                kind: 'decode',
+                keys: divergingKeys(uqpState, nuqsState),
+            });
+            return;
+        }
+        // Only compare encoders when the decoded states agree; otherwise
+        // every decode divergence would be double-reported.
+        const uqpEncoded = presentEntries(encodeSpecParams(specs, uqpState));
+        const nuqsEncoded = presentEntries(
+            encodeParams(toNuqsParsers(specs), uqpState),
+        );
+        const encodedDiff = divergingKeys(uqpEncoded, nuqsEncoded);
+        if (encodedDiff.length > 0) {
+            recordQueryStateDivergence({
+                source,
+                kind: 'encode',
+                keys: encodedDiff,
+            });
+        }
+    }, [enabled, source, uqpSerialized, nuqsSerialized]);
+};

--- a/frontend/src/hooks/useQueryStateLibrary.ts
+++ b/frontend/src/hooks/useQueryStateLibrary.ts
@@ -1,0 +1,36 @@
+export type QueryStateLibrary = 'use-query-params' | 'nuqs';
+
+export type QueryStateLibraryConfig = {
+    /** Which library drives query-param reads and writes. */
+    primary: QueryStateLibrary;
+    /**
+     * Whether to also run the non-primary library as a read-only shadow
+     * and report divergence between the two.
+     */
+    compare: boolean;
+};
+
+const DUMMY_QUERY_STATE_LIBRARY: QueryStateLibraryConfig = {
+    primary: 'use-query-params',
+    compare: true,
+};
+
+/**
+ * Selects which query-param library the dual-run facades use.
+ *
+ * TODO(nuqs-flag): currently returns a hardcoded dummy. Replace with a
+ * real flag variant once the backend scaffolding exists, e.g.:
+ *
+ *   const { uiConfig } = useUiConfig();
+ *   const value = useVariant<QueryStateLibraryConfig>(
+ *       uiConfig.flags.nuqsQueryState as Variant,
+ *   );
+ *   return value ?? DUMMY_QUERY_STATE_LIBRARY;
+ *
+ * with a JSON payload like { "primary": "nuqs", "compare": true }, so the
+ * variant can flip the primary and toggle comparison independently, and an
+ * impact metric on recordQueryStateDivergence can auto-disable the rollout.
+ */
+export const useQueryStateLibrary = (): QueryStateLibraryConfig => {
+    return DUMMY_QUERY_STATE_LIBRARY;
+};

--- a/frontend/src/utils/recordQueryStateDivergence.ts
+++ b/frontend/src/utils/recordQueryStateDivergence.ts
@@ -1,0 +1,25 @@
+export type QueryStateDivergence = {
+    /** Identifies the consumer, e.g. the persistent-table storage key. */
+    source: string;
+    /** Whether decoded state or encoded output diverged. */
+    kind: 'decode' | 'encode';
+    /** The param keys that diverged. Never the values: they can contain user input. */
+    keys: string[];
+};
+
+/**
+ * Reporting seam for use-query-params/nuqs divergence found by the
+ * dual-run facades.
+ *
+ * TODO(nuqs-metrics): wire this to an impact metric so that divergence in
+ * production automatically disables the nuqs rollout flag. Until then it
+ * only logs to the console.
+ */
+export const recordQueryStateDivergence = (
+    divergence: QueryStateDivergence,
+): void => {
+    console.warn(
+        '[query-state-migration] use-query-params and nuqs diverged',
+        divergence,
+    );
+};


### PR DESCRIPTION
Third of the nuqs migration stack. Introduces the dual-run plumbing but wires nothing — no app code calls any of it yet.

Adds:
- hooks/useQueryStateLibrary.ts: flag stub selecting the primary library and whether to run comparison (hardcoded dummy for now; real flag variant + impact metric wiring is a TODO)
- utils/recordQueryStateDivergence.ts: reporting seam (console.warn now; impact-metric hookup is a TODO so divergence can auto-disable rollout)
- hooks/useQueryStateComparison.ts: shadow comparison — given both libraries' decoded state for the same URL, compares decode then encode and reports diverging keys only (never values; they carry user input)

Covered by a direct unit test. The facade starts calling this in PR4 (nuqs-4-dual-run).

## About the changes

Closes #

### Important files

## Discussion points

## OSS PR checklist

- [ ] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [ ] I have added tests or explained why tests are not needed.
- [ ] I have updated documentation where relevant.
