### PR TITLE
chore: better header for smaller screens

### DIFF
--- a/frontend/src/component/commandBar/CommandBar.test.tsx
+++ b/frontend/src/component/commandBar/CommandBar.test.tsx
@@ -1,0 +1,46 @@
+import { beforeEach, expect, test } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'utils/testRenderer';
+import { testServerRoute, testServerSetup } from 'utils/testServer';
+import { CommandBar } from './CommandBar.tsx';
+
+const server = testServerSetup();
+
+const setViewportBelowMd = (belowMd: boolean) => {
+    window.matchMedia = ((query: string) => ({
+        matches: belowMd ? query.includes('max-width') : false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+};
+
+beforeEach(() => {
+    testServerRoute(server, '/api/admin/ui-config', {});
+    testServerRoute(server, '/api/admin/projects', { projects: [] });
+});
+
+test('collapses to a search icon below the md breakpoint', () => {
+    setViewportBelowMd(true);
+
+    render(<CommandBar />);
+
+    expect(screen.getByRole('button', { name: /command menu/i })).toBeVisible();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+});
+
+test('opens a search dialog when the icon is clicked and keeps it open', async () => {
+    setViewportBelowMd(true);
+
+    render(<CommandBar />);
+    await userEvent.click(
+        screen.getByRole('button', { name: /command menu/i }),
+    );
+
+    expect(await screen.findByRole('textbox')).toBeVisible();
+});

--- a/frontend/src/component/commandBar/CommandBar.test.tsx
+++ b/frontend/src/component/commandBar/CommandBar.test.tsx
@@ -1,46 +1,63 @@
 import { beforeEach, expect, test } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'utils/testRenderer';
 import { testServerRoute, testServerSetup } from 'utils/testServer';
+import { resizeScreen } from 'utils/resizeScreen';
 import { CommandBar } from './CommandBar.tsx';
 
 const server = testServerSetup();
-
-const setViewportBelowMd = (belowMd: boolean) => {
-    window.matchMedia = ((query: string) => ({
-        matches: belowMd ? query.includes('max-width') : false,
-        media: query,
-        onchange: null,
-        addListener: () => {},
-        removeListener: () => {},
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        dispatchEvent: () => false,
-    })) as typeof window.matchMedia;
-};
+const BELOW_MD = 600;
 
 beforeEach(() => {
     testServerRoute(server, '/api/admin/ui-config', {});
     testServerRoute(server, '/api/admin/projects', { projects: [] });
+    resizeScreen(BELOW_MD);
 });
 
 test('collapses to a search icon below the md breakpoint', () => {
-    setViewportBelowMd(true);
-
     render(<CommandBar />);
 
     expect(screen.getByRole('button', { name: /command menu/i })).toBeVisible();
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
 });
 
-test('opens a search dialog when the icon is clicked and keeps it open', async () => {
-    setViewportBelowMd(true);
-
+test('opens the search dialog with a focused input when the trigger is clicked', async () => {
     render(<CommandBar />);
+
     await userEvent.click(
         screen.getByRole('button', { name: /command menu/i }),
     );
 
     expect(await screen.findByRole('textbox')).toBeVisible();
+});
+
+test('toggles the search dialog with the Ctrl+K hotkey', async () => {
+    render(<CommandBar />);
+
+    await userEvent.keyboard('{Control>}k{/Control}');
+    expect(await screen.findByRole('textbox')).toBeVisible();
+
+    await userEvent.keyboard('{Control>}k{/Control}');
+    await waitFor(() =>
+        expect(screen.queryByRole('textbox')).not.toBeInTheDocument(),
+    );
+});
+
+test('closing the dialog resets the search input', async () => {
+    render(<CommandBar />);
+    await userEvent.click(
+        screen.getByRole('button', { name: /command menu/i }),
+    );
+    await userEvent.type(await screen.findByRole('textbox'), 'hello');
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() =>
+        expect(screen.queryByRole('textbox')).not.toBeInTheDocument(),
+    );
+
+    await userEvent.click(
+        screen.getByRole('button', { name: /command menu/i }),
+    );
+    expect(await screen.findByRole('textbox')).toHaveValue('');
 });

--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -63,7 +63,6 @@ const StyledContainer = styled('div', {
     backgroundColor: theme.palette.background.application,
     maxWidth: active ? '100%' : '400px',
     [theme.breakpoints.down('md')]: {
-        marginTop: theme.spacing(1),
         maxWidth: '100%',
     },
 }));

--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
 import {
     Box,
+    Dialog,
     IconButton,
     InputBase,
     Paper,
     styled,
     Tooltip,
 } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '@mui/material/styles';
 import Close from '@mui/icons-material/Close';
 import SearchIcon from '@mui/icons-material/Search';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
@@ -51,19 +54,34 @@ export const CommandResultsPaper = styled(Paper)(({ theme }) => ({
 }));
 
 const StyledContainer = styled('div', {
-    shouldForwardProp: (prop) => prop !== 'active',
+    shouldForwardProp: (prop) => prop !== 'active' && prop !== 'compact',
 })<{
     active: boolean | undefined;
-}>(({ theme, active }) => ({
+    compact?: boolean;
+}>(({ theme, active, compact }) => ({
     border: `1px solid transparent`,
     display: 'flex',
     flexGrow: 1,
     alignItems: 'center',
     position: 'relative',
-    backgroundColor: theme.palette.background.application,
+    backgroundColor: compact
+        ? 'transparent'
+        : theme.palette.background.application,
     maxWidth: active ? '100%' : '400px',
     [theme.breakpoints.down('md')]: {
         maxWidth: '100%',
+    },
+}));
+
+const StyledCompactDialog = styled(Dialog)(({ theme }) => ({
+    '& .MuiDialog-container': { alignItems: 'flex-start' },
+    '& .MuiDialog-paper': {
+        overflow: 'visible',
+        marginTop: theme.spacing(8),
+        marginLeft: theme.spacing(2),
+        marginRight: theme.spacing(2),
+        background: 'transparent',
+        boxShadow: 'none',
     },
 }));
 
@@ -104,6 +122,7 @@ export const CommandBar = () => {
     const { trackEvent } = usePlausibleTracker();
     const searchInputRef = useRef<HTMLInputElement>(null);
     const searchContainerRef = useRef<HTMLInputElement>(null);
+    const compactIconRef = useRef<HTMLButtonElement>(null);
     const [showSuggestions, setShowSuggestions] = useState(false);
     const [searchLoading, setSearchLoading] = useState(false);
     const [searchString, setSearchString] = useState<string | undefined>(
@@ -120,9 +139,16 @@ export const CommandBar = () => {
     const [hasNoResults, setHasNoResults] = useState(false);
     const [value, setValue] = useState<string>('');
     const { allRoutes } = useCommandBarRoutes();
+    const theme = useTheme();
+    const isCompact = useMediaQuery(theme.breakpoints.down('md'));
+    const [compactExpanded, setCompactExpanded] = useState(false);
 
     const hideSuggestions = () => {
         setShowSuggestions(false);
+        if (isCompact) {
+            setCompactExpanded(false);
+            setValue('');
+        }
     };
 
     const { projects } = useProjects();
@@ -179,6 +205,7 @@ export const CommandBar = () => {
     const clearSearchValue = () => {
         onSearchChange('');
         setShowSuggestions(false);
+        if (isCompact) setCompactExpanded(false);
     };
 
     const hotkey = useKeyboardShortcut(
@@ -188,7 +215,13 @@ export const CommandBar = () => {
             preventDefault: true,
         },
         () => {
-            if (document.activeElement === searchInputRef.current) {
+            if (isCompact) {
+                if (compactExpanded) {
+                    hideSuggestions();
+                } else {
+                    setCompactExpanded(true);
+                }
+            } else if (document.activeElement === searchInputRef.current) {
                 searchInputRef.current?.blur();
             } else {
                 searchInputRef.current?.focus();
@@ -199,6 +232,10 @@ export const CommandBar = () => {
         setShowSuggestions(false);
         if (searchContainerRef.current?.contains(document.activeElement)) {
             searchInputRef.current?.blur();
+        }
+        if (isCompact && compactExpanded) {
+            setCompactExpanded(false);
+            setValue('');
         }
     });
     const placeholder = `Command menu (${hotkey})`;
@@ -284,7 +321,7 @@ export const CommandBar = () => {
         setShowSuggestions(false);
     });
 
-    useOnClickOutside([searchContainerRef], hideSuggestions);
+    useOnClickOutside([searchContainerRef, compactIconRef], hideSuggestions);
     const onKeyDown = (event: React.KeyboardEvent) => {
         if (event.key === 'Escape') {
             setShowSuggestions(false);
@@ -297,8 +334,12 @@ export const CommandBar = () => {
         }
     };
 
-    return (
-        <StyledContainer ref={searchContainerRef} active={showSuggestions}>
+    const searchBar = (
+        <StyledContainer
+            ref={searchContainerRef}
+            active={showSuggestions}
+            compact={isCompact}
+        >
             <RecentlyVisitedRecorder />
             <StyledSearch isOpen={showSuggestions}>
                 <SearchIcon
@@ -315,6 +356,7 @@ export const CommandBar = () => {
                     id='command-bar-input'
                     inputRef={searchInputRef}
                     placeholder={placeholder}
+                    autoFocus={isCompact}
                     slotProps={{
                         input: {
                             'data-testid': SEARCH_INPUT,
@@ -408,4 +450,35 @@ export const CommandBar = () => {
             />
         </StyledContainer>
     );
+
+    if (isCompact) {
+        return (
+            <>
+                <Tooltip title={placeholder} arrow>
+                    <IconButton
+                        ref={compactIconRef}
+                        size='large'
+                        onClick={() => setCompactExpanded(true)}
+                        aria-label={placeholder}
+                    >
+                        <SearchIcon
+                            sx={{
+                                color: (theme) => theme.palette.neutral.main,
+                            }}
+                        />
+                    </IconButton>
+                </Tooltip>
+                <StyledCompactDialog
+                    open={compactExpanded}
+                    onClose={hideSuggestions}
+                    fullWidth
+                    maxWidth='sm'
+                >
+                    {searchBar}
+                </StyledCompactDialog>
+            </>
+        );
+    }
+
+    return searchBar;
 };

--- a/frontend/src/component/commandBar/CommandBar.tsx
+++ b/frontend/src/component/commandBar/CommandBar.tsx
@@ -107,15 +107,23 @@ const StyledSearch = styled('div')<{ isOpen?: boolean }>(
     }),
 );
 
-const StyledInputBase = styled(InputBase)(({ theme }) => ({
+const StyledInputBase = styled(InputBase, {
+    shouldForwardProp: (prop) => prop !== 'compact',
+})<{ compact?: boolean }>(({ theme, compact }) => ({
     width: '100%',
-    minWidth: '300px',
+    minWidth: compact ? 0 : '300px',
     backgroundColor: theme.palette.background.paper,
 }));
 
 const StyledClose = styled(Close)(({ theme }) => ({
     color: theme.palette.neutral.main,
     fontSize: theme.typography.body1.fontSize,
+}));
+
+const StyledIconButton = styled(IconButton, {
+    shouldForwardProp: (prop) => prop !== 'open',
+})<{ open?: boolean }>(({ theme, open }) => ({
+    color: open ? theme.palette.primary.main : theme.palette.neutral.main,
 }));
 
 export const CommandBar = () => {
@@ -357,6 +365,7 @@ export const CommandBar = () => {
                     inputRef={searchInputRef}
                     placeholder={placeholder}
                     autoFocus={isCompact}
+                    compact={isCompact}
                     slotProps={{
                         input: {
                             'data-testid': SEARCH_INPUT,
@@ -455,18 +464,15 @@ export const CommandBar = () => {
         return (
             <>
                 <Tooltip title={placeholder} arrow>
-                    <IconButton
+                    <StyledIconButton
                         ref={compactIconRef}
                         size='large'
+                        open={compactExpanded}
                         onClick={() => setCompactExpanded(true)}
                         aria-label={placeholder}
                     >
-                        <SearchIcon
-                            sx={{
-                                color: (theme) => theme.palette.neutral.main,
-                            }}
-                        />
-                    </IconButton>
+                        <SearchIcon />
+                    </StyledIconButton>
                 </Tooltip>
                 <StyledCompactDialog
                     open={compactExpanded}

--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -83,13 +83,68 @@ const Header = () => {
     const theme = useTheme();
 
     const mediumScreen = useMediaQuery(theme.breakpoints.down('lg'));
-    const smallScreen = useMediaQuery(theme.breakpoints.down('sm'));
-    const screenBigEnoughForExtraButtons = useMediaQuery(
-        theme.breakpoints.down(700),
-    );
     const [openDrawer, setOpenDrawer] = useState(false);
     const toggleDrawer = () => setOpenDrawer((prev) => !prev);
     const hideTopmenuDocumentation = useUiFlag('hideTopmenuDocumentation');
+
+    const headerItems = (
+        <StyledUserContainer>
+            <CommandBar />
+            <Divider
+                orientation='vertical'
+                variant='middle'
+                flexItem
+                sx={(theme) => ({
+                    marginLeft: theme.spacing(1),
+                    border: 'transparent',
+                })}
+            />
+            <InviteLinkButton />
+            {showThemeButton && (
+                <Tooltip
+                    title={
+                        theme.mode === 'dark'
+                            ? 'Switch to light theme'
+                            : 'Switch to dark theme'
+                    }
+                    arrow
+                >
+                    <StyledIconButton onClick={onSetThemeMode} size='large'>
+                        <ConditionallyRender
+                            condition={theme.mode === 'dark'}
+                            show={<DarkModeOutlined />}
+                            elseShow={<LightModeOutlined />}
+                        />
+                    </StyledIconButton>
+                </Tooltip>
+            )}
+            {hideTopmenuDocumentation && <HelpResources />}
+            {!hideTopmenuDocumentation && (
+                <Tooltip title='Documentation' arrow>
+                    <StyledIconButton
+                        component='a'
+                        nativeButton={false}
+                        href='https://docs.getunleash.io/'
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        size='large'
+                        sx={(theme) => ({
+                            marginRight: theme.spacing(1),
+                        })}
+                    >
+                        <MenuBookIcon />
+                    </StyledIconButton>
+                </Tooltip>
+            )}
+            <Divider
+                orientation='vertical'
+                variant='middle'
+                flexItem
+                sx={{ ml: 1 }}
+            />
+            <UserProfile />
+        </StyledUserContainer>
+    );
 
     if (mediumScreen) {
         return (
@@ -109,20 +164,7 @@ const Header = () => {
                         </IconButton>
                     </Tooltip>
                     <DrawerMenu open={openDrawer} toggleDrawer={toggleDrawer} />
-                    <StyledUserContainer>
-                        {!smallScreen && <CommandBar />}
-                        {!screenBigEnoughForExtraButtons &&
-                            hideTopmenuDocumentation && <HelpResources />}
-                        {!screenBigEnoughForExtraButtons && (
-                            <Divider
-                                orientation='vertical'
-                                variant='middle'
-                                flexItem
-                                sx={{ ml: 1 }}
-                            />
-                        )}
-                        <UserProfile />
-                    </StyledUserContainer>
+                    {headerItems}
                 </ContainerComponent>
             </HeaderComponent>
         );
@@ -131,67 +173,7 @@ const Header = () => {
     return (
         <HeaderComponent position='static'>
             <ContainerComponent>
-                <StyledNav>
-                    <StyledUserContainer>
-                        <CommandBar />
-                        <Divider
-                            orientation='vertical'
-                            variant='middle'
-                            flexItem
-                            sx={(theme) => ({
-                                marginLeft: theme.spacing(1),
-                                border: 'transparent',
-                            })}
-                        />
-                        <InviteLinkButton />
-                        {showThemeButton && (
-                            <Tooltip
-                                title={
-                                    theme.mode === 'dark'
-                                        ? 'Switch to light theme'
-                                        : 'Switch to dark theme'
-                                }
-                                arrow
-                            >
-                                <StyledIconButton
-                                    onClick={onSetThemeMode}
-                                    size='large'
-                                >
-                                    <ConditionallyRender
-                                        condition={theme.mode === 'dark'}
-                                        show={<DarkModeOutlined />}
-                                        elseShow={<LightModeOutlined />}
-                                    />
-                                </StyledIconButton>
-                            </Tooltip>
-                        )}
-                        {hideTopmenuDocumentation && <HelpResources />}
-                        {!hideTopmenuDocumentation && (
-                            <Tooltip title='Documentation' arrow>
-                                <StyledIconButton
-                                    component='a'
-                                    nativeButton={false}
-                                    href='https://docs.getunleash.io/'
-                                    target='_blank'
-                                    rel='noopener noreferrer'
-                                    size='large'
-                                    sx={(theme) => ({
-                                        marginRight: theme.spacing(1),
-                                    })}
-                                >
-                                    <MenuBookIcon />
-                                </StyledIconButton>
-                            </Tooltip>
-                        )}
-                        <Divider
-                            orientation='vertical'
-                            variant='middle'
-                            flexItem
-                            sx={{ ml: 1 }}
-                        />
-                        <UserProfile />
-                    </StyledUserContainer>
-                </StyledNav>
+                <StyledNav>{headerItems}</StyledNav>
             </ContainerComponent>
         </HeaderComponent>
     );

--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -83,7 +83,10 @@ const Header = () => {
     const theme = useTheme();
 
     const mediumScreen = useMediaQuery(theme.breakpoints.down('lg'));
-    const smallScreen = useMediaQuery(theme.breakpoints.down('md'));
+    const smallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+    const screenBigEnoughForExtraButtons = useMediaQuery(
+        theme.breakpoints.down(700),
+    );
     const [openDrawer, setOpenDrawer] = useState(false);
     const toggleDrawer = () => setOpenDrawer((prev) => !prev);
     const hideTopmenuDocumentation = useUiFlag('hideTopmenuDocumentation');
@@ -108,6 +111,16 @@ const Header = () => {
                     <DrawerMenu open={openDrawer} toggleDrawer={toggleDrawer} />
                     <StyledUserContainer>
                         {!smallScreen && <CommandBar />}
+                        {!screenBigEnoughForExtraButtons &&
+                            hideTopmenuDocumentation && <HelpResources />}
+                        {!screenBigEnoughForExtraButtons && (
+                            <Divider
+                                orientation='vertical'
+                                variant='middle'
+                                flexItem
+                                sx={{ ml: 1 }}
+                            />
+                        )}
                         <UserProfile />
                     </StyledUserContainer>
                 </ContainerComponent>


### PR DESCRIPTION
## About the changes

Closes #

### Important files

## Discussion points

## OSS PR checklist

- [x] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [x] I have added tests or explained why tests are not needed.
- [x] I have updated documentation where relevant.

# Problem


<img width="961" height="131" alt="Screenshot 2026-06-22 at 11 33 45" src="https://github.com/user-attachments/assets/d83127a4-a772-44e9-86f4-50f1eb0e3add" />

<img width="704" height="133" alt="Screenshot 2026-06-22 at 11 34 31" src="https://github.com/user-attachments/assets/5b1460d0-c981-422c-923b-84a808e489d3" />



# This PR

<img width="1167" height="211" alt="Screenshot 2026-06-22 at 11 33 14" src="https://github.com/user-attachments/assets/ea729d0c-5a74-4bf5-975a-7b09c56a1c0d" />

<img width="953" height="161" alt="Screenshot 2026-06-22 at 11 32 45" src="https://github.com/user-attachments/assets/b367436f-a665-409e-a53b-b4d3679c98d3" />

<img width="446" height="433" alt="Screenshot 2026-06-22 at 11 32 35" src="https://github.com/user-attachments/assets/befadb78-0a1e-4b26-8a4f-78cb3f0a8bc8" />

When you click on the search icon:

<img width="703" height="364" alt="Screenshot 2026-06-22 at 11 35 19" src="https://github.com/user-attachments/assets/623be16c-2b0b-4bbd-85a3-90ca620c60b3" />



