### PR TITLE
feat: drive SDK flight recorder from feature flag

### DIFF
--- a/frontend/src/component/providers/FlightRecorderProvider/FlightRecorderProvider.tsx
+++ b/frontend/src/component/providers/FlightRecorderProvider/FlightRecorderProvider.tsx
@@ -4,7 +4,8 @@ import {
     createFlightRecorder,
     type FlightRecorder,
 } from '@unleash/sdk-flight-recorder';
-import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
+import { useUiFlag } from 'hooks/useUiFlag';
+import { getVariantValue, type Variant } from 'utils/variants';
 import { FlightRecorderContext } from 'contexts/FlightRecorderContext';
 
 // Custom UI events are low-frequency, so the periodic timer does the flushing
@@ -15,8 +16,8 @@ const BATCH = { flushAt: 100 };
 export const FlightRecorderProvider: FC<{ children?: React.ReactNode }> = ({
     children,
 }) => {
-    const { uiConfig } = useUiConfig();
-    const url = uiConfig?.flightRecorderUrl;
+    const flag = useUiFlag('flightRecorderFrontend');
+    const url = getVariantValue(flag as Variant);
 
     const [recorder, setRecorder] = useState<FlightRecorder | null>(null);
 

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -41,7 +41,6 @@ export interface IUiConfig {
     samlConfiguredThroughEnv?: boolean;
     maxSessionsCount?: number;
     unleashContext?: IMutableContext;
-    flightRecorderUrl?: string;
 }
 
 export type UiFlags = {

--- a/src/lib/__snapshots__/create-config.test.ts.snap
+++ b/src/lib/__snapshots__/create-config.test.ts.snap
@@ -146,7 +146,6 @@ exports[`should create default config 1`] = `
     "enableHeapSnapshotEnpoint": false,
     "enableRequestLogger": false,
     "enableScheduledCreatedByMigration": false,
-    "flightRecorderUrl": undefined,
     "gracefulShutdownEnable": true,
     "gracefulShutdownTimeout": 1000,
     "headersTimeout": 61000,

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -295,7 +295,6 @@ const defaultServerOption: IServerOption = {
     cdnPrefix: process.env.CDN_PREFIX,
     edgeUrl: process.env.EDGE_URL,
     unleashUrl: process.env.UNLEASH_URL || 'http://localhost:4242',
-    flightRecorderUrl: process.env.FLIGHT_RECORDER_FRONTEND_URL,
     logRocketAppId: process.env.LOGROCKET_APP_ID,
     serverMetrics: true,
     enableHeapSnapshotEnpoint: parseEnvVarBoolean(

--- a/src/lib/middleware/secure-headers.ts
+++ b/src/lib/middleware/secure-headers.ts
@@ -55,9 +55,13 @@ const secureHeaders: (config: IUnleashConfig) => RequestHandler = (config) => {
         const logRocketConnectSrc = logRocketEnabled
             ? LOGROCKET_CONNECT_SRC
             : [];
-        const flightRecorderSrc = flightRecorderConnectSrc(
-            config.server.flightRecorderUrl,
+        const flightRecorderVariant = config.flagResolver.getVariant(
+            'flightRecorderFrontend',
         );
+        const flightRecorderUrl = flightRecorderVariant.enabled
+            ? flightRecorderVariant.payload?.value
+            : undefined;
+        const flightRecorderSrc = flightRecorderConnectSrc(flightRecorderUrl);
         const workerSrc = logRocketEnabled ? ["'self'", 'blob:'] : ["'self'"];
         const styleSrc = ["'self'"];
         if (includeUnsafeInline) {

--- a/src/lib/openapi/spec/ui-config-schema.ts
+++ b/src/lib/openapi/spec/ui-config-schema.ts
@@ -49,12 +49,6 @@ export const uiConfigSchema = {
             description: 'The URL of the Unleash instance.',
             example: 'https://unleash.mycompany.com/enterprise',
         },
-        flightRecorderUrl: {
-            type: 'string',
-            description:
-                'The URL the frontend flight recorder posts custom UI events to. When unset, the flight recorder stays disabled.',
-            example: 'https://recorder.mycompany.com',
-        },
         logRocketAppId: {
             type: 'string',
             description:

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -105,7 +105,6 @@ export interface IServerOption {
     cdnPrefix?: string;
     edgeUrl?: string;
     unleashUrl: string;
-    flightRecorderUrl?: string;
     logRocketAppId?: string;
     serverMetrics: boolean;
     enableHeapSnapshotEnpoint: boolean;

--- a/src/lib/ui-config/ui-config-service.ts
+++ b/src/lib/ui-config/ui-config-service.ts
@@ -125,7 +125,6 @@ export class UiConfigService {
             emailEnabled: this.emailService.isEnabled(),
             edgeUrl: this.config.server.edgeUrl,
             unleashUrl: this.config.server.unleashUrl,
-            flightRecorderUrl: this.config.server.flightRecorderUrl,
             logRocketAppId: this.config.server.logRocketAppId,
             baseUriPath: this.config.server.baseUriPath,
             authenticationType: this.config.authentication?.type,


### PR DESCRIPTION
read flight recorder url from a flag instead of env var.
csp response headers are still resolved at startup only but we can runtime control browser data sending at runtime