### PR TITLE
feat: add pathname to custom tracking events

### DIFF
--- a/frontend/src/component/providers/FlightRecorderProvider/usePageViewTracking.test.tsx
+++ b/frontend/src/component/providers/FlightRecorderProvider/usePageViewTracking.test.tsx
@@ -139,7 +139,11 @@ it('records a page leave carrying engaged time, paired to the page left, before 
             eventType: 'custom',
             eventName: 'pageleave',
             context: { userId: 'u-1' },
-            payload: { pageviewId: landingId, engagedMs: expect.any(Number) },
+            payload: {
+                pageviewId: landingId,
+                path: '/projects/default/settings',
+                engagedMs: expect.any(Number),
+            },
         },
     ]);
 });
@@ -162,7 +166,11 @@ it('records a page leave for the current page when the tab is closed', async () 
             eventType: 'custom',
             eventName: 'pageleave',
             context: { userId: 'u-1' },
-            payload: { pageviewId: landingId, engagedMs: expect.any(Number) },
+            payload: {
+                pageviewId: landingId,
+                path: '/projects/default/settings',
+                engagedMs: expect.any(Number),
+            },
         },
     ]);
     expect(recorder.flush).toHaveBeenCalledWith({ keepalive: true });
@@ -221,7 +229,11 @@ it('records a page leave for the current page when tracking is torn down', async
             eventType: 'custom',
             eventName: 'pageleave',
             context: { userId: 'u-1' },
-            payload: { pageviewId: landingId, engagedMs: expect.any(Number) },
+            payload: {
+                pageviewId: landingId,
+                path: '/projects/default/settings',
+                engagedMs: expect.any(Number),
+            },
         },
     ]);
 });

--- a/frontend/src/component/providers/FlightRecorderProvider/usePageViewTracking.ts
+++ b/frontend/src/component/providers/FlightRecorderProvider/usePageViewTracking.ts
@@ -3,16 +3,12 @@ import { useLocation } from 'react-router';
 import type { FlightRecorder } from '@unleash/sdk-flight-recorder';
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { createUuid } from 'utils/createUuid';
+import { normalizePath } from 'utils/normalizePath';
+import { RESERVED_EVENT_NAMES } from 'utils/trackingEvents';
 import {
     type EngagedTimeTracker,
     startEngagedTimeTracker,
 } from './engagedTime';
