### PR TITLE
chore: bump @unleash/sdk-flight-recorder to 0.6.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,7 +84,7 @@
     "@uiw/codemirror-theme-duotone": "4.25.10",
     "@uiw/react-codemirror": "4.25.10",
     "@unleash/proxy-client-react": "5.1.0",
-    "@unleash/sdk-flight-recorder": "^0.5.0",
+    "@unleash/sdk-flight-recorder": "^0.6.0",
     "@vitejs/plugin-react": "6.0.2",
     "cartesian": "^1.0.1",
     "chart.js": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,7 +245,7 @@ importers:
         version: 2.4.1
       unleash-client:
         specifier: ^6.10.1
-        version: 6.11.0
+        version: 6.11.0(supports-color@8.1.1)
     devDependencies:
       '@apidevtools/swagger-parser':
         specifier: 12.1.0
@@ -525,8 +525,8 @@ importers:
         specifier: 5.1.0
         version: 5.1.0(unleash-proxy-client@3.8.0)
       '@unleash/sdk-flight-recorder':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@vitejs/plugin-react':
         specifier: 6.0.2
         version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.101.0)(yaml@2.8.4)))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.101.0)(yaml@2.8.4))
@@ -2397,8 +2397,8 @@ packages:
     peerDependencies:
       unleash-proxy-client: ^3.8.0
 
-  '@unleash/sdk-flight-recorder@0.5.0':
-    resolution: {integrity: sha512-ObKmE6eklndM44BA8xY9elaV3RDTh0rb7mqsNVvPDd4GfoAStcGoa/S3LQ4cOu98Hc47IOchhYp4P+ja77DrXg==}
+  '@unleash/sdk-flight-recorder@0.6.0':
+    resolution: {integrity: sha512-V4Zs1E7PwQ2gKJvgzClu3aBhZCslG5eGG29Gq8ZXIUkPVVCRYuSz/he5iegTlHrCkpaVh2da0vNu2boGDo6n/g==}
     engines: {node: '>=20'}
 
   '@vitejs/plugin-react@6.0.2':
@@ -7550,13 +7550,13 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@npmcli/agent@4.0.2':
+  '@npmcli/agent@4.0.2(supports-color@8.1.1)':
     dependencies:
       agent-base: 7.1.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 11.5.1
-      socks-proxy-agent: 8.0.5
+      socks-proxy-agent: 8.0.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8489,7 +8489,7 @@ snapshots:
     dependencies:
       unleash-proxy-client: 3.8.0
 
-  '@unleash/sdk-flight-recorder@0.5.0':
+  '@unleash/sdk-flight-recorder@0.6.0':
     dependencies:
       ky: 2.0.2
 
@@ -10809,10 +10809,10 @@ snapshots:
 
   make-error@1.3.6: {}
 
-  make-fetch-happen@15.0.6:
+  make-fetch-happen@15.0.6(supports-color@8.1.1):
     dependencies:
       '@gar/promise-retry': 1.0.3
-      '@npmcli/agent': 4.0.2
+      '@npmcli/agent': 4.0.2(supports-color@8.1.1)
       '@npmcli/redact': 4.0.0
       cacache: 20.0.4
       http-cache-semantics: 4.2.0
@@ -12253,7 +12253,7 @@ snapshots:
       dot-case: 3.0.4
       tslib: 2.8.1
 
-  socks-proxy-agent@8.0.5:
+  socks-proxy-agent@8.0.5(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -12776,14 +12776,14 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unleash-client@6.11.0:
+  unleash-client@6.11.0(supports-color@8.1.1):
     dependencies:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       ip-address: 10.2.0
       launchdarkly-eventsource: 2.2.0
       lru-cache: 11.5.1
-      make-fetch-happen: 15.0.6
+      make-fetch-happen: 15.0.6(supports-color@8.1.1)
       murmurhash3js: 3.0.1
       proxy-from-env: 1.1.0
       re2js: 1.4.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ minimumReleaseAge: 10080
 minimumReleaseAgeIgnoreMissingTime: false
 minimumReleaseAgeExclude:
   - '@unleash/proxy-client-react'
+  - '@unleash/sdk-flight-recorder'
   # Renovate security update: esbuild@0.28.1
   - '@esbuild/aix-ppc64@0.28.1'
   - '@esbuild/android-arm@0.28.1'


### PR DESCRIPTION
## What

Bumps `@unleash/sdk-flight-recorder` `^0.5.0` → `^0.6.0` in the frontend.

## Notes

- `0.6.0` was published today, within the 7-day `minimumReleaseAge` supply-chain gate, so it's added to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` — same treatment as the first-party `@unleash/proxy-client-react` already there.
- Lockfile also shows incidental `(supports-color@8.1.1)` peer-context annotations on `unleash-client`/`make-fetch-happen`/`@npmcli/agent`/`socks-proxy-agent` — no version drift, just pnpm normalizing peer resolution.