### PR TITLE
feat: add registerProvider to AddonService

### DIFF
--- a/src/lib/server-impl.ts
+++ b/src/lib/server-impl.ts
@@ -44,6 +44,7 @@ import { CRUDStore } from './db/crud/crud-store.js';
 import type { CrudStoreConfig } from './db/crud/crud-store.js';
 import { type Logger, LogLevel, type LogProvider } from './logger.js';
 import { ImportTogglesStore } from './features/export-import-toggles/import-toggles-store.js';
+import Addon from './addons/addon.js';
 import { ALL_PROJECTS, CUSTOM_ROOT_ROLE_TYPE } from './util/index.js';
 import {
     extractAuditInfoFromUser,
@@ -572,6 +573,7 @@ export {
     EnvironmentStore,
     ProjectStore,
     defaultMetricsRegister,
+    Addon,
 };
 
 export type {

--- a/src/lib/services/addon-service.test.ts
+++ b/src/lib/services/addon-service.test.ts
@@ -5,7 +5,10 @@ import {
     ADDON_CONFIG_DELETED,
     ADDON_CONFIG_UPDATED,
     FEATURE_CREATED,
+    type IEvent,
 } from '../events/index.js';
+import Addon from '../addons/addon.js';
+import type { IAddonConfig } from '../types/model.js';
 import createStores from '../../test/fixtures/store.js';
 
 import AddonService from './addon-service.js';
@@ -68,6 +71,7 @@ function getSetup() {
         eventService,
         stores,
         tagTypeService,
+        integrationEventsService,
     };
 }
 
@@ -804,4 +808,119 @@ test('Should reject addon config if a required parameter is just the empty strin
     await expect(async () =>
         addonService.createAddon(config, TEST_AUDIT_USER),
     ).rejects.toThrow(ValidationError);
+});
+
+describe('registerProvider', () => {
+    class RegisterableAddon extends Addon {
+        received: Array<{ event: IEvent; parameters: any }> = [];
+
+        constructor(cfg: IAddonConfig, name: string) {
+            super(
+                {
+                    name,
+                    displayName: name,
+                    description: 'Some addon',
+                    documentationUrl: 'https://www.example.com',
+                    parameters: [
+                        {
+                            name: 'token',
+                            displayName: 'Token',
+                            type: 'text',
+                            required: false,
+                            sensitive: true,
+                        },
+                    ],
+                    events: [FEATURE_CREATED],
+                },
+                cfg,
+            );
+        }
+
+        async handleEvent(event: IEvent, parameters: any): Promise<void> {
+            this.received.push({ event, parameters });
+        }
+    }
+
+    const buildProvider = (
+        integrationEventsService: IntegrationEventsService,
+        name: string,
+    ): RegisterableAddon =>
+        new RegisterableAddon(
+            {
+                getLogger,
+                unleashUrl: 'http://test',
+                integrationEventsService,
+                flagResolver: {} as IFlagResolver,
+                eventBus: config.eventBus,
+            },
+            name,
+        );
+
+    test('a registered provider appears in the provider list and can be used to create an addon', async () => {
+        const { addonService, integrationEventsService } = getSetup();
+
+        expect(
+            addonService
+                .getProviderDefinitions()
+                .find((p) => p.name === 'someaddon'),
+        ).toBeUndefined();
+
+        addonService.registerProvider(
+            buildProvider(integrationEventsService, 'someaddon'),
+        );
+
+        expect(
+            addonService
+                .getProviderDefinitions()
+                .find((p) => p.name === 'someaddon'),
+        ).toBeDefined();
+
+        await expect(
+            addonService.createAddon(
+                {
+                    provider: 'someaddon',
+                    enabled: true,
+                    parameters: { token: 'secret' },
+                    events: [FEATURE_CREATED],
+                    description: '',
+                },
+                TEST_AUDIT_USER,
+            ),
+        ).resolves.toMatchObject({ provider: 'someaddon' });
+    });
+
+    test('registerProvider rejects a duplicate provider name', () => {
+        const { addonService, integrationEventsService } = getSetup();
+
+        addonService.registerProvider(
+            buildProvider(integrationEventsService, 'someaddon'),
+        );
+
+        expect(() =>
+            addonService.registerProvider(
+                buildProvider(integrationEventsService, 'someaddon'),
+            ),
+        ).toThrow(/already registered/);
+    });
+
+    test('registerProvider masks the new provider sensitive params', async () => {
+        const { addonService, integrationEventsService } = getSetup();
+        addonService.registerProvider(
+            buildProvider(integrationEventsService, 'someaddon'),
+        );
+
+        const created = await addonService.createAddon(
+            {
+                provider: 'someaddon',
+                enabled: true,
+                parameters: { token: 'super-secret' },
+                events: [FEATURE_CREATED],
+                description: '',
+            },
+            TEST_AUDIT_USER,
+        );
+
+        const fetched = await addonService.getAddon(created.id);
+        expect(fetched.parameters.token).toBe(MASKED_VALUE);
+    });
 });

