### PR TITLE
fix(flight-recorder): normalize trailing slash in tracked page paths

### DIFF
--- a/frontend/src/component/providers/FlightRecorderProvider/usePageViewTracking.test.tsx
+++ b/frontend/src/component/providers/FlightRecorderProvider/usePageViewTracking.test.tsx
@@ -62,6 +62,12 @@ const Harness = ({ recorder }: { recorder: FakeRecorder | null }) => {
             <button type='button' onClick={() => setTick(tick + 1)}>
                 re-render without navigating
             </button>
+            <button
+                type='button'
+                onClick={() => navigate('/projects/default/settings/')}
+            >
+                add a trailing slash
+            </button>
         </>
     );
 };
@@ -234,6 +240,34 @@ it('does not record a duplicate page view while the path is unchanged', async ()
     );
     await userEvent.click(
         screen.getByRole('button', { name: 'change only the query string' }),
+    );
+
+    expect(recorder.record).toHaveBeenCalledTimes(1);
+});
+
+it('records one screen without a trailing slash regardless of how the URL was written', async () => {
+    respondWithIdentity();
+
+    // The same screen reached with a trailing slash must not become a second path.
+    render(<Harness recorder={recorder} />, {
+        route: '/projects/default/settings/',
+    });
+    await screen.findByText('config-ready');
+
+    expect(pageviews()[0].payload.path).toBe('/projects/default/settings');
+});
+
+it('does not record a new page view when only a trailing slash is added to the path', async () => {
+    respondWithIdentity();
+
+    render(<Harness recorder={recorder} />, {
+        route: '/projects/default/settings',
+    });
+    await screen.findByText('config-ready');
+
+    // A trailing slash names the same screen, so it is not a new page.
+    await userEvent.click(
+        screen.getByRole('button', { name: 'add a trailing slash' }),
     );
 
     expect(recorder.record).toHaveBeenCalledTimes(1);

--- a/frontend/src/component/providers/FlightRecorderProvider/usePageViewTracking.ts
+++ b/frontend/src/component/providers/FlightRecorderProvider/usePageViewTracking.ts
@@ -8,10 +8,15 @@ import {
     startEngagedTimeTracker,
 } from './engagedTime';
 
-// Full path is stored as-is; collapsing ids into templates (/projects/:projectId) is
-// done downstream at query time, so it stays editable without a frontend deploy.
+// Trailing slashes are the only divergence react-router leaves in pathname (query string
+// and hash are already excluded), so '/x/settings/' and '/x/settings' would otherwise split
+// one screen across two stored paths. Normalize to the slash-free form at record time;
+// id->template collapsing stays downstream at query time so it's editable without a deploy.
+const normalizePath = (path: string): string => path.replace(/\/+$/, '') || '/';
+
 export const usePageViewTracking = (recorder: FlightRecorder | null): void => {
     const { pathname } = useLocation();
+    const normalizedPath = normalizePath(pathname);
     const { uiConfig } = useUiConfig();
 
     const context = uiConfig?.unleashContext;
@@ -44,13 +49,15 @@ export const usePageViewTracking = (recorder: FlightRecorder | null): void => {
         currentPageRef.current = null;
     });
 
-    const emitPageView = useEffectEvent((path: string) => {
+    const emitPageView = useEffectEvent((rawPath: string) => {
         // pageshow path bypasses the navigation effect's identity gate, so re-check here.
         if (!recorder || !contextReady) {
             return;
         }
         // Close any still-open page first; the pageshow path has no preceding pageleave.
         emitPageLeave(recorder);
+        // pageshow passes a raw location.pathname, so normalize here too, not only at the effect.
+        const path = normalizePath(rawPath);
         const referrer = previousPathRef.current ?? document.referrer;
         previousPathRef.current = path;
 
@@ -75,8 +82,8 @@ export const usePageViewTracking = (recorder: FlightRecorder | null): void => {
         if (!recorder || !contextReady) {
             return;
         }
-        emitPageView(pathname);
-    }, [recorder, contextReady, pathname]);
+        emitPageView(normalizedPath);
+    }, [recorder, contextReady, normalizedPath]);
 
     // Captured recorder lands the closing leave in the instance being torn down.
     useEffect(() => {


### PR DESCRIPTION
## What

react-router leaves a trailing slash on some routes (e.g. the project settings index), so `/projects/x/settings/` and `/projects/x/settings` were recorded as two separate `pageview` paths for the same screen. That splits the screen's view counts in any `GROUP BY path` query, and the query-time template collapse doesn't fix it either since it only rewrites id segments.

## Change

Normalize the pathname to its slash-free form at record time — before emitting the `pageview` and before deriving the `referrer` from the previous path — so one screen is always one path. Root `/` is preserved. Query string and hash are already excluded from react-router's `pathname`, so the trailing slash was the only divergence.

## Tests

- The same screen reached with a trailing slash records the slash-free path.
- Adding only a trailing slash does not record a second page view.