### PR TITLE
feat: make project onboarding steps visible to LogRocket

### DIFF
--- a/frontend/src/component/onboarding/flow/ProjectOnboarding.tsx
+++ b/frontend/src/component/onboarding/flow/ProjectOnboarding.tsx
@@ -104,7 +104,7 @@ export const ProjectOnboarding = ({
                 </TitleRow>
             </StyledAccordionSummary>
             <StyledAccordionDetails>
-                <Actions>
+                <Actions data-public>
                     <CreateFlagStep
                         state={stepState(step, 1)}
                         refetchFeatures={refetchFeatures}


### PR DESCRIPTION
Adds the `data-public` attribute to the container wrapping the three project onboarding steps (Create a feature flag / Connect SDKs / Turn flag on) in `ProjectOnboarding.tsx`.
