### PR TITLE
fix: change password should not be available with SSO

### DIFF
--- a/frontend/src/component/user/Profile/PasswordTab/PasswordTab.tsx
+++ b/frontend/src/component/user/Profile/PasswordTab/PasswordTab.tsx
@@ -8,6 +8,7 @@ import PasswordChecker, {
 import PasswordMatcher from 'component/user/common/ResetPasswordForm/PasswordMatcher';
 import { usePasswordApi } from 'hooks/api/actions/usePasswordApi/usePasswordApi';
 import useAuthSettings from 'hooks/api/getters/useAuthSettings/useAuthSettings';
+import { useProfile } from 'hooks/api/getters/useProfile/useProfile';
 import useToast from 'hooks/useToast';
 import { type SyntheticEvent, useState } from 'react';
 import { formatUnknownError } from 'utils/formatUnknownError';
@@ -23,6 +24,7 @@ const StyledForm = styled('form')(({ theme }) => ({
 export const PasswordTab = () => {
     const { config: simpleAuthConfig, loading: authSettingsLoading } =
         useAuthSettings('simple');
+    const { profile, loading: profileLoading } = useProfile();
 
     const [loading, setLoading] = useState(false);
     const { setToastData, setToastApiError } = useToast();
@@ -79,7 +81,7 @@ export const PasswordTab = () => {
         setLoading(false);
     };
 
-    if (authSettingsLoading) return null;
+    if (authSettingsLoading || profileLoading) return null;
 
     return (
         <PageContent isLoading={loading} header='Change password'>
@@ -92,63 +94,78 @@ export const PasswordTab = () => {
                     </Alert>
                 }
                 elseShow={
-                    <StyledForm>
-                        <PasswordChecker
-                            password={password}
-                            callback={setValidPassword}
-                            data-loading
-                        />
-                        <PasswordField
-                            data-loading
-                            label='Old password'
-                            name='oldPassword'
-                            value={oldPassword}
-                            error={Boolean(authenticationError)}
-                            helperText={authenticationError}
-                            autoComplete='current-password'
-                            onChange={(
-                                e: React.ChangeEvent<HTMLInputElement>,
-                            ) => setOldPassword(e.target.value)}
-                        />
-                        <PasswordField
-                            data-loading
-                            label='Password'
-                            name='password'
-                            value={password}
-                            error={Boolean(error)}
-                            helperText={error}
-                            autoComplete='new-password'
-                            onChange={(
-                                e: React.ChangeEvent<HTMLInputElement>,
-                            ) => setPassword(e.target.value)}
-                        />
-                        <PasswordField
-                            data-loading
-                            label='Confirm password'
-                            name='confirmPassword'
-                            value={confirmPassword}
-                            autoComplete='new-password'
-                            onChange={(
-                                e: React.ChangeEvent<HTMLInputElement>,
-                            ) => setConfirmPassword(e.target.value)}
-                        />
-                        <PasswordMatcher
-                            data-loading
-                            started={allPasswordsFilled}
-                            passwordsDoNotMatch={passwordsDoNotMatch}
-                            sameAsOldPassword={sameAsOldPassword}
-                        />
-                        <Button
-                            data-loading
-                            variant='contained'
-                            color='primary'
-                            type='submit'
-                            onClick={submit}
-                            disabled={hasError}
-                        >
-                            Save
-                        </Button>
-                    </StyledForm>
+                    <ConditionallyRender
+                        condition={profile?.canChangePassword === false}
+                        show={
+                            <Alert severity='info'>
+                                Your account does not use a password. You sign
+                                in using your organization&apos;s single sign-on
+                                provider, so there is no Unleash password to
+                                change here. To update your sign-in credentials,
+                                use your identity provider or contact your
+                                administrator.
+                            </Alert>
+                        }
+                        elseShow={
+                            <StyledForm>
+                                <PasswordChecker
+                                    password={password}
+                                    callback={setValidPassword}
+                                    data-loading
+                                />
+                                <PasswordField
+                                    data-loading
+                                    label='Old password'
+                                    name='oldPassword'
+                                    value={oldPassword}
+                                    error={Boolean(authenticationError)}
+                                    helperText={authenticationError}
+                                    autoComplete='current-password'
+                                    onChange={(
+                                        e: React.ChangeEvent<HTMLInputElement>,
+                                    ) => setOldPassword(e.target.value)}
+                                />
+                                <PasswordField
+                                    data-loading
+                                    label='Password'
+                                    name='password'
+                                    value={password}
+                                    error={Boolean(error)}
+                                    helperText={error}
+                                    autoComplete='new-password'
+                                    onChange={(
+                                        e: React.ChangeEvent<HTMLInputElement>,
+                                    ) => setPassword(e.target.value)}
+                                />
+                                <PasswordField
+                                    data-loading
+                                    label='Confirm password'
+                                    name='confirmPassword'
+                                    value={confirmPassword}
+                                    autoComplete='new-password'
+                                    onChange={(
+                                        e: React.ChangeEvent<HTMLInputElement>,
+                                    ) => setConfirmPassword(e.target.value)}
+                                />
+                                <PasswordMatcher
+                                    data-loading
+                                    started={allPasswordsFilled}
+                                    passwordsDoNotMatch={passwordsDoNotMatch}
+                                    sameAsOldPassword={sameAsOldPassword}
+                                />
+                                <Button
+                                    data-loading
+                                    variant='contained'
+                                    color='primary'
+                                    type='submit'
+                                    onClick={submit}
+                                    disabled={hasError}
+                                >
+                                    Save
+                                </Button>
+                            </StyledForm>
+                        }
+                    />
                 }
             />
         </PageContent>

--- a/frontend/src/openapi/models/profileSchema.ts
+++ b/frontend/src/openapi/models/profileSchema.ts
@@ -11,6 +11,8 @@ import type { RoleSchema } from './roleSchema';
  * User profile overview
  */
 export interface ProfileSchema {
+    /** Whether the current user has a local password that can be changed. */
+    canChangePassword: boolean;
     /** Deprecated, always returns empty array */
     features: FeatureSchema[];
     /** Experimental: Which groups this user is a member of */

--- a/src/lib/openapi/spec/profile-schema.test.ts
+++ b/src/lib/openapi/spec/profile-schema.test.ts
@@ -11,6 +11,7 @@ test('profileSchema', () => {
         projects: ['default', 'secretproject'],
         groups: [],
         subscriptions: ['productivity-report'],
+        canChangePassword: true,
         features: [
             { name: 'firstFeature', project: 'default' },
             { name: 'secondFeature', project: 'secretproject' },

--- a/src/lib/openapi/spec/profile-schema.ts
+++ b/src/lib/openapi/spec/profile-schema.ts
@@ -8,7 +8,14 @@ export const profileSchema = {
     type: 'object',
     additionalProperties: false,
     description: 'User profile overview',
-    required: ['rootRole', 'projects', 'groups', 'features', 'subscriptions'],
+    required: [
+        'rootRole',
+        'projects',
+        'groups',
+        'features',
+        'subscriptions',
+        'canChangePassword',
+    ],
     properties: {
         rootRole: {
             $ref: '#/components/schemas/roleSchema',
@@ -44,6 +51,12 @@ export const profileSchema = {
                 $ref: '#/components/schemas/featureSchema',
             },
             example: [],
+        },
+        canChangePassword: {
+            description:
+                'Whether the current user has a local password that can be changed.',
+            type: 'boolean',
+            example: true,
         },
     },
     components: {

--- a/src/lib/routes/admin-api/user/user.test.ts
+++ b/src/lib/routes/admin-api/user/user.test.ts
@@ -7,18 +7,26 @@ import getApp from '../../../app.js';
 import User from '../../../types/user.js';
 import bcrypt from 'bcryptjs';
 
-const currentUser = new User({ id: 1337, email: 'test@mail.com' });
+const currentUserData = { id: 1337, email: 'test@mail.com' };
 const oldPassword = 'old-pass';
 
-async function getSetup() {
+async function getSetup({
+    withPassword = true,
+}: {
+    withPassword?: boolean;
+} = {}) {
     const base = `/random${Math.round(Math.random() * 1000)}`;
     const stores = createStores();
-    await stores.userStore.insert(currentUser);
-    await stores.userStore.setPasswordHash(
-        currentUser.id,
-        await bcrypt.hash(oldPassword, 10),
-        5,
+    const currentUser = await stores.userStore.insert(
+        new User(currentUserData),
     );
+    if (withPassword) {
+        await stores.userStore.setPasswordHash(
+            currentUser.id,
+            await bcrypt.hash(oldPassword, 10),
+            5,
+        );
+    }
 
     const config = createTestConfig({
         preHook: (a) => {
@@ -35,6 +43,7 @@ async function getSetup() {
     const app = await getApp(config, stores, services);
     return {
         base,
+        currentUser,
         userStore: stores.userStore,
         sessionStore: stores.sessionStore,
         request: supertest(app),
@@ -50,7 +59,7 @@ test('should return current user', async () => {
         .expect(200)
         .expect('Content-Type', /json/)
         .expect((res) => {
-            expect(res.body.user.email).toBe(currentUser.email);
+            expect(res.body.user.email).toBe(currentUserData.email);
         });
 });
 const owaspPassword = 't7GTx&$Y9pcsnxRv6';
@@ -65,6 +74,7 @@ test('should return current profile', async () => {
         .expect('Content-Type', /json/)
         .expect((res) => {
             expect(res.body).toMatchObject({
+                canChangePassword: true,
                 projects: [],
                 groups: [],
                 rootRole: { id: -1, name: 'Viewer', type: 'root' },
@@ -75,7 +85,7 @@ test('should return current profile', async () => {
 });
 
 test('should allow user to change password', async () => {
-    const { request, base, userStore } = await getSetup();
+    const { request, base, currentUser, userStore } = await getSetup();
     await request
         .post(`${base}/api/admin/user/change-password`)
         .send({
@@ -90,7 +100,7 @@ test('should allow user to change password', async () => {
 });
 
 test('changing own password keeps the current session and terminates the others', async () => {
-    const { request, base, sessionStore } = await getSetup();
+    const { request, base, currentUser, sessionStore } = await getSetup();
     await sessionStore.insertSession({
         sid: 'current-session',
         sess: { user: { id: currentUser.id } },
@@ -125,6 +135,30 @@ test('should not allow user to change password with incorrect old password', asy
             oldPassword: 'incorrect',
         })
         .expect(401);
+});
+
+test('should not allow user without a local password to change password', async () => {
+    const { request, base } = await getSetup({ withPassword: false });
+    await request
+        .post(`${base}/api/admin/user/change-password`)
+        .send({
+            password: owaspPassword,
+            confirmPassword: owaspPassword,
+            oldPassword,
+        })
+        .expect(401);
+});
+
+test('should report that user without a local password cannot change password', async () => {
+    const { request, base } = await getSetup({ withPassword: false });
+
+    return request
+        .get(`${base}/api/admin/user/profile`)
+        .expect(200)
+        .expect('Content-Type', /json/)
+        .expect((res) => {
+            expect(res.body.canChangePassword).toBe(false);
+        });
 });
 
 test('should not allow user to change password without providing old password', async () => {

--- a/src/lib/routes/admin-api/user/user.ts
+++ b/src/lib/routes/admin-api/user/user.ts
@@ -273,12 +273,14 @@ class UserController extends Controller {
             throw new BadDataError('User id is missing in request user object');
         }
 
-        const [projects, groups, rootRole, subscriptions] = await Promise.all([
-            this.projectService.getProjectsByUser(user.id),
-            this.groupService.getGroupsForUser(user.id),
-            this.accessService.getRootRoleForUser(user.id),
-            this.userSubscriptionsService.getUserSubscriptions(user.id),
-        ]);
+        const [projects, groups, rootRole, subscriptions, canChangePassword] =
+            await Promise.all([
+                this.projectService.getProjectsByUser(user.id),
+                this.groupService.getGroupsForUser(user.id),
+                this.accessService.getRootRoleForUser(user.id),
+                this.userSubscriptionsService.getUserSubscriptions(user.id),
+                this.userService.hasPassword(user.id),
+            ]);
 
         const responseData: ProfileSchema = {
             projects,
@@ -286,6 +288,7 @@ class UserController extends Controller {
             rootRole,
             subscriptions,
             features: [],
+            canChangePassword,
         };
 
         this.openApiService.respondWithValidation(

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -641,6 +641,12 @@ export class UserService {
         options: ChangePasswordOptions = {},
     ): Promise<void> {
         const currentPasswordHash = await this.store.getPasswordHash(userId);
+        if (!currentPasswordHash) {
+            throw new PasswordMismatch(
+                `The old password you provided is invalid. If you have forgotten your password, visit ${this.baseUriPath}/forgotten-password or get in touch with your instance administrator.`,
+            );
+        }
+
         const match = await bcrypt.compare(oldPassword, currentPasswordHash);
         if (!match) {
             throw new PasswordMismatch(
@@ -653,6 +659,12 @@ export class UserService {
             newPassword,
             options,
         );
+    }
+
+    async hasPassword(userId: number): Promise<boolean> {
+        const passwordHash = await this.store.getPasswordHash(userId);
+
+        return Boolean(passwordHash);
     }
 
     async getUserForToken(token: string): Promise<TokenUserSchema> {


### PR DESCRIPTION
## About the changes
Users logged in with SSO or other password-less method, should not be allowed to change the password. Currently, attempting to do so will yield a 500 error:

<img width="697" height="566" alt="image" src="https://github.com/user-attachments/assets/73364482-53c1-4f43-a3fb-d8c2b2a3d36e" />

This PR adds both a proper handling in the backend as well as a notice in the UI.

## OSS PR checklist

- [x] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [x] I have added tests or explained why tests are not needed.
- [x] I have updated documentation where relevant.
