### PR TITLE
feat: add flightRecorderAdminEvents flag

### DIFF
--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -65,6 +65,7 @@ export type IFlagKey =
     | 'newInUnleash'
     | 'oidcPkceSupport'
     | 'flightRecorderSdk'
+    | 'flightRecorderAdminEvents'
     | 'regexConstraintOperator'
     | 'enterpriseEdgeTokensList'
     | 'impactMetricsFlagPage'
@@ -298,6 +299,10 @@ const flags: IFlags = {
     ),
     flightRecorderSdk: parseEnvVarBoolean(
         process.env.UNLEASH_EXPERIMENTAL_FLIGHT_RECORDER_SDK,
+        false,
+    ),
+    flightRecorderAdminEvents: parseEnvVarBoolean(
+        process.env.UNLEASH_EXPERIMENTAL_FLIGHT_RECORDER_ADMIN_EVENTS,
         false,
     ),
     regexConstraintOperator: parseEnvVarBoolean(


### PR DESCRIPTION
Adds the `flightRecorderAdminEvents` experimental flag (default off).

Gates ingestion of admin events into the flight recorder, separate from `flightRecorderSdk`. Consumed by unleash-enterprise (cloud) to toggle admin-event ingestion.