### PR TITLE
fix: json editor cursor color

### DIFF
--- a/frontend/src/component/common/ReactJSONEditor/ReactJSONEditor.story.tsx
+++ b/frontend/src/component/common/ReactJSONEditor/ReactJSONEditor.story.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import type { Story, StoryMeta } from 'component/stories/types';
+import ReactJSONEditor from './ReactJSONEditor';
+
+export const meta: StoryMeta = {
+    title: 'Common/ReactJSONEditor',
+};
+
+const sampleJson = {
+    name: 'example',
+    enabled: true,
+    value: 42,
+    tags: ['a', 'b'],
+};
+
+const Controlled = ({ initial }: { initial: string }) => {
+    const [content, setContent] = useState<{ text: string }>({ text: initial });
+    return (
+        <ReactJSONEditor
+            content={content}
+            onChange={(c) => setContent(c as { text: string })}
+        />
+    );
+};
+
+export const Default: Story = () => (
+    <Controlled initial={JSON.stringify(sampleJson, undefined, 2)} />
+);
+
+const ControlledWithStatusBar = () => {
+    const [content, setContent] = useState<{ text: string }>({
+        text: JSON.stringify(sampleJson, undefined, 2),
+    });
+    return (
+        <ReactJSONEditor
+            content={content}
+            onChange={(c) => setContent(c as { text: string })}
+            statusBar
+        />
+    );
+};
+
+export const WithStatusBar: Story = () => <ControlledWithStatusBar />;
+
+export const ReadOnly: Story = () => (
+    <ReactJSONEditor content={{ json: sampleJson }} readOnly />
+);
+
+export const WithValidationError: Story = () => (
+    <ReactJSONEditor
+        content={{ text: '{ "key": "value" }' }}
+        validationError='Custom validation error: value must be a number'
+    />
+);
+
+export const InvalidJson: Story = () => (
+    <Controlled initial='{ invalid json }' />
+);
+
+export const Empty: Story = () => <Controlled initial='' />;

--- a/frontend/src/component/common/ReactJSONEditor/ReactJSONEditor.tsx
+++ b/frontend/src/component/common/ReactJSONEditor/ReactJSONEditor.tsx
@@ -37,6 +37,10 @@ const StyledEditorWrapper = styled(Box, {
         '&:hover': {
             borderColor: theme.palette.action.disabled,
         },
+        '& .cm-cursor': {
+            borderLeftWidth: theme.spacing(0.2),
+            borderLeftColor: theme.palette.text.primary,
+        },
         '&:focus-within': {
             borderColor: hasError
                 ? theme.palette.error.main


### PR DESCRIPTION
## About the changes

cursor in dark mode is impossible to see:

<img width="233" height="119" alt="Screenshot 2026-06-18 at 17 28 17" src="https://github.com/user-attachments/assets/c9d43e4c-b19b-48e2-9d5d-ab03162b8320" />


### Important files

## Discussion points

## OSS PR checklist

- [x] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [x] I have added tests or explained why tests are not needed.
- [x] I have updated documentation where relevant.

It will look like this: 


<img width="297" height="265" alt="Screenshot 2026-06-18 at 17 22 17" src="https://github.com/user-attachments/assets/c64e77e9-ecde-4fdf-8f88-02b3515718e8" />
<img width="291" height="275" alt="Screenshot 2026-06-18 at 17 22 10" src="https://github.com/user-attachments/assets/ccad0923-2104-46aa-bb2a-ed81dd973bcf" />

