### PR TITLE
chore: cap codebox height

### DIFF
--- a/frontend/src/component/common/Codebox/Codebox.tsx
+++ b/frontend/src/component/common/Codebox/Codebox.tsx
@@ -9,7 +9,7 @@ const StyledContainer = styled('div')(({ theme }) => ({
     padding: theme.spacing(2),
     borderRadius: theme.shape.borderRadiusMedium,
     position: 'relative',
-    maxHeight: '500px',
+    maxHeight: '320px',
     overflow: 'auto',
 }));
 

--- a/frontend/src/component/common/FormTemplate/ApiCommandBlock.tsx
+++ b/frontend/src/component/common/FormTemplate/ApiCommandBlock.tsx
@@ -28,11 +28,6 @@ const StyledIcon = styled(FileCopy)(({ theme }) => ({
     fill: theme.palette.primary.contrastText,
 }));
 
-const StyledCodeboxWrapper = styled('div')(() => ({
-    maxHeight: '320px',
-    overflow: 'auto',
-}));
-
 export const ApiCommandBlock: React.FC<Props> = ({
     command,
     onCopy,
@@ -48,8 +43,6 @@ export const ApiCommandBlock: React.FC<Props> = ({
                 </IconButton>
             </Tooltip>
         </StyledSubtitle>
-        <StyledCodeboxWrapper>
-            <Codebox text={command} />
-        </StyledCodeboxWrapper>
+        <Codebox text={command} />
     </>
 );

--- a/frontend/src/component/common/FormTemplate/ApiCommandBlock.tsx
+++ b/frontend/src/component/common/FormTemplate/ApiCommandBlock.tsx
@@ -28,6 +28,11 @@ const StyledIcon = styled(FileCopy)(({ theme }) => ({
     fill: theme.palette.primary.contrastText,
 }));
 
+const StyledCodeboxWrapper = styled('div')(() => ({
+    maxHeight: '320px',
+    overflow: 'auto',
+}));
+
 export const ApiCommandBlock: React.FC<Props> = ({
     command,
     onCopy,
@@ -43,6 +48,8 @@ export const ApiCommandBlock: React.FC<Props> = ({
                 </IconButton>
             </Tooltip>
         </StyledSubtitle>
-        <Codebox text={command} />
+        <StyledCodeboxWrapper>
+            <Codebox text={command} />
+        </StyledCodeboxWrapper>
     </>
 );


### PR DESCRIPTION
Cap codebox height before scroll occurs so that we don't get large layout jumps in the application