### PR TITLE
fix: infinite update loop (React error 185) when editing segment constraints with legal values

### DIFF
--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/constraint-reducer.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/constraint-reducer.test.ts
@@ -502,6 +502,45 @@ describe('removing / clearing values', () => {
         });
     });
 });
+describe('deleted legal values update', () => {
+    test('returns the same state reference when the set is unchanged (prevents infinite update loop)', () => {
+        const input = {
+            ...multiValueConstraint,
+            deletedLegalValues: new Set(['A', 'B']),
+        };
+        // new Set instance, same values -> must NOT produce a new state ref,
+        // otherwise the useEditableConstraint onUpdate effect re-fires forever.
+        const output = constraintReducer(input, {
+            type: 'deleted legal values update',
+            payload: new Set(['B', 'A']),
+        });
+        expect(output).toBe(input);
+    });
+
+    test('treats undefined and empty set as unchanged', () => {
+        const input = multiValueConstraint; // no deletedLegalValues
+        const output = constraintReducer(input, {
+            type: 'deleted legal values update',
+            payload: new Set(),
+        });
+        expect(output).toBe(input);
+    });
+
+    test('returns a new state when the set actually changes', () => {
+        const input = {
+            ...multiValueConstraint,
+            deletedLegalValues: new Set(['A']),
+        };
+        const payload = new Set(['A', 'B']);
+        const output = constraintReducer(input, {
+            type: 'deleted legal values update',
+            payload,
+        });
+        expect(output).not.toBe(input);
+        expect(output.deletedLegalValues).toBe(payload);
+    });
+});
+
 describe('toggle options', () => {
     const stateTransitions = [
         [undefined, true],

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/constraint-reducer.test.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/constraint-reducer.test.ts
@@ -506,24 +506,27 @@ describe('deleted legal values update', () => {
     test('returns the same state reference when the set is unchanged (prevents infinite update loop)', () => {
         const input = {
             ...multiValueConstraint,
-            deletedLegalValues: new Set(['A', 'B']),
+            deletedLegalValues: new Set(['A']),
         };
-        // new Set instance, same values -> must NOT produce a new state ref,
-        // otherwise the useEditableConstraint onUpdate effect re-fires forever.
         const output = constraintReducer(input, {
             type: 'deleted legal values update',
-            payload: new Set(['B', 'A']),
+            payload: new Set(['A']),
         });
         expect(output).toBe(input);
     });
 
-    test('treats undefined and empty set as unchanged', () => {
-        const input = multiValueConstraint; // no deletedLegalValues
+    test('treats undefined and empty set as the same', () => {
+        const input = multiValueConstraint;
         const output = constraintReducer(input, {
             type: 'deleted legal values update',
             payload: new Set(),
         });
         expect(output).toBe(input);
+
+        const withUndefinedPayload = constraintReducer(input, {
+            type: 'deleted legal values update',
+        });
+        expect(withUndefinedPayload).toBe(input);
     });
 
     test('returns a new state when the set actually changes', () => {

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/constraint-reducer.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/constraint-reducer.ts
@@ -183,10 +183,16 @@ export const constraintReducer = (
                 return removeValue(action.payload);
             }
             return addValue(action.payload);
-        case 'deleted legal values update':
+        case 'deleted legal values update': {
+            const next = action.payload ?? new Set<string>();
+            const current = state.deletedLegalValues ?? new Set<string>();
+            if (current.size === next.size && current.isSubsetOf(next)) {
+                return state;
+            }
             return {
                 ...state,
                 deletedLegalValues: action.payload,
             };
+        }
     }
 };

--- a/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/constraint-reducer.ts
+++ b/frontend/src/component/feature/FeatureStrategy/FeatureStrategyConstraints/EditableConstraint/useEditableConstraint/constraint-reducer.ts
@@ -186,7 +186,10 @@ export const constraintReducer = (
         case 'deleted legal values update': {
             const next = action.payload ?? new Set<string>();
             const current = state.deletedLegalValues ?? new Set<string>();
-            if (current.size === next.size && current.isSubsetOf(next)) {
+            if (
+                current.size === next.size &&
+                Array.from(current).every((value) => next.has(value))
+            ) {
                 return state;
             }
             return {


### PR DESCRIPTION


### What

Editing a segment constraint on a context field that has **legal values** could send the
component tree into an infinite render loop, crashing the UI with
[React error 185](https://react.dev/errors/185) ("Maximum update depth exceeded").

It surfaced most visibly in the project-segments → change-request flow: clicking **Add to
draft** appeared to do nothing (the modal stayed open), and clicking outside the modal to
dismiss it crashed the page. Both symptoms were the same wedged render loop — not separate
bugs.

### Root cause

A feedback loop between two effects in `useEditableConstraint`, kept alive by a reducer that
always produced a new state object:

1. The `onUpdate` effect pushes the local constraint up to the parent. For multi-value
   constraints `toIConstraint` rebuilds `values` via `Array.from(...)`, so the parent gets a
   **new array reference** every pass.
2. The parent splices that back in, so the `constraint.values` prop changes identity.
3. The "deleted legal values" effect keys on `constraint.values` identity, so it re-fires and
   dispatches `'deleted legal values update'`.
4. `constraintReducer` returned `{ ...state, deletedLegalValues }` **unconditionally** — a new
   state ref even when the set was value-unchanged — which re-derived `localConstraint` and
   re-fired the `onUpdate` effect → back to step 1, forever.


### Fix

Make the reducer bail when nothing actually changed, returning the **same state reference** so
the effect chain settles: Equal size + a subset of b ⟹ equal sets.
