### PR TITLE
feat: adds support for headers specifying OpenFeature provider usage

### DIFF
--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -122,6 +122,7 @@ export const DEFAULT_STRATEGY_UPDATED = 'default-strategy-updated' as const;
 export const CLIENT_METRICS = 'client-metrics' as const;
 export const CLIENT_METRICS_ADDED = 'client-metrics-added' as const;
 export const CLIENT_REGISTER = 'client-register' as const;
+export const OPEN_FEATURE_REGISTER = 'open_feature_register';
 
 export const PAT_CREATED = 'pat-created' as const;
 export const PAT_DELETED = 'pat-deleted' as const;
@@ -340,6 +341,7 @@ export const IEventTypes = [
     SETTING_DELETED,
     CLIENT_METRICS,
     CLIENT_REGISTER,
+    OPEN_FEATURE_REGISTER,
     PAT_CREATED,
     PAT_DELETED,
     PUBLIC_SIGNUP_TOKEN_CREATED,

--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -122,7 +122,7 @@ export const DEFAULT_STRATEGY_UPDATED = 'default-strategy-updated' as const;
 export const CLIENT_METRICS = 'client-metrics' as const;
 export const CLIENT_METRICS_ADDED = 'client-metrics-added' as const;
 export const CLIENT_REGISTER = 'client-register' as const;
-export const OPEN_FEATURE_REGISTER = 'open_feature_register';
+export const OPEN_FEATURE_REGISTER = 'open_feature_register' as const;
 
 export const PAT_CREATED = 'pat-created' as const;
 export const PAT_DELETED = 'pat-deleted' as const;

--- a/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
+++ b/src/lib/features/metrics/client-metrics/metrics-service-v2.ts
@@ -1,5 +1,9 @@
 import type { Logger } from '../../../logger.js';
-import type { IFlagResolver, IUnleashConfig } from '../../../types/index.js';
+import type {
+    IFlagResolver,
+    IOpenFeatureMetadata,
+    IUnleashConfig,
+} from '../../../types/index.js';
 import type { ISdkHeartbeat, IUnleashStores } from '../../../types/index.js';
 import type { ToggleMetricsSummary } from '../../../types/models/metrics.js';
 import type {
@@ -12,6 +16,7 @@ import {
     CLIENT_METRICS,
     CLIENT_METRICS_ADDED,
     CLIENT_REGISTER,
+    OPEN_FEATURE_REGISTER,
 } from '../../../events/index.js';
 import ApiUser, { type IApiUser } from '../../../types/api-user.js';
 import { ALL } from '../../../types/models/api-token.js';
@@ -264,6 +269,10 @@ export default class ClientMetricsServiceV2 {
             // impact metrics should not affect other metrics on failure
             this.logger.warn('Impact metrics registration failed:', e);
         }
+    }
+
+    async registerOpenFeatureUsage(data: IOpenFeatureMetadata): Promise<void> {
+        this.config.eventBus.emit(OPEN_FEATURE_REGISTER, data);
     }
 
     async registerClientMetrics(

--- a/src/lib/features/metrics/instance/metrics.ts
+++ b/src/lib/features/metrics/instance/metrics.ts
@@ -176,7 +176,13 @@ export default class ClientMetricsController extends Controller {
             res.status(204).end();
         } else {
             try {
-                const { body: data, user } = req;
+                const { body: data, user, headers } = req;
+                const openFeatureName = headers['open-feature-provider-name'] as
+                    | string
+                    | undefined;
+                const openFeatureVersion = headers[
+                    'open-feature-provider-version'
+                ] as string | undefined;
                 const clientIp = extractClientIp(req);
                 const { impactMetrics, ...metricsData } = data;
                 const environment =
@@ -193,6 +199,14 @@ export default class ClientMetricsController extends Controller {
                     clientIp,
                     environment,
                 );
+
+                if (openFeatureName && openFeatureVersion) {
+                    await this.metricsV2.registerOpenFeatureUsage({
+                        providerName: openFeatureName,
+                        version: openFeatureVersion,
+                    });
+                }
+
                 if (impactMetrics) {
                     await this.metricsV2.registerImpactMetrics(
                         impactMetrics as Metric[],

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -26,12 +26,17 @@ import {
     RELEASE_PLAN_ADDED,
     RELEASE_PLAN_REMOVED,
     RELEASE_PLAN_MILESTONE_STARTED,
+    OPEN_FEATURE_REGISTER,
 } from './events/index.js';
 import type { IUnleashConfig } from './types/option.js';
 import type { IUnleashStores } from './types/stores.js';
 import { hoursToMilliseconds, minutesToMilliseconds } from 'date-fns';
 import type { InstanceStatsService } from './features/instance-stats/instance-stats-service.js';
-import type { IEnvironment, ISdkHeartbeat } from './types/index.js';
+import type {
+    IEnvironment,
+    IOpenFeatureMetadata,
+    ISdkHeartbeat,
+} from './types/index.js';
 import {
     createCounter,
     createGauge,
@@ -504,6 +509,12 @@ export function registerPrometheusMetrics(
             'yggdrasil_version',
             'spec_version',
         ],
+    });
+
+    const openFeatureUsage = createCounter({
+        name: 'open_feature_versions',
+        help: 'Which OpenFeature versions are being used',
+        labelNames: ['providerName', 'providerVersion'],
     });
 
     const productionChanges30 = createGauge({
@@ -1164,6 +1175,13 @@ export function registerPrometheusMetrics(
         } catch (e) {
             logger.warn('Metrics registration failed', e);
         }
+    });
+
+    eventStore.on(OPEN_FEATURE_REGISTER, (metadata: IOpenFeatureMetadata) => {
+        openFeatureUsage.increment({
+            providerName: metadata.providerName,
+            providerVersion: metadata.version,
+        });
     });
 
     eventStore.on(CLIENT_REGISTER, (heartbeatEvent: ISdkHeartbeat) => {

--- a/src/lib/types/model.ts
+++ b/src/lib/types/model.ts
@@ -724,3 +724,8 @@ export interface EnvironmentRevisionId {
     revisionId: number;
     projects?: string[];
 }
+
+export interface IOpenFeatureMetadata {
+    providerName: string;
+    version: string;
+}


### PR DESCRIPTION
This adds support for two headers specifying which OpenFeature provider is in use and version, and adds metrics for observability