--- a/src/lib/services/addon-service.test.ts
+++ b/src/lib/services/addon-service.test.ts
@@ -889,20 +889,6 @@ describe('registerProvider', () => {
         ).resolves.toMatchObject({ provider: 'someaddon' });
     });
 
-    test('registerProvider rejects a duplicate provider name', () => {
-        const { addonService, integrationEventsService } = getSetup();
-
-        addonService.registerProvider(
-            buildProvider(integrationEventsService, 'someaddon'),
-        );
-
-        expect(() =>
-            addonService.registerProvider(
-                buildProvider(integrationEventsService, 'someaddon'),
-            ),
-        ).toThrow(/already registered/);
-    });
-
     test('registerProvider masks the new provider sensitive params', async () => {
         const { addonService, integrationEventsService } = getSetup();
         addonService.registerProvider(

--- a/src/lib/services/addon-service.ts
+++ b/src/lib/services/addon-service.ts
@@ -2,6 +2,7 @@ import memoizee from 'memoizee';
 import joi from 'joi';
 const { ValidationError } = joi;
 import { getAddons, type IAddonProviders } from '../addons/index.js';
+import type Addon from '../addons/addon.js';
 import {
     AddonConfigCreatedEvent,
     AddonConfigDeletedEvent,
@@ -120,6 +121,16 @@ export default class AddonService {
             o[definition.name] = sensitiveParams;
             return o;
         }, {});
+    }
+
+    registerProvider(provider: Addon): void {
+        if (this.addonProviders[provider.name]) {
+            throw new Error(
+                `Addon provider "${provider.name}" is already registered`,
+            );
+        }
+        this.addonProviders[provider.name] = provider;
+        this.sensitiveParams = this.loadSensitiveParams(this.addonProviders);
     }
 
     registerEventHandler(): void {

--- a/src/lib/services/addon-service.ts
+++ b/src/lib/services/addon-service.ts
@@ -2,7 +2,7 @@ import memoizee from 'memoizee';
 import joi from 'joi';
 const { ValidationError } = joi;
 import { getAddons, type IAddonProviders } from '../addons/index.js';
-import type { IAddonProvider } from '../addons/addon.js';
+import type Addon from '../addons/addon.js';
 import {
     AddonConfigCreatedEvent,
     AddonConfigDeletedEvent,
@@ -123,7 +123,7 @@ export default class AddonService {
         }, {});
     }
 
-    registerProvider(provider: IAddonProvider): void {
+    registerProvider(provider: Addon): void {
         if (this.addonProviders[provider.name]) {
             this.logger.error(
                 `Addon provider "${provider.name}" is already registered`,

--- a/src/lib/services/addon-service.ts
+++ b/src/lib/services/addon-service.ts
@@ -2,7 +2,7 @@ import memoizee from 'memoizee';
 import joi from 'joi';
 const { ValidationError } = joi;
 import { getAddons, type IAddonProviders } from '../addons/index.js';
-import type Addon from '../addons/addon.js';
+import type { IAddonProvider } from '../addons/addon.js';
 import {
     AddonConfigCreatedEvent,
     AddonConfigDeletedEvent,
@@ -123,11 +123,12 @@ export default class AddonService {
         }, {});
     }
 
-    registerProvider(provider: Addon): void {
+    registerProvider(provider: IAddonProvider): void {
         if (this.addonProviders[provider.name]) {
-            throw new Error(
+            this.logger.error(
                 `Addon provider "${provider.name}" is already registered`,
             );
+            return;
         }
         this.addonProviders[provider.name] = provider;
         this.sensitiveParams = this.loadSensitiveParams(this.addonProviders);


### PR DESCRIPTION
Adds `registerProvider` so addon providers can be registered with
`AddonService` after construction, and exports the `Addon` base class from
`unleash-server`.
