### PR TITLE
fix: close any open page before opening a new pageview

### DIFF
--- a/frontend/src/component/providers/FlightRecorderProvider/usePageViewTracking.ts
+++ b/frontend/src/component/providers/FlightRecorderProvider/usePageViewTracking.ts
@@ -49,6 +49,8 @@ export const usePageViewTracking = (recorder: FlightRecorder | null): void => {
         if (!recorder || !contextReady) {
             return;
         }
+        // Close any still-open page first; the pageshow path has no preceding pageleave.
+        emitPageLeave(recorder);
         const referrer = previousPathRef.current ?? document.referrer;
         previousPathRef.current = path;
 
@@ -73,12 +75,10 @@ export const usePageViewTracking = (recorder: FlightRecorder | null): void => {
         if (!recorder || !contextReady) {
             return;
         }
-        emitPageLeave(recorder);
         emitPageView(pathname);
     }, [recorder, contextReady, pathname]);
 
-    // This hook owns the unload flush so the provider doesn't also flush on pagehide and
-    // double-flush. Captured recorder lands the closing leave in the torn-down instance.
+    // Captured recorder lands the closing leave in the instance being torn down.
     useEffect(() => {
         if (!recorder) {
             return;


### PR DESCRIPTION
emitPageView now stops and records the prior page's engaged time before opening the next, so the bfcache pageshow path (which has no preceding pagehide) can no longer orphan a live tracker. The navigation effect no longer needs its own emitPageLeave.

## OSS PR checklist

- [ ] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [ ] I have added tests or explained why tests are not needed.
- [ ] I have updated documentation where relevant.
