### PR TITLE
test: try fixing e2e group deletion test

### DIFF
--- a/frontend/cypress/enterprise/groups.spec.ts
+++ b/frontend/cypress/enterprise/groups.spec.ts
@@ -105,6 +105,6 @@ describe('groups', () => {
         // so after we've see the success message
         // reload the page and check that the group is really not there anymore
         cy.reload();
-        cy.get('body').should('not.contain', groupName);
+        cy.contains(groupName).should('not.exist');
     });
 });

--- a/frontend/cypress/enterprise/groups.spec.ts
+++ b/frontend/cypress/enterprise/groups.spec.ts
@@ -100,6 +100,11 @@ describe('groups', () => {
         cy.get("[data-testid='UG_DELETE_BTN_ID']").click();
         cy.get("[data-testid='DIALOGUE_CONFIRM_ID'").click();
 
+        cy.contains('Group removed successfully');
+        // there is some issue on CI that I can't replicate locally
+        // so after we've see the success message
+        // reload the page and check that the group is really not there anymore
+        cy.reload();
         cy.get('body').should('not.contain', groupName);
     });
 });


### PR DESCRIPTION
## About the changes

Turns out that https://github.com/Unleash/unleash/pull/12340 didn't help as I still get failures in [unrelated PRs](https://github.com/Unleash/unleash/actions/runs/27748251071/job/82093412577?pr=12350) . (so  bringing back the simpler assertion)

It's also fine locally. 

I noticed we get a success message correctly on CI so trying to make this test more resilient based on that. 

Unfortunately I don't know what's the root cause. It's possible we have a bug this is exposing, but without replication it's just noise on our CI 😞 


### Important files

## Discussion points

## OSS PR checklist

- [x] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [x] I have added tests or explained why tests are not needed.
- [x] I have updated documentation where relevant.
