### PR TITLE
feat: gate servicenow addon behind serviceNowIntegration flag

### DIFF
--- a/src/lib/routes/admin-api/addon.ts
+++ b/src/lib/routes/admin-api/addon.ts
@@ -206,8 +206,15 @@ Note: passing \`null\` as a value for the description property will set it to an
     }
 
     async getAddons(_req: Request, res: Response<AddonsSchema>): Promise<void> {
-        const addons = await this.addonService.getAddons();
-        const providers = this.addonService.getProviderDefinitions();
+        let addons = await this.addonService.getAddons();
+        let providers = this.addonService.getProviderDefinitions();
+
+        if (!this.flagResolver.isEnabled('serviceNowIntegration')) {
+            addons = addons.filter((addon) => addon.provider !== 'servicenow');
+            providers = providers.filter(
+                (provider) => provider.name !== 'servicenow',
+            );
+        }
 
         this.openApiService.respondWithValidation(200, res, addonsSchema.$id, {
             addons: serializeDates(addons),


### PR DESCRIPTION
Filter servicenow addons and provider definition out of the getAddons listing when the serviceNowIntegration flag is disabled.
