### PR TITLE
chore: use OIDC for static asset publishing

### DIFF
--- a/.github/workflows/notify_enterprise.yaml
+++ b/.github/workflows/notify_enterprise.yaml
@@ -7,6 +7,10 @@ on:
     paths-ignore:
       - coverage/**
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -48,9 +52,9 @@ jobs:
           pnpm build
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          role-to-assume: ${{ secrets.AWS_STATIC_ASSETS_ROLE_ARN }}
+          role-session-name: github-actions-unleash
       - name: Get the commit hash
         id: get_commit_hash
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,9 +46,9 @@ jobs:
           npm publish --tag ${TAG:-latest}
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          role-to-assume: ${{ secrets.AWS_STATIC_ASSETS_ROLE_ARN }}
+          role-session-name: github-actions-unleash
       - name: Publish static assets to S3
         run: |
           aws s3 cp frontend/build s3://getunleash-static/unleash/v${{ inputs.version }} --recursive

--- a/.github/workflows/update_contributors.yaml
+++ b/.github/workflows/update_contributors.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,9 +28,9 @@ jobs:
           ./svg-contributors/bin/contributors -o unleash -n unleash -l 500
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          role-to-assume: ${{ secrets.AWS_STATIC_ASSETS_ROLE_ARN }}
+          role-session-name: github-actions-unleash
       - name: Publish static assets to S3
         run: |
           ls -l


### PR DESCRIPTION
Replace long-lived AWS credentials with GitHub OIDC when publishing static assets to S3