-
-// Trailing slashes are the only divergence react-router leaves in pathname (query string
-// and hash are already excluded), so '/x/settings/' and '/x/settings' would otherwise split
-// one screen across two stored paths. Normalize to the slash-free form at record time;
-// id->template collapsing stays downstream at query time so it's editable without a deploy.
-const normalizePath = (path: string): string => path.replace(/\/+$/, '') || '/';
 
 export const usePageViewTracking = (recorder: FlightRecorder | null): void => {
     const { pathname } = useLocation();
@@ -38,7 +34,7 @@ export const usePageViewTracking = (recorder: FlightRecorder | null): void => {
         }
         recorder.record({
             eventType: 'custom',
-            eventName: 'pageleave',
+            eventName: RESERVED_EVENT_NAMES.pageLeave,
             context: { ...context },
             payload: {
                 pageviewId: page.pageviewId,
@@ -64,7 +60,7 @@ export const usePageViewTracking = (recorder: FlightRecorder | null): void => {
         const pageviewId = createUuid();
         recorder.record({
             eventType: 'custom',
-            eventName: 'pageview',
+            eventName: RESERVED_EVENT_NAMES.pageView,
             context: { ...context },
             payload: {
                 pageviewId,

--- a/frontend/src/component/providers/FlightRecorderProvider/usePageViewTracking.ts
+++ b/frontend/src/component/providers/FlightRecorderProvider/usePageViewTracking.ts
@@ -19,6 +19,7 @@ export const usePageViewTracking = (recorder: FlightRecorder | null): void => {
     const previousPathRef = useRef<string | null>(null);
     const currentPageRef = useRef<{
         pageviewId: string;
+        path: string;
         tracker: EngagedTimeTracker;
     } | null>(null);
 
@@ -38,6 +39,7 @@ export const usePageViewTracking = (recorder: FlightRecorder | null): void => {
             context: { ...context },
             payload: {
                 pageviewId: page.pageviewId,
+                path: page.path,
                 engagedMs: page.tracker.engagedMs(),
             },
         });
@@ -70,6 +72,7 @@ export const usePageViewTracking = (recorder: FlightRecorder | null): void => {
         });
         currentPageRef.current = {
             pageviewId,
+            path,
             tracker: startEngagedTimeTracker(),
         };
     });

--- a/frontend/src/component/providers/TrackerProvider/EventTrackerProvider.test.tsx
+++ b/frontend/src/component/providers/TrackerProvider/EventTrackerProvider.test.tsx
@@ -64,6 +64,6 @@ test('trackEvent fans out to Plausible and the flight recorder', async () => {
         eventType: 'custom',
         eventName: 'invite',
         context: { userId: 'u-1', email: 'already-hashed-email' },
-        payload: { eventType: 'test' },
+        payload: { eventType: 'test', path: '/' },
     });
 });

--- a/frontend/src/component/providers/TrackerProvider/EventTrackerProvider.tsx
+++ b/frontend/src/component/providers/TrackerProvider/EventTrackerProvider.tsx
@@ -1,5 +1,7 @@
 import type React from 'react';
 import { type FC, useContext, useMemo, useRef } from 'react';
+import { useLocation } from 'react-router';
+import { normalizePath } from 'utils/normalizePath';
 import { PlausibleContext } from 'contexts/PlausibleContext';
 import { FlightRecorderContext } from 'contexts/FlightRecorderContext';
 import {
@@ -14,6 +16,7 @@ export const EventTrackerProvider: FC<{ children?: React.ReactNode }> = ({
     const plausible = useContext(PlausibleContext);
     const flightRecorder = useContext(FlightRecorderContext);
     const { uiConfig } = useUiConfig();
+    const { pathname } = useLocation();
 
     const plausibleRef = useRef(plausible);
     plausibleRef.current = plausible;
@@ -21,6 +24,8 @@ export const EventTrackerProvider: FC<{ children?: React.ReactNode }> = ({
     flightRecorderRef.current = flightRecorder;
     const unleashContextRef = useRef(uiConfig?.unleashContext);
     unleashContextRef.current = uiConfig?.unleashContext;
+    const pathRef = useRef(pathname);
+    pathRef.current = pathname;
 
     const tracker = useMemo<EventTracker>(
         () => ({
@@ -30,7 +35,10 @@ export const EventTrackerProvider: FC<{ children?: React.ReactNode }> = ({
                     eventType: 'custom',
                     eventName,
                     context: { ...unleashContextRef.current },
-                    payload: options?.props,
+                    payload: {
+                        ...options?.props,
+                        path: normalizePath(pathRef.current),
+                    },
                 });
             },
         }),

--- a/frontend/src/contexts/EventTrackerContext.ts
+++ b/frontend/src/contexts/EventTrackerContext.ts
@@ -1,12 +1,18 @@
 import { createContext } from 'react';
-import type { CustomEvents } from 'utils/trackingEvents';
+import type { CustomEvents, ReservedEventName } from 'utils/trackingEvents';
 
+// `path` is reserved: the provider injects the current route so custom events correlate
+// with page views on the same screen.
 export type TrackEventOptions = {
-    props?: Record<string, string | number | boolean>;
+    props?: Record<string, string | number | boolean> & { path?: never };
 };
 
+// pageview/pageleave are emitted internally by page-view tracking; excluding them here
+// makes trackEvent('pageview') a compile error even if someone adds them to CustomEvents.
+export type TrackableEvent = Exclude<CustomEvents, ReservedEventName>;
+
 export type EventTracker = {
-    trackEvent: (event: CustomEvents, options?: TrackEventOptions) => void;
+    trackEvent: (event: TrackableEvent, options?: TrackEventOptions) => void;
 };
 
 export const EventTrackerContext = createContext<EventTracker | null>(null);

--- a/frontend/src/utils/normalizePath.ts
+++ b/frontend/src/utils/normalizePath.ts
@@ -1,0 +1,3 @@
+// Remove trailing slashes so one screen is always recorded under the same `path`.
+export const normalizePath = (path: string): string =>
+    path.replace(/\/+$/, '') || '/';

--- a/frontend/src/utils/trackingEvents.ts
+++ b/frontend/src/utils/trackingEvents.ts
@@ -89,3 +89,12 @@ export type CustomEvents =
     | 'external-impact-metrics'
     | 'help-resources'
     | 'access-requests-notification';
+
+// Flight recorder uses these reserved names internally; they are not available for custom events.
+export const RESERVED_EVENT_NAMES = {
+    pageView: 'pageview',
+    pageLeave: 'pageleave',
+} as const;
+
+export type ReservedEventName =
+    (typeof RESERVED_EVENT_NAMES)[keyof typeof RESERVED_EVENT_NAMES];


### PR DESCRIPTION
Records the current route path on custom tracking events so they can be correlated with page views by page.

The `path` prop and the `pageview`/`pageleave` event names are reserved at the type level, so callers get a compile error if they try to set them.