### PR TITLE
feat: onboarding experiments from the demo workshop (5 flag-gated features)

### DIFF
--- a/frontend/src/component/demoProject/CreateDemoProjectButton.tsx
+++ b/frontend/src/component/demoProject/CreateDemoProjectButton.tsx
@@ -1,0 +1,44 @@
+import type { FC } from 'react';
+import type { ButtonProps } from '@mui/material';
+import AutoAwesome from '@mui/icons-material/AutoAwesome';
+import ResponsiveButton from 'component/common/ResponsiveButton/ResponsiveButton';
+import { CREATE_PROJECT } from 'component/providers/AccessProvider/permissions';
+import { useUiFlag } from 'hooks/useUiFlag';
+import { useSeedDemoProject } from './useSeedDemoProject.ts';
+
+type CreateDemoProjectButtonProps = {
+    variant?: ButtonProps['variant'];
+};
+
+/**
+ * Seeds a pre-populated example project ("Demo: Online Shop") so that new
+ * users can explore a living project instead of an empty instance. Gated
+ * behind the `demoProjectSeeding` UI flag.
+ */
+export const CreateDemoProjectButton: FC<CreateDemoProjectButtonProps> = ({
+    variant = 'outlined',
+}) => {
+    const demoProjectSeedingEnabled = useUiFlag('demoProjectSeeding');
+    const { seedDemoProject, seeding } = useSeedDemoProject();
+
+    if (!demoProjectSeedingEnabled) {
+        return null;
+    }
+
+    return (
+        <ResponsiveButton
+            Icon={AutoAwesome}
+            onClick={seedDemoProject}
+            maxWidth='700px'
+            permission={CREATE_PROJECT}
+            disabled={seeding}
+            variant={variant}
+            tooltipProps={{
+                title: 'Create a pre-populated example project to explore flags, strategies, variants and segments',
+            }}
+            data-testid='CREATE_DEMO_PROJECT_BUTTON'
+        >
+            {seeding ? 'Creating example project...' : 'Create example project'}
+        </ResponsiveButton>
+    );
+};

--- a/frontend/src/component/demoProject/demoProjectTemplate.test.ts
+++ b/frontend/src/component/demoProject/demoProjectTemplate.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'vitest';
+import {
+    buildDemoImportPayload,
+    DEMO_PROJECT_ID,
+    DEMO_SEGMENT,
+    demoProjectImportData,
+    withoutSegments,
+} from './demoProjectTemplate.ts';
+
+describe('demoProjectTemplate', () => {
+    const featureNames = demoProjectImportData.features.map(
+        (feature) => feature.name,
+    );
+
+    test('contains the expected story flags', () => {
+        expect(featureNames).toEqual([
+            'new-checkout',
+            'dark-mode',
+            'beta-search',
+            'holiday-banner',
+            'legacy-payment-kill',
+        ]);
+        demoProjectImportData.features.forEach((feature) => {
+            expect(feature.description).toBeTruthy();
+            expect(feature.project).toBe(DEMO_PROJECT_ID);
+            expect(feature.archived).toBe(false);
+        });
+    });
+
+    test('every strategy references an included feature', () => {
+        demoProjectImportData.featureStrategies.forEach((strategy) => {
+            expect(featureNames).toContain(strategy.featureName);
+        });
+    });
+
+    test('flexibleRollout strategies define rollout, stickiness and groupId', () => {
+        demoProjectImportData.featureStrategies
+            .filter((strategy) => strategy.name === 'flexibleRollout')
+            .forEach((strategy) => {
+                expect(strategy.parameters).toMatchObject({
+                    rollout: expect.any(String),
+                    stickiness: expect.any(String),
+                    groupId: strategy.featureName,
+                });
+            });
+    });
+
+    test('every feature has an environment entry where name matches the feature', () => {
+        // The import endpoint resolves the feature by `name` when setting the
+        // enabled state and by `featureName` when importing variants.
+        const environmentEntries =
+            demoProjectImportData.featureEnvironments ?? [];
+        expect(environmentEntries.map((entry) => entry.name)).toEqual(
+            featureNames,
+        );
+        environmentEntries.forEach((entry) => {
+            expect(entry.featureName).toBe(entry.name);
+        });
+    });
+
+    test('variant weights add up to 1000 per feature environment', () => {
+        const withVariants = (
+            demoProjectImportData.featureEnvironments ?? []
+        ).filter((entry) => (entry.variants ?? []).length > 0);
+        expect(withVariants.length).toBeGreaterThan(0);
+        withVariants.forEach((entry) => {
+            const totalWeight = (entry.variants ?? []).reduce(
+                (total, variant) => total + variant.weight,
+                0,
+            );
+            expect(totalWeight).toBe(1000);
+        });
+    });
+
+    test('segments referenced by strategies are declared and match the pre-created segment', () => {
+        const declaredSegmentIds = (demoProjectImportData.segments ?? []).map(
+            (segment) => segment.id,
+        );
+        const referencedSegmentIds =
+            demoProjectImportData.featureStrategies.flatMap(
+                (strategy) => strategy.segments ?? [],
+            );
+        expect(referencedSegmentIds.length).toBeGreaterThan(0);
+        referencedSegmentIds.forEach((segmentId) => {
+            expect(declaredSegmentIds).toContain(segmentId);
+        });
+        expect(
+            demoProjectImportData.segments?.map((segment) => segment.name),
+        ).toContain(DEMO_SEGMENT.name);
+    });
+
+    test('feature tags reference included features and declared tag types', () => {
+        const tagTypeNames = demoProjectImportData.tagTypes.map(
+            (tagType) => tagType.name,
+        );
+        (demoProjectImportData.featureTags ?? []).forEach((featureTag) => {
+            expect(featureNames).toContain(featureTag.featureName);
+            expect(tagTypeNames).toContain(featureTag.tagType);
+        });
+    });
+
+    test('buildDemoImportPayload targets the demo project and given environment', () => {
+        const payload = buildDemoImportPayload('development');
+        expect(payload.project).toBe(DEMO_PROJECT_ID);
+        expect(payload.environment).toBe('development');
+        expect(payload.data).toBe(demoProjectImportData);
+    });
+
+    test('withoutSegments strips all segment references', () => {
+        const stripped = withoutSegments(buildDemoImportPayload('production'));
+        expect(stripped.data.segments).toEqual([]);
+        stripped.data.featureStrategies.forEach((strategy) => {
+            expect(strategy).not.toHaveProperty('segments');
+        });
+        // The original template must remain untouched.
+        expect(
+            demoProjectImportData.featureStrategies.some(
+                (strategy) => (strategy.segments ?? []).length > 0,
+            ),
+        ).toBe(true);
+    });
+});

--- a/frontend/src/component/demoProject/demoProjectTemplate.ts
+++ b/frontend/src/component/demoProject/demoProjectTemplate.ts
@@ -1,0 +1,258 @@
+import type { ExportResultSchema, ImportTogglesSchema } from 'openapi';
+import type { ISegmentPayload } from 'interfaces/segment';
+
+export const DEMO_PROJECT_ID = 'demo-app';
+export const DEMO_PROJECT_NAME = 'Demo: Online Shop';
+export const DEMO_PROJECT_DESCRIPTION =
+    'A seeded example project for a fictional online shop. Explore flags in different lifecycle stages: gradual rollouts, A/B experiments, constraints, segments and a stale kill switch.';
+
+/**
+ * The import endpoint does not create segments, it only maps them by name to
+ * segments that already exist. This segment is therefore created up front via
+ * the segments API before the import runs.
+ */
+export const DEMO_SEGMENT: ISegmentPayload = {
+    name: 'demo-beta-testers',
+    description:
+        'Demo segment: users who opted into the beta program of the online shop.',
+    constraints: [
+        {
+            contextName: 'userId',
+            operator: 'STR_ENDS_WITH',
+            values: ['@beta.example.com'],
+            caseInsensitive: true,
+            inverted: false,
+        },
+    ],
+};
+
+// Arbitrary local id used to reference the segment from strategies in the
+// import payload. The backend remaps it by name to the real segment id.
+const DEMO_SEGMENT_REF = 1;
+
+export const demoProjectImportData: ExportResultSchema = {
+    features: [
+        {
+            name: 'new-checkout',
+            description:
+                'This flag shows a gradual rollout in progress: 50% of users get the new checkout flow. Open the strategy and drag the rollout slider to change how many users are included.',
+            type: 'release',
+            project: DEMO_PROJECT_ID,
+            stale: false,
+            impressionData: false,
+            archived: false,
+        },
+        {
+            name: 'dark-mode',
+            description:
+                'This flag is fully rolled out to 100% of users. A flag in this state has completed its lifecycle: in a real project you would remove it from the code and archive it.',
+            type: 'release',
+            project: DEMO_PROJECT_ID,
+            stale: false,
+            impressionData: false,
+            archived: false,
+        },
+        {
+            name: 'beta-search',
+            description:
+                'This flag runs an A/B experiment: beta testers are split 50/50 between two search algorithms using variants. Open the flag and check the variants on the environment to see the split.',
+            type: 'experiment',
+            project: DEMO_PROJECT_ID,
+            stale: false,
+            impressionData: true,
+            archived: false,
+        },
+        {
+            name: 'holiday-banner',
+            description:
+                'This flag uses a strategy constraint: only visitors with country NO, SE or DK see the holiday banner. Edit the constraint on the strategy to target different countries.',
+            type: 'operational',
+            project: DEMO_PROJECT_ID,
+            stale: false,
+            impressionData: false,
+            archived: false,
+        },
+        {
+            name: 'legacy-payment-kill',
+            description:
+                'This kill switch is turned off and marked as stale: the legacy payment provider has been disabled and the flag is ready to be cleaned up from the codebase and archived.',
+            type: 'kill-switch',
+            project: DEMO_PROJECT_ID,
+            stale: true,
+            impressionData: false,
+            archived: false,
+        },
+    ],
+    featureStrategies: [
+        {
+            name: 'flexibleRollout',
+            featureName: 'new-checkout',
+            title: 'Gradual rollout to 50%',
+            disabled: false,
+            constraints: [],
+            parameters: {
+                rollout: '50',
+                stickiness: 'default',
+                groupId: 'new-checkout',
+            },
+        },
+        {
+            name: 'flexibleRollout',
+            featureName: 'dark-mode',
+            title: 'Rolled out to everyone',
+            disabled: false,
+            constraints: [],
+            parameters: {
+                rollout: '100',
+                stickiness: 'default',
+                groupId: 'dark-mode',
+            },
+        },
+        {
+            name: 'flexibleRollout',
+            featureName: 'beta-search',
+            title: 'Beta testers only',
+            disabled: false,
+            constraints: [],
+            segments: [DEMO_SEGMENT_REF],
+            parameters: {
+                rollout: '100',
+                stickiness: 'default',
+                groupId: 'beta-search',
+            },
+        },
+        {
+            name: 'flexibleRollout',
+            featureName: 'holiday-banner',
+            title: 'Nordic countries only',
+            disabled: false,
+            constraints: [
+                {
+                    contextName: 'country',
+                    operator: 'IN',
+                    values: ['NO', 'SE', 'DK'],
+                    caseInsensitive: true,
+                    inverted: false,
+                },
+            ],
+            parameters: {
+                rollout: '100',
+                stickiness: 'default',
+                groupId: 'holiday-banner',
+            },
+        },
+        {
+            name: 'flexibleRollout',
+            featureName: 'legacy-payment-kill',
+            title: 'Legacy payment provider',
+            disabled: false,
+            constraints: [],
+            parameters: {
+                rollout: '100',
+                stickiness: 'default',
+                groupId: 'legacy-payment-kill',
+            },
+        },
+    ],
+    // Note: `name` is used by the import endpoint to resolve the feature when
+    // setting the enabled state, so it must be the feature name (not the
+    // environment name). `featureName` is used when importing variants.
+    featureEnvironments: [
+        {
+            name: 'new-checkout',
+            featureName: 'new-checkout',
+            enabled: true,
+        },
+        {
+            name: 'dark-mode',
+            featureName: 'dark-mode',
+            enabled: true,
+        },
+        {
+            name: 'beta-search',
+            featureName: 'beta-search',
+            enabled: true,
+            variants: [
+                {
+                    name: 'search-algorithm-a',
+                    weight: 500,
+                    weightType: 'variable',
+                    stickiness: 'default',
+                    overrides: [],
+                },
+                {
+                    name: 'search-algorithm-b',
+                    weight: 500,
+                    weightType: 'variable',
+                    stickiness: 'default',
+                    overrides: [],
+                },
+            ],
+        },
+        {
+            name: 'holiday-banner',
+            featureName: 'holiday-banner',
+            enabled: true,
+        },
+        {
+            name: 'legacy-payment-kill',
+            featureName: 'legacy-payment-kill',
+            enabled: false,
+        },
+    ],
+    contextFields: [
+        {
+            name: 'country',
+            description:
+                'Demo context field: the country of the current visitor, used by the holiday-banner flag.',
+            stickiness: false,
+            sortOrder: 10,
+        },
+    ],
+    tagTypes: [
+        {
+            name: 'simple',
+            description: 'Used to simplify filtering of features',
+            icon: '#',
+        },
+    ],
+    featureTags: [
+        { featureName: 'new-checkout', tagType: 'simple', tagValue: 'demo' },
+        { featureName: 'dark-mode', tagType: 'simple', tagValue: 'demo' },
+        { featureName: 'beta-search', tagType: 'simple', tagValue: 'demo' },
+        { featureName: 'holiday-banner', tagType: 'simple', tagValue: 'demo' },
+        {
+            featureName: 'legacy-payment-kill',
+            tagType: 'simple',
+            tagValue: 'demo',
+        },
+    ],
+    segments: [{ id: DEMO_SEGMENT_REF, name: DEMO_SEGMENT.name }],
+};
+
+export const buildDemoImportPayload = (
+    environment: string,
+    project: string = DEMO_PROJECT_ID,
+): ImportTogglesSchema => ({
+    project,
+    environment,
+    data: demoProjectImportData,
+});
+
+/**
+ * Fallback used when the segment could not be created (e.g. missing
+ * permissions): importing data that references a non-existing segment is
+ * rejected by the backend, so we strip all segment references.
+ */
+export const withoutSegments = (
+    payload: ImportTogglesSchema,
+): ImportTogglesSchema => ({
+    ...payload,
+    data: {
+        ...payload.data,
+        segments: [],
+        featureStrategies: payload.data.featureStrategies.map(
+            ({ segments, ...strategy }) => strategy,
+        ),
+    },
+});

--- a/frontend/src/component/demoProject/useSeedDemoProject.ts
+++ b/frontend/src/component/demoProject/useSeedDemoProject.ts
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router';
+import useProjects from 'hooks/api/getters/useProjects/useProjects';
+import useProjectApi from 'hooks/api/actions/useProjectApi/useProjectApi';
+import { useImportApi } from 'hooks/api/actions/useImportApi/useImportApi';
+import { useSegmentsApi } from 'hooks/api/actions/useSegmentsApi/useSegmentsApi';
+import useToast from 'hooks/useToast';
+import { formatUnknownError } from 'utils/formatUnknownError';
+import {
+    buildDemoImportPayload,
+    DEMO_PROJECT_DESCRIPTION,
+    DEMO_PROJECT_ID,
+    DEMO_PROJECT_NAME,
+    DEMO_SEGMENT,
+    withoutSegments,
+} from './demoProjectTemplate.ts';
+
+const DEMO_PROJECT_PATH = `/projects/${DEMO_PROJECT_ID}`;
+const PREFERRED_ENVIRONMENT = 'development';
+
+const resolveEnvironment = (projectEnvironments?: string[]): string => {
+    const environments = (projectEnvironments ?? []).filter(
+        (environment) => environment !== 'default',
+    );
+    if (environments.includes(PREFERRED_ENVIRONMENT)) {
+        return PREFERRED_ENVIRONMENT;
+    }
+    return environments[0] ?? projectEnvironments?.[0] ?? PREFERRED_ENVIRONMENT;
+};
+
+const isAlreadyExistsError = (error: unknown): boolean =>
+    error instanceof Error && /exist/i.test(error.message);
+
+export const useSeedDemoProject = () => {
+    const { projects, refetch: refetchProjects } = useProjects();
+    const { createProject } = useProjectApi();
+    const { createImport } = useImportApi();
+    const { createSegment } = useSegmentsApi();
+    const { setToastData, setToastApiError } = useToast();
+    const navigate = useNavigate();
+    const [seeding, setSeeding] = useState(false);
+
+    const seedDemoProject = async () => {
+        if (seeding) {
+            return;
+        }
+
+        if (projects.some((project) => project.id === DEMO_PROJECT_ID)) {
+            setToastData({
+                type: 'success',
+                text: 'The example project already exists - taking you there.',
+            });
+            navigate(DEMO_PROJECT_PATH);
+            return;
+        }
+
+        setSeeding(true);
+        try {
+            let projectEnvironments: string[] | undefined;
+            let targetProject = DEMO_PROJECT_ID;
+            try {
+                const created = await createProject({
+                    id: DEMO_PROJECT_ID,
+                    name: DEMO_PROJECT_NAME,
+                    description: DEMO_PROJECT_DESCRIPTION,
+                });
+                projectEnvironments = created.environments;
+            } catch (error) {
+                if (isAlreadyExistsError(error)) {
+                    // Created in the meantime (or by someone else): just go there.
+                    setToastData({
+                        type: 'success',
+                        text: 'The example project already exists - taking you there.',
+                    });
+                    navigate(DEMO_PROJECT_PATH);
+                    return;
+                }
+                // Project creation is not available on OSS instances (the
+                // route only exists on Pro/Enterprise). Seed into an existing
+                // project instead of failing outright.
+                const fallback =
+                    projects.find((project) => project.id === 'default') ??
+                    projects[0];
+                if (!fallback) {
+                    throw error;
+                }
+                targetProject = fallback.id;
+            }
+
+            // The import endpoint only maps segments by name to existing
+            // segments, so the demo segment has to be created up front. If it
+            // fails (already exists, missing permission) we still try to
+            // import - with a segment-free fallback below.
+            let segmentAvailable = true;
+            try {
+                await createSegment(DEMO_SEGMENT);
+            } catch (error) {
+                segmentAvailable = isAlreadyExistsError(error);
+            }
+
+            const payload = buildDemoImportPayload(
+                resolveEnvironment(projectEnvironments),
+                targetProject,
+            );
+            try {
+                await createImport(
+                    segmentAvailable ? payload : withoutSegments(payload),
+                );
+            } catch (error) {
+                if (!segmentAvailable) {
+                    throw error;
+                }
+                // The segment may still be unusable (e.g. bound to another
+                // project); retry once without segment references.
+                await createImport(withoutSegments(payload));
+            }
+
+            refetchProjects();
+            setToastData({
+                type: 'success',
+                text:
+                    targetProject === DEMO_PROJECT_ID
+                        ? 'Example project created. Take a look around and explore the flags!'
+                        : `Example flags seeded into the "${targetProject}" project. Take a look around and explore them!`,
+            });
+            navigate(`/projects/${targetProject}`);
+        } catch (error) {
+            setToastApiError(
+                `Could not create the example project: ${formatUnknownError(error)}`,
+            );
+        } finally {
+            setSeeding(false);
+        }
+    };
+
+    return { seedDemoProject, seeding };
+};

--- a/frontend/src/component/feature/StrategyTypes/RolloutSlider/RolloutSlider.tsx
+++ b/frontend/src/component/feature/StrategyTypes/RolloutSlider/RolloutSlider.tsx
@@ -109,6 +109,10 @@ interface IRolloutSliderProps {
     value: number;
     onChange: (e: Event, newValue: number | number[]) => void;
     disabled?: boolean;
+    /** Hide the numeric input box to give the slider its full width. */
+    hideInput?: boolean;
+    /** Hide the help (?) icon and its rollout/stickiness/groupId tooltip. */
+    hideHelp?: boolean;
 }
 
 const RolloutSlider = ({
@@ -116,6 +120,8 @@ const RolloutSlider = ({
     value,
     onChange,
     disabled = false,
+    hideInput = false,
+    hideHelp = false,
 }: IRolloutSliderProps) => {
     // Bounds validation stays in component - hook only handles parsing
     const handleValueChange = (numValue: number) => {
@@ -136,54 +142,57 @@ const RolloutSlider = ({
         <SliderWrapper>
             <StyledBox>
                 <Typography id='discrete-slider-always'>{name}</Typography>
-                <HelpIcon
-                    htmlTooltip
-                    tooltip={
-                        <Box>
-                            <StyledHeader variant='h3'>
-                                Rollout percentage
-                            </StyledHeader>
-                            <Typography variant='body2'>
-                                The rollout percentage determines the proportion
-                                of users exposed to a feature. It's based on the
-                                MurmurHash of a user's unique identifier,
-                                normalized to a number between 1 and 100. If the
-                                normalized hash is less than or equal to the
-                                rollout percentage, the user sees the feature.
-                                This ensures a consistent, random distribution
-                                of the feature among users.
-                            </Typography>
+                {!hideHelp && (
+                    <HelpIcon
+                        htmlTooltip
+                        tooltip={
+                            <Box>
+                                <StyledHeader variant='h3'>
+                                    Rollout percentage
+                                </StyledHeader>
+                                <Typography variant='body2'>
+                                    The rollout percentage determines the
+                                    proportion of users exposed to a feature.
+                                    It's based on the MurmurHash of a user's
+                                    unique identifier, normalized to a number
+                                    between 1 and 100. If the normalized hash is
+                                    less than or equal to the rollout
+                                    percentage, the user sees the feature. This
+                                    ensures a consistent, random distribution of
+                                    the feature among users.
+                                </Typography>
 
-                            <StyledSubheader variant='h3'>
-                                Stickiness
-                            </StyledSubheader>
-                            <Typography variant='body2'>
-                                Stickiness refers to the value used for hashing
-                                to ensure a consistent user experience. It
-                                determines the input for the MurmurHash,
-                                ensuring that a user's feature exposure remains
-                                consistent across sessions.
-                                <br />
-                                By default Unleash will use the first value
-                                present in the context in the order of{' '}
-                                <b>userId, sessionId and random</b>.
-                            </Typography>
+                                <StyledSubheader variant='h3'>
+                                    Stickiness
+                                </StyledSubheader>
+                                <Typography variant='body2'>
+                                    Stickiness refers to the value used for
+                                    hashing to ensure a consistent user
+                                    experience. It determines the input for the
+                                    MurmurHash, ensuring that a user's feature
+                                    exposure remains consistent across sessions.
+                                    <br />
+                                    By default Unleash will use the first value
+                                    present in the context in the order of{' '}
+                                    <b>userId, sessionId and random</b>.
+                                </Typography>
 
-                            <StyledSubheader variant='h3'>
-                                GroupId
-                            </StyledSubheader>
-                            <Typography variant='body2'>
-                                The groupId is used as a seed for the hash
-                                function, ensuring consistent feature exposure
-                                across different feature flags for a uniform
-                                user experience.
-                            </Typography>
-                        </Box>
-                    }
-                />
+                                <StyledSubheader variant='h3'>
+                                    GroupId
+                                </StyledSubheader>
+                                <Typography variant='body2'>
+                                    The groupId is used as a seed for the hash
+                                    function, ensuring consistent feature
+                                    exposure across different feature flags for
+                                    a uniform user experience.
+                                </Typography>
+                            </Box>
+                        }
+                    />
+                )}
             </StyledBox>
             <StyledSliderContainer>
-                <SliderContent>
+                <SliderContent sx={{ px: hideInput ? 2.5 : 0 }}>
                     <StyledSlider
                         min={0}
                         max={100}
@@ -198,32 +207,34 @@ const RolloutSlider = ({
                         disabled={disabled}
                     />
                 </SliderContent>
-                <StyledInputBox>
-                    <StyledTextField
-                        size='small'
-                        aria-labelledby='discrete-slider-always'
-                        type='number'
-                        value={inputValue}
-                        onChange={handleInputChange}
-                        onBlur={handleInputBlur}
-                        onKeyDown={handleKeyDown}
-                        disabled={disabled}
-                        slotProps={{
-                            htmlInput: {
-                                min: 0,
-                                max: 100,
-                                step: 1,
-                            },
-                            input: {
-                                endAdornment: (
-                                    <InputAdornment position='end'>
-                                        %
-                                    </InputAdornment>
-                                ),
-                            },
-                        }}
-                    />
-                </StyledInputBox>
+                {!hideInput && (
+                    <StyledInputBox>
+                        <StyledTextField
+                            size='small'
+                            aria-labelledby='discrete-slider-always'
+                            type='number'
+                            value={inputValue}
+                            onChange={handleInputChange}
+                            onBlur={handleInputBlur}
+                            onKeyDown={handleKeyDown}
+                            disabled={disabled}
+                            slotProps={{
+                                htmlInput: {
+                                    min: 0,
+                                    max: 100,
+                                    step: 1,
+                                },
+                                input: {
+                                    endAdornment: (
+                                        <InputAdornment position='end'>
+                                            %
+                                        </InputAdornment>
+                                    ),
+                                },
+                            }}
+                        />
+                    </StyledInputBox>
+                )}
             </StyledSliderContainer>
         </SliderWrapper>
     );

--- a/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
+++ b/frontend/src/component/layout/MainLayout/NavigationSidebar/NavigationSidebar.tsx
@@ -21,6 +21,7 @@ import LogoOnly from 'assets/img/logoDark.svg?react';
 import { Link } from 'react-router';
 import { useFlag } from '@unleash/proxy-client-react';
 import { useNewAdminMenu } from 'hooks/useNewAdminMenu';
+import { GettingStartedChecklist } from 'component/onboarding/gettingStarted/GettingStartedChecklist';
 
 export const StretchContainer = styled(Box, {
     shouldForwardProp: (propName) =>
@@ -207,6 +208,7 @@ export const NavigationSidebar: FC = () => {
             </MidContainer>
 
             <BottomContainer admin={showOnlyAdminMenu}>
+                <GettingStartedChecklist mode={mode} />
                 <ShowHide
                     mode={mode}
                     onChange={() => {

--- a/frontend/src/component/menu/Header/Header.tsx
+++ b/frontend/src/component/menu/Header/Header.tsx
@@ -22,6 +22,7 @@ import { useUiFlag } from 'hooks/useUiFlag';
 import InviteLinkButton from './InviteLink/InviteLinkButton/InviteLinkButton.tsx';
 import { CommandBar } from 'component/commandBar/CommandBar';
 import { HelpResources } from './HelpResources/HelpResources';
+import { QuickTourButton } from './QuickTour/QuickTourButton.tsx';
 
 const HeaderComponent = styled(AppBar)(({ theme }) => ({
     backgroundColor: theme.palette.background.application,
@@ -104,6 +105,7 @@ const Header = () => {
                     </IconButton>
                 </Tooltip>
             )}
+            <QuickTourButton />
             {hideTopmenuDocumentation && <HelpResources />}
             {!hideTopmenuDocumentation && (
                 <Tooltip title='Documentation' arrow>

--- a/frontend/src/component/menu/Header/QuickTour/QuickTourButton.test.tsx
+++ b/frontend/src/component/menu/Header/QuickTour/QuickTourButton.test.tsx
@@ -1,0 +1,22 @@
+import { vi, expect, test } from 'vitest';
+import { render } from 'utils/testRenderer';
+import { screen, fireEvent } from '@testing-library/react';
+import { QuickTourButton } from './QuickTourButton.tsx';
+
+// Enable the gating flag and stub confetti (canvas isn't in jsdom).
+vi.mock('hooks/useUiFlag.ts', () => ({ useUiFlag: () => true }));
+vi.mock('react-confetti', () => ({ default: () => null }));
+
+test('shows the launcher and opens the quick tour on click', async () => {
+    render(<QuickTourButton />);
+
+    const button = screen.getByTestId('QUICK_TOUR_BUTTON');
+    expect(button).toBeInTheDocument();
+
+    fireEvent.click(button);
+
+    // The tour (lazy-loaded) mounts and shows its first step.
+    expect(
+        await screen.findByText('Flip a feature on and off'),
+    ).toBeInTheDocument();
+});

--- a/frontend/src/component/menu/Header/QuickTour/QuickTourButton.tsx
+++ b/frontend/src/component/menu/Header/QuickTour/QuickTourButton.tsx
@@ -1,0 +1,44 @@
+import { lazy, Suspense, useState } from 'react';
+import { IconButton, Tooltip } from '@mui/material';
+import ExploreOutlinedIcon from '@mui/icons-material/ExploreOutlined';
+import { useUiFlag } from 'hooks/useUiFlag.ts';
+
+// Lazy so the demo (and react-confetti) stay out of the always-loaded header
+// chunk and are only fetched when the tour is opened.
+const QuickTourDialog = lazy(() =>
+    import('./QuickTourDialog.tsx').then((m) => ({
+        default: m.QuickTourDialog,
+    })),
+);
+
+/**
+ * A launcher in the top bar (next to Help & resources) that opens the 4-step
+ * "quick tour" of feature flags as a dialog floating over the app.
+ */
+export const QuickTourButton = () => {
+    const enabled = useUiFlag('onboardingClosedDemo');
+    const [open, setOpen] = useState(false);
+
+    if (!enabled) {
+        return null;
+    }
+
+    return (
+        <>
+            <Tooltip title='Quick tour' arrow>
+                <IconButton
+                    size='large'
+                    onClick={() => setOpen(true)}
+                    data-testid='QUICK_TOUR_BUTTON'
+                >
+                    <ExploreOutlinedIcon />
+                </IconButton>
+            </Tooltip>
+            {open && (
+                <Suspense fallback={null}>
+                    <QuickTourDialog onClose={() => setOpen(false)} />
+                </Suspense>
+            )}
+        </>
+    );
+};

--- a/frontend/src/component/menu/Header/QuickTour/QuickTourDialog.tsx
+++ b/frontend/src/component/menu/Header/QuickTour/QuickTourDialog.tsx
@@ -1,0 +1,36 @@
+import { Dialog, IconButton, styled } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { GridDemo } from 'component/onboarding/closedDemo/ClosedDemo.tsx';
+
+const StyledDialog = styled(Dialog)(({ theme }) => ({
+    '& .MuiDialog-paper': {
+        width: 'min(960px, 94vw)',
+        height: 'min(680px, 92vh)',
+        maxWidth: 'unset',
+        margin: 0,
+        overflow: 'hidden',
+        borderRadius: theme.shape.borderRadiusLarge,
+    },
+}));
+
+const StyledClose = styled(IconButton)(({ theme }) => ({
+    position: 'absolute',
+    top: theme.spacing(1),
+    right: theme.spacing(1),
+    zIndex: 1,
+    color: theme.palette.text.secondary,
+}));
+
+/**
+ * The quick tour as a centered dialog floating over the (dimmed) app - as
+ * opposed to the full-screen dialog used in the signup flow. Backdrop click,
+ * Escape, the ✕, and the tour's own Skip/Finish all close it.
+ */
+export const QuickTourDialog = ({ onClose }: { onClose: () => void }) => (
+    <StyledDialog open onClose={onClose}>
+        <StyledClose onClick={onClose} aria-label='Close' size='small'>
+            <CloseIcon fontSize='small' />
+        </StyledClose>
+        <GridDemo onComplete={onClose} />
+    </StyledDialog>
+);

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -58,8 +58,20 @@ import { ExploreCounters } from 'component/counters/ExploreCounters/ExploreCount
 import { UnknownFlagsTable } from 'component/unknownFlags/UnknownFlagsTable';
 import { ChangeRequests } from 'component/changeRequest/ChangeRequests/ChangeRequests';
 import { LazyStoriesPage } from 'component/stories/LazyStoriesPage.tsx';
+import { ClosedDemoPreview } from 'component/onboarding/closedDemo/ClosedDemoPreview.tsx';
 
 export const routes: IRoute[] = [
+    // TEMPORARY: preview route for the onboarding closed demo. Unprotected so it
+    // can be viewed without logging in. Remove together with ClosedDemoPreview.tsx
+    // once the demo has been reviewed.
+    {
+        path: '/closed-demo-preview',
+        title: 'Closed demo preview',
+        component: ClosedDemoPreview,
+        type: 'unprotected',
+        menu: {},
+        isStandalone: true,
+    },
     // Splash
     {
         path: '/splash/:splashId',

--- a/frontend/src/component/onboarding/celebration/OnboardingCelebrationDialog.test.tsx
+++ b/frontend/src/component/onboarding/celebration/OnboardingCelebrationDialog.test.tsx
@@ -1,0 +1,97 @@
+import { expect, test, vi } from 'vitest';
+import { render } from 'utils/testRenderer';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { testServerRoute, testServerSetup } from 'utils/testServer';
+import { OnboardingCelebrationDialog } from './OnboardingCelebrationDialog.tsx';
+
+vi.mock('react-confetti', () => ({
+    default: () => <div data-testid='confetti' />,
+}));
+
+const server = testServerSetup();
+
+const setupApi = () => {
+    testServerRoute(server, '/api/admin/search/features', {
+        features: [
+            {
+                name: 'my-first-flag',
+                environments: [
+                    {
+                        name: 'development',
+                        type: 'development',
+                        enabled: true,
+                    },
+                ],
+            },
+        ],
+        total: 1,
+    });
+};
+
+test('shows celebration with confetti and next steps when open', async () => {
+    setupApi();
+    render(
+        <OnboardingCelebrationDialog
+            projectId='default'
+            open
+            onClose={() => {}}
+            onConnectSdk={() => {}}
+        />,
+    );
+
+    await screen.findByText(/Your flag is live/);
+    expect(screen.getByTestId('confetti')).toBeInTheDocument();
+
+    const rolloutLink = await screen.findByRole('link', {
+        name: /Add a gradual rollout/,
+    });
+    expect(rolloutLink).toHaveAttribute(
+        'href',
+        expect.stringContaining(
+            '/projects/default/features/my-first-flag/strategies/create',
+        ),
+    );
+
+    const inviteLink = screen.getByRole('link', {
+        name: /Invite a teammate/,
+    });
+    expect(inviteLink).toHaveAttribute('href', '/admin/invite-link');
+});
+
+test('connect SDK card opens the SDK dialog and closes the celebration', async () => {
+    setupApi();
+    const onClose = vi.fn();
+    const onConnectSdk = vi.fn();
+    render(
+        <OnboardingCelebrationDialog
+            projectId='default'
+            open
+            onClose={onClose}
+            onConnectSdk={onConnectSdk}
+        />,
+    );
+
+    await screen.findByText(/Your flag is live/);
+    await userEvent.click(
+        screen.getByRole('button', { name: /Connect your SDK/ }),
+    );
+
+    expect(onClose).toHaveBeenCalled();
+    expect(onConnectSdk).toHaveBeenCalled();
+});
+
+test('renders nothing visible when closed', () => {
+    setupApi();
+    render(
+        <OnboardingCelebrationDialog
+            projectId='default'
+            open={false}
+            onClose={() => {}}
+            onConnectSdk={() => {}}
+        />,
+    );
+
+    expect(screen.queryByText(/Your flag is live/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('confetti')).not.toBeInTheDocument();
+});

--- a/frontend/src/component/onboarding/celebration/OnboardingCelebrationDialog.tsx
+++ b/frontend/src/component/onboarding/celebration/OnboardingCelebrationDialog.tsx
@@ -1,0 +1,198 @@
+import {
+    Dialog,
+    IconButton,
+    styled,
+    type Theme,
+    Typography,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import PersonAddOutlinedIcon from '@mui/icons-material/PersonAddOutlined';
+import Confetti from 'react-confetti';
+import { Link } from 'react-router';
+import CodeBlockIcon from 'assets/icons/code-block.svg?react';
+import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
+import { formatCreateStrategyPath } from 'component/feature/FeatureStrategy/FeatureStrategyCreate/FeatureStrategyCreate';
+import { getOnboardingEnvironment } from '../flow/steps/getOnboardingEnvironment.ts';
+
+interface IOnboardingCelebrationDialogProps {
+    projectId: string;
+    open: boolean;
+    onClose: () => void;
+    onConnectSdk: () => void;
+}
+
+const StyledDialog = styled(Dialog)(({ theme }) => ({
+    '& .MuiDialog-paper': {
+        borderRadius: theme.shape.borderRadiusExtraLarge,
+        maxWidth: theme.spacing(90),
+        padding: theme.spacing(4),
+    },
+}));
+
+const StyledCloseButton = styled(IconButton)(({ theme }) => ({
+    position: 'absolute',
+    right: theme.spacing(2),
+    top: theme.spacing(2),
+    color: theme.palette.neutral.main,
+}));
+
+const Headline = styled(Typography)(({ theme }) => ({
+    fontSize: theme.fontSizes.largeHeader,
+    fontWeight: theme.fontWeight.bold,
+    marginRight: theme.spacing(4),
+}));
+
+const Subtitle = styled(Typography)(({ theme }) => ({
+    color: theme.palette.text.secondary,
+    marginTop: theme.spacing(1),
+}));
+
+const NextSteps = styled('div')(({ theme }) => ({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gap: theme.spacing(2),
+    marginTop: theme.spacing(4),
+    [theme.breakpoints.down('md')]: {
+        gridTemplateColumns: '1fr',
+    },
+}));
+
+const cardStyles = (theme: Theme) => ({
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'flex-start',
+    gap: theme.spacing(1),
+    padding: theme.spacing(2.5),
+    borderRadius: theme.shape.borderRadiusLarge,
+    border: `1px solid ${theme.palette.divider}`,
+    background: theme.palette.background.default,
+    textAlign: 'left' as const,
+    textDecoration: 'none',
+    color: 'inherit',
+    cursor: 'pointer',
+    '&:hover': {
+        borderColor: theme.palette.primary.main,
+        background: theme.palette.background.elevation1,
+    },
+});
+
+const CardLink = styled(Link)(({ theme }) => cardStyles(theme));
+
+const CardButton = styled('button')(({ theme }) => ({
+    ...cardStyles(theme),
+    fontFamily: 'inherit',
+}));
+
+const CardIcon = styled('div')(({ theme }) => ({
+    width: 32,
+    height: 32,
+    borderRadius: 8,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: theme.palette.primary.light,
+    color: theme.palette.primary.contrastText,
+    '& svg': { fontSize: 20 },
+    '& svg path': { fill: 'currentColor' },
+}));
+
+const CardTitle = styled(Typography)(({ theme }) => ({
+    fontSize: theme.typography.body1.fontSize,
+    fontWeight: theme.typography.fontWeightBold,
+}));
+
+const CardBody = styled(Typography)(({ theme }) => ({
+    fontSize: theme.typography.body2.fontSize,
+    color: theme.palette.text.secondary,
+}));
+
+export const OnboardingCelebrationDialog = ({
+    projectId,
+    open,
+    onClose,
+    onConnectSdk,
+}: IOnboardingCelebrationDialogProps) => {
+    const { features } = useFeatureSearch({
+        project: `IS:${projectId}`,
+    });
+    const firstFeature = features[0];
+    const environment = getOnboardingEnvironment(firstFeature);
+
+    const gradualRolloutPath =
+        firstFeature && environment
+            ? formatCreateStrategyPath(
+                  projectId,
+                  firstFeature.name,
+                  environment.name,
+                  'flexibleRollout',
+              )
+            : `/projects/${projectId}`;
+
+    return (
+        <>
+            {open ? (
+                <Confetti
+                    recycle={false}
+                    numberOfPieces={1000}
+                    initialVelocityY={50}
+                    gravity={0.3}
+                    style={{ zIndex: 3000 }}
+                />
+            ) : null}
+            <StyledDialog
+                open={open}
+                onClose={onClose}
+                aria-labelledby='onboarding-celebration-headline'
+            >
+                <StyledCloseButton aria-label='close' onClick={onClose}>
+                    <CloseIcon />
+                </StyledCloseButton>
+                <Headline id='onboarding-celebration-headline'>
+                    Your flag is live 🎉
+                </Headline>
+                <Subtitle>
+                    Your app just changed behavior — no deploy needed. Here are
+                    some great next steps.
+                </Subtitle>
+                <NextSteps>
+                    <CardLink to={gradualRolloutPath} onClick={onClose}>
+                        <CardIcon>
+                            <TrendingUpIcon />
+                        </CardIcon>
+                        <CardTitle>Add a gradual rollout</CardTitle>
+                        <CardBody>
+                            Release to a percentage of your users instead of
+                            everyone at once.
+                        </CardBody>
+                    </CardLink>
+                    <CardButton
+                        type='button'
+                        onClick={() => {
+                            onClose();
+                            onConnectSdk();
+                        }}
+                    >
+                        <CardIcon>
+                            <CodeBlockIcon />
+                        </CardIcon>
+                        <CardTitle>Connect your SDK</CardTitle>
+                        <CardBody>
+                            See the flag evaluated live in your own application.
+                        </CardBody>
+                    </CardButton>
+                    <CardLink to='/admin/invite-link' onClick={onClose}>
+                        <CardIcon>
+                            <PersonAddOutlinedIcon />
+                        </CardIcon>
+                        <CardTitle>Invite a teammate</CardTitle>
+                        <CardBody>
+                            Feature flags are better together. Share what you
+                            just built.
+                        </CardBody>
+                    </CardLink>
+                </NextSteps>
+            </StyledDialog>
+        </>
+    );
+};

--- a/frontend/src/component/onboarding/closedDemo/ClosedDemo.test.tsx
+++ b/frontend/src/component/onboarding/closedDemo/ClosedDemo.test.tsx
@@ -1,0 +1,54 @@
+import { vi, expect, test } from 'vitest';
+import { render } from 'utils/testRenderer';
+import { screen, fireEvent } from '@testing-library/react';
+import { ClosedDemo } from './ClosedDemo.tsx';
+
+// react-confetti renders to a canvas, which jsdom doesn't implement.
+vi.mock('react-confetti', () => ({ default: () => null }));
+
+const next = () =>
+    fireEvent.click(screen.getByTestId('CLOSED_DEMO_NEXT_BUTTON'));
+
+test('renders the first (on/off) topic and a live user count', () => {
+    render(<ClosedDemo onComplete={vi.fn()} />);
+    expect(screen.getByText('Flip a feature on and off')).toBeInTheDocument();
+    expect(screen.getByText(/users see the feature/)).toBeInTheDocument();
+    expect(screen.getByTestId('CLOSED_DEMO_ONOFF_SWITCH')).toBeInTheDocument();
+});
+
+test('walks through all four topics to the finish screen', () => {
+    render(<ClosedDemo onComplete={vi.fn()} />);
+
+    next();
+    expect(screen.getByText('Release gradually, safely')).toBeInTheDocument();
+
+    next();
+    expect(screen.getByText('Target exactly who you want')).toBeInTheDocument();
+
+    next();
+    expect(screen.getByText('Run an A/B test')).toBeInTheDocument();
+
+    next();
+    expect(screen.getByTestId('CLOSED_DEMO_FINISH_BUTTON')).toBeInTheDocument();
+});
+
+test('calls onComplete when finishing', () => {
+    const onComplete = vi.fn();
+    render(<ClosedDemo onComplete={onComplete} />);
+
+    next(); // -> rollout
+    next(); // -> target
+    next(); // -> variants
+    next(); // -> finish screen
+    fireEvent.click(screen.getByTestId('CLOSED_DEMO_FINISH_BUTTON'));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+});
+
+test('calls onComplete when skipping', () => {
+    const onComplete = vi.fn();
+    render(<ClosedDemo onComplete={onComplete} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+});

--- a/frontend/src/component/onboarding/closedDemo/ClosedDemo.tsx
+++ b/frontend/src/component/onboarding/closedDemo/ClosedDemo.tsx
@@ -1,0 +1,587 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+    Box,
+    Button,
+    Chip,
+    Dialog,
+    FormControlLabel,
+    styled,
+    Switch,
+    Typography,
+    useTheme,
+} from '@mui/material';
+import Confetti from 'react-confetti';
+import RolloutSlider from 'component/feature/StrategyTypes/RolloutSlider/RolloutSlider.tsx';
+import { VariantsSplitPreview } from 'component/common/VariantsSplitPreview/VariantsSplitPreview.tsx';
+import type { StrategyVariantSchema } from 'openapi';
+import { useEventTracker } from 'hooks/useEventTracker.ts';
+import {
+    computeEvaluations,
+    DEMO_COUNTRIES,
+    type DemoFlagConfig,
+    type DemoUser,
+    generateDemoUsers,
+    summarize,
+} from './demoModel.js';
+import { UserGrid, type GridMode } from './UserGrid.tsx';
+import { SampleAppPreview } from './SampleAppPreview.tsx';
+
+const USER_COUNT = 60;
+const FLAG_NAME = 'new-checkout';
+
+const DEFAULT_VARIANTS = [
+    { name: 'A', weight: 50 },
+    { name: 'B', weight: 50 },
+];
+
+interface ITopic {
+    key: string;
+    mode: GridMode;
+    title: string;
+    body: string;
+}
+
+const TOPICS: ITopic[] = [
+    {
+        key: 'onoff',
+        mode: 'onoff',
+        title: 'Flip a feature on and off',
+        body: 'Imagine you run the online store on the right, and you just built a new 1-click checkout. A feature flag is a switch that controls it without deploying. Toggle it and watch every user get it instantly, then take it away just as fast.',
+    },
+    {
+        key: 'rollout',
+        mode: 'rollout',
+        title: 'Release gradually, safely',
+        body: 'You don’t have to go all-or-nothing. Drag the slider to roll the feature out to a percentage of your users. Watch how the same users stay in as you increase. Nobody flips back off. That’s a consistent, controlled release.',
+    },
+    {
+        key: 'target',
+        mode: 'target',
+        title: 'Target exactly who you want',
+        body: 'Switch the feature on for whole segments, here by country, no matter the rollout percentage. Perfect for betas, internal users, or a single region.',
+    },
+    {
+        key: 'variants',
+        mode: 'variants',
+        title: 'Run an A/B test',
+        body: 'The new feature has two versions, A and B. Everyone gets the feature, but each user sees just one version, so you can compare which works better.',
+    },
+];
+
+const StyledPanel = styled(Box)(({ theme }) => ({
+    height: '100%',
+    display: 'grid',
+    gridTemplateColumns: 'minmax(340px, 2fr) 3fr',
+    background: theme.palette.background.paper,
+    [theme.breakpoints.down('md')]: {
+        gridTemplateColumns: '1fr',
+        overflowY: 'auto',
+    },
+}));
+
+const StyledLeft = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: 0,
+    padding: theme.spacing(5),
+    gap: theme.spacing(2),
+    borderRight: `1px solid ${theme.palette.divider}`,
+    [theme.breakpoints.down('md')]: {
+        borderRight: 'none',
+        borderBottom: `1px solid ${theme.palette.divider}`,
+    },
+}));
+
+// Scrolls when the panel is short (e.g. the over-app dialog) so the pinned
+// footer nav below it never gets clipped.
+const StyledScroll = styled(Box)(({ theme }) => ({
+    flex: 1,
+    minHeight: 0,
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2.5),
+}));
+
+const StyledRight = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    padding: theme.spacing(5),
+    gap: theme.spacing(2),
+    background: theme.palette.background.elevation1,
+    overflowY: 'auto',
+}));
+
+const StyledEyebrow = styled(Typography)(({ theme }) => ({
+    color: theme.palette.text.secondary,
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
+    fontSize: theme.fontSizes.smallerBody,
+    fontWeight: theme.typography.fontWeightBold,
+}));
+
+const StyledTitle = styled('h1')(({ theme }) => ({
+    margin: 0,
+    fontSize: theme.typography.h1.fontSize,
+}));
+
+const StyledControls = styled(Box)(({ theme }) => ({
+    marginTop: theme.spacing(1),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+}));
+
+const StyledChips = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1),
+}));
+
+const StyledFooter = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1.5),
+    flexShrink: 0,
+    paddingTop: theme.spacing(2),
+    borderTop: `1px solid ${theme.palette.divider}`,
+}));
+
+const StyledDots = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    gap: theme.spacing(1),
+    marginRight: 'auto',
+}));
+
+const StyledDot = styled('span', {
+    shouldForwardProp: (prop) => prop !== 'active',
+})<{ active: boolean }>(({ theme, active }) => ({
+    width: theme.spacing(1),
+    height: theme.spacing(1),
+    borderRadius: '50%',
+    background: active ? theme.palette.primary.main : theme.palette.divider,
+}));
+
+const StyledStat = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: theme.spacing(1),
+}));
+
+const StyledStatValue = styled('span')(({ theme }) => ({
+    fontSize: theme.typography.h1.fontSize,
+    fontWeight: theme.typography.fontWeightBold,
+    color: theme.palette.primary.main,
+    fontVariantNumeric: 'tabular-nums',
+}));
+
+const StyledFinish = styled(Box)(({ theme }) => ({
+    gridColumn: '1 / -1',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+    padding: theme.spacing(8),
+    gap: theme.spacing(2),
+}));
+
+interface IGridDemoProps {
+    /** In the signup flow this navigates to the project; optional in the lab. */
+    onComplete?: () => void;
+    companyName?: string;
+}
+
+/**
+ * The "god's-eye grid" demo variant, rendered as a panel that fills its
+ * container. Wrapped in a full-screen dialog by `ClosedDemo` for the signup
+ * flow, or dropped straight into the comparison lab.
+ */
+export const GridDemo = ({ onComplete, companyName }: IGridDemoProps) => {
+    const theme = useTheme();
+    const { trackEvent } = useEventTracker();
+    const users = useMemo(() => generateDemoUsers(USER_COUNT), []);
+
+    const [topicIndex, setTopicIndex] = useState(0);
+    const [finished, setFinished] = useState(false);
+    const [selectedId, setSelectedId] = useState<string | undefined>();
+    const [config, setConfig] = useState<DemoFlagConfig>({
+        flagName: FLAG_NAME,
+        environmentEnabled: true,
+        rollout: 100,
+        targetCountryCodes: [],
+        variantsEnabled: false,
+        variants: DEFAULT_VARIANTS,
+    });
+
+    useEffect(() => {
+        trackEvent('closed-demo', { props: { eventType: 'start' } });
+    }, [trackEvent]);
+
+    const topic = TOPICS[topicIndex];
+
+    const evaluations = useMemo(
+        () => computeEvaluations(users, config),
+        [users, config],
+    );
+    const stats = useMemo(
+        () => summarize(users, evaluations),
+        [users, evaluations],
+    );
+
+    const variantOrder = config.variants.map((v) => v.name);
+    const variantAccent = (index: number) =>
+        theme.palette.variants[index % theme.palette.variants.length];
+
+    const selectedUser = users.find((u) => u.id === selectedId);
+    const selectedEvaluation = selectedUser
+        ? evaluations[users.indexOf(selectedUser)]
+        : undefined;
+
+    const applyTopicPreset = (index: number) => {
+        const key = TOPICS[index].key;
+        if (key === 'onoff') {
+            setConfig((c) => ({
+                ...c,
+                environmentEnabled: true,
+                rollout: 100,
+                targetCountryCodes: [],
+                variantsEnabled: false,
+            }));
+        } else if (key === 'rollout') {
+            setConfig((c) => ({
+                ...c,
+                environmentEnabled: true,
+                rollout: 25,
+                targetCountryCodes: [],
+                variantsEnabled: false,
+            }));
+        } else if (key === 'target') {
+            setConfig((c) => ({
+                ...c,
+                environmentEnabled: true,
+                rollout: 10,
+                targetCountryCodes: ['US'],
+                variantsEnabled: false,
+            }));
+        } else {
+            setConfig((c) => ({
+                ...c,
+                environmentEnabled: true,
+                rollout: 100,
+                targetCountryCodes: [],
+                variantsEnabled: true,
+                variants: DEFAULT_VARIANTS,
+            }));
+        }
+    };
+
+    const goToTopic = (index: number) => {
+        setTopicIndex(index);
+        applyTopicPreset(index);
+        trackEvent('closed-demo', {
+            props: { eventType: 'topic', topic: TOPICS[index].key },
+        });
+    };
+
+    const handleNext = () => {
+        if (topicIndex < TOPICS.length - 1) {
+            goToTopic(topicIndex + 1);
+        } else {
+            setFinished(true);
+            trackEvent('closed-demo', { props: { eventType: 'finish' } });
+        }
+    };
+
+    // In the signup flow onComplete navigates away; in the lab there's nowhere
+    // to go, so completing just replays the tour.
+    const complete = () => {
+        if (onComplete) {
+            onComplete();
+        } else {
+            setFinished(false);
+            goToTopic(0);
+        }
+    };
+
+    const handleSkip = () => {
+        trackEvent('closed-demo', {
+            props: { eventType: 'skip', topic: topic.key },
+        });
+        complete();
+    };
+
+    const setEnvironmentEnabled = (value: boolean) =>
+        setConfig((c) => ({ ...c, environmentEnabled: value }));
+
+    const setRollout = (value: number) =>
+        setConfig((c) => ({ ...c, rollout: value }));
+
+    const toggleCountry = (code: string) =>
+        setConfig((c) => ({
+            ...c,
+            targetCountryCodes: c.targetCountryCodes.includes(code)
+                ? c.targetCountryCodes.filter((x) => x !== code)
+                : [...c.targetCountryCodes, code],
+        }));
+
+    const setSplit = (value: number) =>
+        setConfig((c) => ({
+            ...c,
+            variants: [
+                { name: 'A', weight: 100 - value },
+                { name: 'B', weight: value },
+            ],
+        }));
+
+    const previewVariants: StrategyVariantSchema[] = config.variants.map(
+        (v) => ({
+            name: v.name,
+            weight: v.weight * 10,
+            weightType: 'variable',
+            stickiness: 'default',
+        }),
+    );
+
+    return (
+        <StyledPanel>
+            {finished ? (
+                <>
+                    <Confetti
+                        recycle={false}
+                        numberOfPieces={400}
+                        gravity={0.3}
+                        style={{ zIndex: 3000 }}
+                    />
+                    <StyledFinish data-public>
+                        <StyledTitle>That’s feature flagging 🎉</StyledTitle>
+                        <Typography
+                            color='textSecondary'
+                            sx={{ maxWidth: 520 }}
+                        >
+                            You just ran a gradual rollout, targeted a segment,
+                            and split an A/B test, with no deploys and no code.
+                            Ready to do it for real in your project?
+                        </Typography>
+                        <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
+                            <Button
+                                variant='outlined'
+                                onClick={() => {
+                                    setFinished(false);
+                                    goToTopic(0);
+                                }}
+                            >
+                                Replay
+                            </Button>
+                            <Button
+                                variant='contained'
+                                onClick={complete}
+                                data-testid='CLOSED_DEMO_FINISH_BUTTON'
+                            >
+                                Start using Unleash
+                            </Button>
+                        </Box>
+                    </StyledFinish>
+                </>
+            ) : (
+                <>
+                    <StyledLeft>
+                        <StyledScroll>
+                            <StyledEyebrow>
+                                {companyName
+                                    ? `${companyName} · quick tour`
+                                    : 'Quick tour'}{' '}
+                                · {topicIndex + 1} of {TOPICS.length}
+                            </StyledEyebrow>
+                            <StyledTitle>{topic.title}</StyledTitle>
+                            <Typography color='textSecondary'>
+                                {topic.body}
+                            </Typography>
+
+                            <StyledControls>
+                                {topic.mode === 'onoff' && (
+                                    <FormControlLabel
+                                        control={
+                                            <Switch
+                                                checked={
+                                                    config.environmentEnabled
+                                                }
+                                                onChange={(e) =>
+                                                    setEnvironmentEnabled(
+                                                        e.target.checked,
+                                                    )
+                                                }
+                                                data-testid='CLOSED_DEMO_ONOFF_SWITCH'
+                                            />
+                                        }
+                                        label={
+                                            config.environmentEnabled
+                                                ? 'Feature is ON, everyone sees it'
+                                                : 'Feature is OFF, no one sees it'
+                                        }
+                                    />
+                                )}
+
+                                {topic.mode === 'rollout' && (
+                                    <RolloutSlider
+                                        name='Rollout %'
+                                        value={config.rollout}
+                                        onChange={(_, value) =>
+                                            setRollout(value as number)
+                                        }
+                                        hideInput
+                                        hideHelp
+                                    />
+                                )}
+
+                                {topic.mode === 'target' && (
+                                    <>
+                                        <Typography variant='body2'>
+                                            Rollout stays at{' '}
+                                            <strong>{config.rollout}%</strong>.
+                                            Targeted countries are always in:
+                                        </Typography>
+                                        <StyledChips>
+                                            {DEMO_COUNTRIES.map((country) => {
+                                                const active =
+                                                    config.targetCountryCodes.includes(
+                                                        country.code,
+                                                    );
+                                                return (
+                                                    <Chip
+                                                        key={country.code}
+                                                        label={`${country.flag} ${country.code}`}
+                                                        color={
+                                                            active
+                                                                ? 'primary'
+                                                                : 'default'
+                                                        }
+                                                        variant={
+                                                            active
+                                                                ? 'filled'
+                                                                : 'outlined'
+                                                        }
+                                                        onClick={() =>
+                                                            toggleCountry(
+                                                                country.code,
+                                                            )
+                                                        }
+                                                    />
+                                                );
+                                            })}
+                                        </StyledChips>
+                                    </>
+                                )}
+
+                                {topic.mode === 'variants' && (
+                                    <>
+                                        <RolloutSlider
+                                            name='Users on version B'
+                                            value={
+                                                config.variants.find(
+                                                    (v) => v.name === 'B',
+                                                )?.weight ?? 50
+                                            }
+                                            onChange={(_, value) =>
+                                                setSplit(value as number)
+                                            }
+                                            hideInput
+                                            hideHelp
+                                        />
+                                        <VariantsSplitPreview
+                                            variants={previewVariants}
+                                            selected={
+                                                selectedEvaluation?.variant
+                                            }
+                                        />
+                                    </>
+                                )}
+                            </StyledControls>
+                        </StyledScroll>
+
+                        <StyledFooter>
+                            <StyledDots>
+                                {TOPICS.map((t, i) => (
+                                    <StyledDot
+                                        key={t.key}
+                                        active={i === topicIndex}
+                                    />
+                                ))}
+                            </StyledDots>
+                            <Button onClick={handleSkip} color='inherit'>
+                                Skip
+                            </Button>
+                            {topicIndex > 0 && (
+                                <Button
+                                    variant='outlined'
+                                    onClick={() => goToTopic(topicIndex - 1)}
+                                >
+                                    Back
+                                </Button>
+                            )}
+                            <Button
+                                variant='contained'
+                                onClick={handleNext}
+                                data-testid='CLOSED_DEMO_NEXT_BUTTON'
+                            >
+                                {topicIndex < TOPICS.length - 1
+                                    ? 'Next'
+                                    : 'Finish'}
+                            </Button>
+                        </StyledFooter>
+                    </StyledLeft>
+
+                    <StyledRight>
+                        <StyledStat>
+                            <StyledStatValue>{stats.enabled}</StyledStatValue>
+                            <Typography color='textSecondary'>
+                                of {stats.total} users see the feature (
+                                {stats.percentage}%)
+                            </Typography>
+                        </StyledStat>
+                        <UserGrid
+                            users={users}
+                            evaluations={evaluations}
+                            mode={topic.mode}
+                            variantOrder={variantOrder}
+                            selectedId={selectedId}
+                            onSelect={(user: DemoUser) =>
+                                setSelectedId(user.id)
+                            }
+                        />
+                        <SampleAppPreview
+                            user={selectedUser}
+                            evaluation={selectedEvaluation}
+                            mode={topic.mode}
+                            variantOrder={variantOrder}
+                            variantAccent={variantAccent}
+                        />
+                    </StyledRight>
+                </>
+            )}
+        </StyledPanel>
+    );
+};
+
+const StyledFullScreenDialog = styled(Dialog)({
+    '& .MuiDialog-paper': {
+        overflow: 'hidden',
+    },
+});
+
+interface IClosedDemoProps {
+    onComplete: () => void;
+    companyName?: string;
+}
+
+/**
+ * The closed demo as shown in the real signup flow: the grid variant wrapped in
+ * a full-screen dialog.
+ */
+export const ClosedDemo = ({ onComplete, companyName }: IClosedDemoProps) => (
+    <StyledFullScreenDialog open fullScreen>
+        <GridDemo onComplete={onComplete} companyName={companyName} />
+    </StyledFullScreenDialog>
+);

--- a/frontend/src/component/onboarding/closedDemo/ClosedDemoLab.test.tsx
+++ b/frontend/src/component/onboarding/closedDemo/ClosedDemoLab.test.tsx
@@ -1,0 +1,27 @@
+import { vi, expect, test } from 'vitest';
+import { render } from 'utils/testRenderer';
+import { screen, fireEvent } from '@testing-library/react';
+import { ClosedDemoLab } from './ClosedDemoLab.tsx';
+
+// react-confetti renders to a canvas, which jsdom doesn't implement.
+vi.mock('react-confetti', () => ({ default: () => null }));
+
+const FRAMING_LABELS = [
+    '1 · Full page',
+    '2 · Dialog over app',
+    '3 · Side drawer',
+    '4 · Inline on project',
+    '5 · Welcome splash',
+];
+
+test('mounts every framing without crashing when switching', () => {
+    render(<ClosedDemoLab />);
+
+    for (const label of FRAMING_LABELS) {
+        fireEvent.click(screen.getByRole('button', { name: label }));
+        // Every framing hosts the grid demo, so its first topic must render.
+        expect(
+            screen.getAllByText('Flip a feature on and off').length,
+        ).toBeGreaterThan(0);
+    }
+});

--- a/frontend/src/component/onboarding/closedDemo/ClosedDemoLab.tsx
+++ b/frontend/src/component/onboarding/closedDemo/ClosedDemoLab.tsx
@@ -1,0 +1,87 @@
+import { type ComponentType, useState } from 'react';
+import {
+    Box,
+    styled,
+    ToggleButton,
+    ToggleButtonGroup,
+    Typography,
+} from '@mui/material';
+import { PageFrame } from './frames/PageFrame.tsx';
+import { DialogFrame } from './frames/DialogFrame.tsx';
+import { DrawerFrame } from './frames/DrawerFrame.tsx';
+import { InlineFrame } from './frames/InlineFrame.tsx';
+import { SplashFrame } from './frames/SplashFrame.tsx';
+
+interface IFraming {
+    key: string;
+    label: string;
+    component: ComponentType;
+}
+
+const FRAMINGS: IFraming[] = [
+    { key: 'page', label: '1 · Full page', component: PageFrame },
+    { key: 'dialog', label: '2 · Dialog over app', component: DialogFrame },
+    { key: 'drawer', label: '3 · Side drawer', component: DrawerFrame },
+    { key: 'inline', label: '4 · Inline on project', component: InlineFrame },
+    { key: 'splash', label: '5 · Welcome splash', component: SplashFrame },
+];
+
+const StyledLab = styled(Box)({
+    height: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+});
+
+const StyledBar = styled(Box)(({ theme }) => ({
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(2),
+    padding: theme.spacing(1.5, 2),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    background: theme.palette.background.paper,
+}));
+
+const StyledStage = styled(Box)({
+    flex: 1,
+    minHeight: 0,
+    overflow: 'hidden',
+});
+
+/**
+ * TEMPORARY comparison harness: renders every "inside Unleash" framing of the
+ * grid demo behind a selector so they can be evaluated side by side under one
+ * URL. Remove together with the preview route once a framing is chosen.
+ */
+export const ClosedDemoLab = () => {
+    const [selected, setSelected] = useState(FRAMINGS[0].key);
+    const Current =
+        FRAMINGS.find((f) => f.key === selected)?.component ??
+        FRAMINGS[0].component;
+
+    return (
+        <StyledLab>
+            <StyledBar>
+                <Typography sx={{ fontWeight: 'bold', mr: 1 }}>
+                    Closed demo framings
+                </Typography>
+                <ToggleButtonGroup
+                    value={selected}
+                    exclusive
+                    size='small'
+                    onChange={(_, value) => value && setSelected(value)}
+                >
+                    {FRAMINGS.map((framing) => (
+                        <ToggleButton key={framing.key} value={framing.key}>
+                            {framing.label}
+                        </ToggleButton>
+                    ))}
+                </ToggleButtonGroup>
+            </StyledBar>
+            <StyledStage>
+                <Current />
+            </StyledStage>
+        </StyledLab>
+    );
+};

--- a/frontend/src/component/onboarding/closedDemo/ClosedDemoPreview.tsx
+++ b/frontend/src/component/onboarding/closedDemo/ClosedDemoPreview.tsx
@@ -1,0 +1,9 @@
+import { ClosedDemoLab } from './ClosedDemoLab.tsx';
+
+/**
+ * TEMPORARY preview route (`/closed-demo-preview`) for eyeballing the onboarding
+ * closed-demo variants without going through the enterprise pay-as-you-go signup
+ * flow or logging in. Renders the variant-comparison lab. Safe to delete
+ * together with its route entry in `component/menu/routes.ts`.
+ */
+export const ClosedDemoPreview = () => <ClosedDemoLab />;

--- a/frontend/src/component/onboarding/closedDemo/SampleAppPreview.tsx
+++ b/frontend/src/component/onboarding/closedDemo/SampleAppPreview.tsx
@@ -1,0 +1,180 @@
+import { Box, styled, Typography, useTheme } from '@mui/material';
+import type { DemoUser, UserEvaluation } from './demoModel.js';
+import type { GridMode } from './UserGrid.tsx';
+
+const StyledWindow = styled(Box)(({ theme }) => ({
+    borderRadius: theme.shape.borderRadiusLarge,
+    border: `1px solid ${theme.palette.divider}`,
+    overflow: 'hidden',
+    background: theme.palette.background.paper,
+    boxShadow: theme.boxShadows.card,
+    width: '100%',
+}));
+
+const StyledChrome = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.75),
+    padding: theme.spacing(1, 1.5),
+    background: theme.palette.neutral.light,
+    borderBottom: `1px solid ${theme.palette.divider}`,
+}));
+
+const StyledDot = styled('span')(({ theme }) => ({
+    width: theme.spacing(1.25),
+    height: theme.spacing(1.25),
+    borderRadius: '50%',
+    background: theme.palette.divider,
+}));
+
+const StyledUrl = styled(Box)(({ theme }) => ({
+    marginLeft: theme.spacing(1),
+    padding: theme.spacing(0.25, 1),
+    borderRadius: theme.shape.borderRadius,
+    background: theme.palette.background.default,
+    color: theme.palette.text.secondary,
+    fontSize: theme.fontSizes.smallerBody,
+    flexGrow: 1,
+}));
+
+const StyledScreen = styled(Box)(({ theme }) => ({
+    padding: theme.spacing(1.75),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+}));
+
+const StyledProductRow = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+}));
+
+const StyledThumb = styled(Box)(({ theme }) => ({
+    width: theme.spacing(4.5),
+    height: theme.spacing(4.5),
+    borderRadius: theme.shape.borderRadius,
+    background: theme.palette.neutral.border,
+    flexShrink: 0,
+}));
+
+const StyledLine = styled(Box)<{ w: number }>(({ theme, w }) => ({
+    height: theme.spacing(1),
+    width: `${w}%`,
+    borderRadius: theme.shape.borderRadius,
+    background: theme.palette.divider,
+}));
+
+const StyledCheckoutClassic = styled('button')(({ theme }) => ({
+    all: 'unset',
+    textAlign: 'center',
+    cursor: 'default',
+    padding: theme.spacing(1),
+    borderRadius: theme.shape.borderRadius,
+    border: `1px solid ${theme.palette.divider}`,
+    color: theme.palette.text.primary,
+    fontWeight: theme.typography.fontWeightBold,
+    background: theme.palette.background.default,
+}));
+
+const StyledCheckoutNew = styled('button', {
+    shouldForwardProp: (prop) => prop !== 'accent',
+})<{ accent: string }>(({ theme, accent }) => ({
+    all: 'unset',
+    textAlign: 'center',
+    cursor: 'default',
+    padding: theme.spacing(1),
+    borderRadius: theme.shape.borderRadius,
+    color: theme.palette.getContrastText(accent),
+    fontWeight: theme.typography.fontWeightBold,
+    background: accent,
+    transition: theme.transitions.create(['background-color']),
+    '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
+}));
+
+const StyledCaption = styled(Typography)(({ theme }) => ({
+    marginTop: theme.spacing(0.5),
+    color: theme.palette.text.secondary,
+    textAlign: 'center',
+}));
+
+const StyledLabel = styled(Typography)(({ theme }) => ({
+    marginBottom: theme.spacing(0.75),
+    color: theme.palette.text.secondary,
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
+    fontSize: theme.fontSizes.smallerBody,
+    fontWeight: theme.typography.fontWeightBold,
+}));
+
+interface ISampleAppPreviewProps {
+    user?: DemoUser;
+    evaluation?: UserEvaluation;
+    mode: GridMode;
+    variantOrder: string[];
+    variantAccent: (index: number) => string;
+}
+
+export const SampleAppPreview = ({
+    user,
+    evaluation,
+    mode,
+    variantOrder,
+    variantAccent,
+}: ISampleAppPreviewProps) => {
+    const theme = useTheme();
+    const enabled = evaluation?.enabled ?? false;
+    const variant = evaluation?.variant;
+    const accentIndex = variant
+        ? Math.max(0, variantOrder.indexOf(variant))
+        : 0;
+    // In the variants topic the checkout is coloured by the user's variant; in
+    // the rollout/targeting topics it's just the primary "new feature" accent.
+    const accent =
+        mode === 'variants' && variant
+            ? variantAccent(accentIndex)
+            : theme.palette.primary.main;
+
+    const caption = !user
+        ? 'Click any user in the grid to preview what they see.'
+        : enabled
+          ? mode === 'variants' && variant
+              ? `${user.name} sees version ${variant}.`
+              : `${user.name} sees the new checkout.`
+          : `${user.name} still sees the current checkout.`;
+
+    return (
+        <Box>
+            <StyledLabel>Example app · your online store</StyledLabel>
+            <StyledWindow>
+                <StyledChrome>
+                    <StyledDot />
+                    <StyledDot />
+                    <StyledDot />
+                    <StyledUrl>shop.example.com/cart</StyledUrl>
+                </StyledChrome>
+                <StyledScreen>
+                    <StyledProductRow>
+                        <StyledThumb />
+                        <Box sx={{ flexGrow: 1, display: 'grid', gap: 0.75 }}>
+                            <StyledLine w={70} />
+                            <StyledLine w={40} />
+                        </Box>
+                    </StyledProductRow>
+                    {enabled ? (
+                        <StyledCheckoutNew accent={accent}>
+                            {mode === 'variants' && variant
+                                ? `1-click checkout · ${variant}`
+                                : '⚡ 1-click checkout'}
+                        </StyledCheckoutNew>
+                    ) : (
+                        <StyledCheckoutClassic>
+                            Proceed to checkout
+                        </StyledCheckoutClassic>
+                    )}
+                    <StyledCaption variant='body2'>{caption}</StyledCaption>
+                </StyledScreen>
+            </StyledWindow>
+        </Box>
+    );
+};

--- a/frontend/src/component/onboarding/closedDemo/UserGrid.tsx
+++ b/frontend/src/component/onboarding/closedDemo/UserGrid.tsx
@@ -1,0 +1,154 @@
+import { Box, styled, Tooltip, useTheme, type Theme } from '@mui/material';
+import type { DemoUser, UserEvaluation } from './demoModel.js';
+
+export type GridMode = 'onoff' | 'rollout' | 'target' | 'variants';
+
+const StyledGrid = styled(Box)(({ theme }) => ({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(10, 1fr)',
+    gap: theme.spacing(1),
+    [theme.breakpoints.down('sm')]: {
+        gridTemplateColumns: 'repeat(6, 1fr)',
+    },
+}));
+
+const StyledTile = styled('button', {
+    shouldForwardProp: (prop) =>
+        !['background', 'foreground', 'enabled', 'selected'].includes(
+            prop as string,
+        ),
+})<{
+    background: string;
+    foreground: string;
+    enabled: boolean;
+    selected: boolean;
+}>(({ theme, background, foreground, enabled, selected }) => ({
+    all: 'unset',
+    cursor: 'pointer',
+    aspectRatio: '1 / 1',
+    borderRadius: theme.shape.borderRadius,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: theme.fontSizes.smallerBody,
+    fontWeight: theme.typography.fontWeightBold,
+    color: foreground,
+    backgroundColor: background,
+    outline: selected
+        ? `2px solid ${theme.palette.primary.main}`
+        : '2px solid transparent',
+    outlineOffset: 2,
+    opacity: enabled ? 1 : 0.9,
+    transform: enabled ? 'scale(1)' : 'scale(0.94)',
+    // The smooth colour + scale transition is what makes the rollout "fill in"
+    // as the slider moves - the core dopamine moment.
+    transition: theme.transitions.create(
+        ['background-color', 'transform', 'color', 'opacity'],
+        { duration: theme.transitions.duration.shorter },
+    ),
+    '&:hover': {
+        transform: 'scale(1.08)',
+    },
+    '@media (prefers-reduced-motion: reduce)': {
+        transition: 'none',
+    },
+}));
+
+const tileColors = (
+    theme: Theme,
+    evaluation: UserEvaluation | undefined,
+    mode: GridMode,
+    variantOrder: string[],
+): { background: string; foreground: string } => {
+    if (!evaluation?.enabled) {
+        return {
+            background: theme.palette.divider,
+            foreground: theme.palette.text.secondary,
+        };
+    }
+    if (mode === 'variants' && evaluation.variant) {
+        const index = Math.max(0, variantOrder.indexOf(evaluation.variant));
+        const background =
+            theme.palette.variants[index % theme.palette.variants.length];
+        return {
+            background,
+            foreground: theme.palette.getContrastText(background),
+        };
+    }
+    if (mode === 'target' && evaluation.reason === 'target') {
+        const background = theme.palette.secondary.main;
+        return {
+            background,
+            foreground: theme.palette.getContrastText(background),
+        };
+    }
+    const background = theme.palette.success.main;
+    return {
+        background,
+        foreground: theme.palette.getContrastText(background),
+    };
+};
+
+interface IUserGridProps {
+    users: DemoUser[];
+    evaluations: UserEvaluation[];
+    mode: GridMode;
+    /** Variant names in configured order, for stable per-variant colours. */
+    variantOrder?: string[];
+    selectedId?: string;
+    onSelect: (user: DemoUser) => void;
+}
+
+export const UserGrid = ({
+    users,
+    evaluations,
+    mode,
+    variantOrder = [],
+    selectedId,
+    onSelect,
+}: IUserGridProps) => {
+    const theme = useTheme();
+
+    return (
+        <StyledGrid>
+            {users.map((user, i) => {
+                const evaluation = evaluations[i];
+                const enabled = evaluation?.enabled ?? false;
+                const { background, foreground } = tileColors(
+                    theme,
+                    evaluation,
+                    mode,
+                    variantOrder,
+                );
+
+                const tooltip = enabled
+                    ? `${user.name} · ${user.country.flag} ${user.country.code}${
+                          evaluation?.variant
+                              ? ` · ${evaluation.variant}`
+                              : ' · sees the feature'
+                      }`
+                    : `${user.name} · ${user.country.flag} ${user.country.code} · not yet`;
+
+                const content =
+                    mode === 'target' && user.country.flag
+                        ? user.country.flag
+                        : user.name.charAt(0).toUpperCase();
+
+                return (
+                    <Tooltip key={user.id} title={tooltip} arrow>
+                        <StyledTile
+                            type='button'
+                            background={background}
+                            foreground={foreground}
+                            enabled={enabled}
+                            selected={selectedId === user.id}
+                            onClick={() => onSelect(user)}
+                        >
+                            {content}
+                        </StyledTile>
+                    </Tooltip>
+                );
+            })}
+        </StyledGrid>
+    );
+};

--- a/frontend/src/component/onboarding/closedDemo/demoModel.test.ts
+++ b/frontend/src/component/onboarding/closedDemo/demoModel.test.ts
@@ -1,0 +1,117 @@
+import {
+    computeEvaluations,
+    type DemoFlagConfig,
+    generateDemoUsers,
+    summarize,
+} from './demoModel.js';
+
+const baseConfig = (
+    overrides: Partial<DemoFlagConfig> = {},
+): DemoFlagConfig => ({
+    flagName: 'new-checkout',
+    environmentEnabled: true,
+    rollout: 0,
+    targetCountryCodes: [],
+    variantsEnabled: false,
+    variants: [],
+    ...overrides,
+});
+
+const countEnabled = (
+    users: ReturnType<typeof generateDemoUsers>,
+    config: DemoFlagConfig,
+) => computeEvaluations(users, config).filter((e) => e.enabled).length;
+
+describe('demoModel', () => {
+    it('generates stable users', () => {
+        const a = generateDemoUsers(60);
+        const b = generateDemoUsers(60);
+        expect(a).toEqual(b);
+        expect(a).toHaveLength(60);
+        expect(a[0].id).toBe('user-1');
+    });
+
+    it('spreads the rollout evenly: an N% rollout enables ~N% of users', () => {
+        const users = generateDemoUsers(60);
+        expect(countEnabled(users, baseConfig({ rollout: 0 }))).toBe(0);
+        expect(countEnabled(users, baseConfig({ rollout: 25 }))).toBe(15);
+        expect(countEnabled(users, baseConfig({ rollout: 50 }))).toBe(30);
+        expect(countEnabled(users, baseConfig({ rollout: 100 }))).toBe(60);
+    });
+
+    it('gates everything behind the environment master switch', () => {
+        const users = generateDemoUsers(60);
+        expect(
+            countEnabled(
+                users,
+                baseConfig({
+                    environmentEnabled: false,
+                    rollout: 100,
+                    targetCountryCodes: ['US'],
+                }),
+            ),
+        ).toBe(0);
+    });
+
+    it('is monotonic: a user enabled at X% stays enabled as the rollout grows', () => {
+        const users = generateDemoUsers(60);
+        const enabledIdsAt = (rollout: number) => {
+            const evaluations = computeEvaluations(
+                users,
+                baseConfig({ rollout }),
+            );
+            return new Set(
+                users.filter((_, i) => evaluations[i].enabled).map((u) => u.id),
+            );
+        };
+        let previous = new Set<string>();
+        for (let rollout = 0; rollout <= 100; rollout += 5) {
+            const current = enabledIdsAt(rollout);
+            for (const id of previous) {
+                expect(current.has(id)).toBe(true);
+            }
+            previous = current;
+        }
+    });
+
+    it('targets a country at 100% regardless of the rollout percentage', () => {
+        const users = generateDemoUsers(60);
+        const evaluations = computeEvaluations(
+            users,
+            baseConfig({ rollout: 0, targetCountryCodes: ['US'] }),
+        );
+        const usIndexes = users
+            .map((u, i) => ({ u, i }))
+            .filter(({ u }) => u.country.code === 'US');
+        expect(usIndexes.length).toBeGreaterThan(0);
+        for (const { i } of usIndexes) {
+            expect(evaluations[i].enabled).toBe(true);
+            expect(evaluations[i].reason).toBe('target');
+        }
+    });
+
+    it('splits enabled users into even, sticky variants', () => {
+        const users = generateDemoUsers(60);
+        const config = baseConfig({
+            rollout: 100,
+            variantsEnabled: true,
+            variants: [
+                { name: 'control', weight: 50 },
+                { name: 'treatment', weight: 50 },
+            ],
+        });
+        const evaluations = computeEvaluations(users, config);
+        for (const evaluation of evaluations) {
+            expect(evaluation.variant).toBeDefined();
+        }
+        const stats = summarize(users, evaluations);
+        expect(stats.variantCounts.control).toBe(30);
+        expect(stats.variantCounts.treatment).toBe(30);
+
+        // stickiness: recomputing with the same config is identical
+        const again = computeEvaluations(users, config);
+        expect(again.map((e) => e.variant)).toEqual(
+            evaluations.map((e) => e.variant),
+        );
+    });
+});

--- a/frontend/src/component/onboarding/closedDemo/demoModel.test.ts
+++ b/frontend/src/component/onboarding/closedDemo/demoModel.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import {
     computeEvaluations,
     type DemoFlagConfig,

--- a/frontend/src/component/onboarding/closedDemo/demoModel.ts
+++ b/frontend/src/component/onboarding/closedDemo/demoModel.ts
@@ -1,0 +1,241 @@
+import {
+    normalizedStrategyValue,
+    normalizedVariantValue,
+} from 'utils/rolloutHash.js';
+
+/**
+ * A synthetic end-user of the pretend "sample app" shown in the onboarding
+ * closed demo. These are not real Unleash users - they exist only so a rollout
+ * percentage / targeting rule / variant split becomes something you can watch.
+ */
+export interface DemoUser {
+    id: string;
+    name: string;
+    country: DemoCountry;
+    plan: 'free' | 'pro';
+}
+
+export interface DemoCountry {
+    code: string;
+    label: string;
+    flag: string;
+}
+
+export const DEMO_COUNTRIES: DemoCountry[] = [
+    { code: 'US', label: 'United States', flag: '🇺🇸' },
+    { code: 'GB', label: 'United Kingdom', flag: '🇬🇧' },
+    { code: 'DE', label: 'Germany', flag: '🇩🇪' },
+    { code: 'IN', label: 'India', flag: '🇮🇳' },
+    { code: 'BR', label: 'Brazil', flag: '🇧🇷' },
+    { code: 'JP', label: 'Japan', flag: '🇯🇵' },
+];
+
+export interface DemoVariant {
+    name: string;
+    /** Weight out of the sum of all variant weights (matches Unleash semantics). */
+    weight: number;
+}
+
+/** Shared constants so every demo variant tells the same story. */
+export const DEMO_FLAG_NAME = 'new-checkout';
+export const DEMO_USER_COUNT = 60;
+export const DEFAULT_VARIANTS: DemoVariant[] = [
+    { name: 'control', weight: 50 },
+    { name: 'treatment', weight: 50 },
+];
+
+export interface DemoFlagConfig {
+    /** Used as the hashing groupId, exactly like a real flag name. */
+    flagName: string;
+    /** The environment master switch - gates every strategy below it. */
+    environmentEnabled: boolean;
+    rollout: number;
+    targetCountryCodes: string[];
+    variantsEnabled: boolean;
+    variants: DemoVariant[];
+}
+
+export type EvaluationReason = 'rollout' | 'target' | 'off';
+
+export interface UserEvaluation {
+    enabled: boolean;
+    reason: EvaluationReason;
+    /** The user's 1-100 rollout bucket; stable across slider changes. */
+    rolloutBucket: number;
+    variant?: string;
+}
+
+const FIRST_NAMES = [
+    'Ada',
+    'Ben',
+    'Cara',
+    'Dev',
+    'Eli',
+    'Fay',
+    'Gus',
+    'Hana',
+    'Ivo',
+    'Jo',
+    'Kit',
+    'Lena',
+    'Milo',
+    'Nia',
+    'Omar',
+    'Pia',
+    'Quinn',
+    'Rai',
+    'Sol',
+    'Tom',
+    'Uma',
+    'Val',
+    'Wren',
+    'Xan',
+    'Yas',
+    'Zoe',
+];
+
+/**
+ * Deterministically generate a stable set of synthetic users. The same index
+ * always yields the same identity, so re-generating never reshuffles the grid.
+ */
+export const generateDemoUsers = (count: number): DemoUser[] =>
+    Array.from({ length: count }, (_, i) => {
+        const country = DEMO_COUNTRIES[i % DEMO_COUNTRIES.length];
+        const name = `${FIRST_NAMES[i % FIRST_NAMES.length]}`;
+        return {
+            id: `user-${i + 1}`,
+            name,
+            country,
+            plan: i % 3 === 0 ? 'pro' : 'free',
+        };
+    });
+
+/**
+ * Evaluate the whole population against the current flag configuration.
+ *
+ * Unlike raw hash bucketing (which, on a small fixed population, visibly skews
+ * away from the slider value), the demo uses an *idealized even distribution*:
+ * users are ranked by their hash and given evenly-spread rollout thresholds, so
+ * an N% rollout lights up ~N% of the grid. Ranking by hash keeps the lit tiles
+ * scattered across the grid (not filling sequentially), and because each user's
+ * threshold is fixed, the rollout is deterministic, sticky, and monotonic - a
+ * user who is in at X% stays in for every value above X. The environment master
+ * switch gates every strategy, exactly like a real flag.
+ */
+export const computeEvaluations = (
+    users: DemoUser[],
+    config: DemoFlagConfig,
+): UserEvaluation[] => {
+    const n = users.length;
+    if (n === 0) {
+        return [];
+    }
+
+    // Even-spread rollout thresholds (1-100), assigned in hash order so the lit
+    // tiles scatter across the grid instead of filling in sequence.
+    const order = users
+        .map((user, index) => ({
+            index,
+            key: normalizedStrategyValue(user.id, config.flagName),
+        }))
+        .sort((a, b) => a.key - b.key || a.index - b.index);
+    const threshold: number[] = new Array(n);
+    order.forEach((entry, rank) => {
+        threshold[entry.index] = Math.round(((rank + 1) / n) * 100);
+    });
+
+    const base = users.map((user, index) => {
+        const inRollout = threshold[index] <= config.rollout;
+        const inTarget =
+            config.targetCountryCodes.length > 0 &&
+            config.targetCountryCodes.includes(user.country.code);
+        const enabled = config.environmentEnabled && (inRollout || inTarget);
+        const reason: EvaluationReason = !enabled
+            ? 'off'
+            : inRollout
+              ? 'rollout'
+              : 'target';
+        return { user, enabled, reason, rolloutBucket: threshold[index] };
+    });
+
+    // Variants: an even split across the enabled users, assigned in variant-hash
+    // order so the split is exact and scattered.
+    const variantByUserId = new Map<string, string>();
+    const totalWeight = config.variants.reduce((acc, v) => acc + v.weight, 0);
+    if (config.variantsEnabled && totalWeight > 0) {
+        const enabled = base
+            .filter((entry) => entry.enabled)
+            .map((entry) => ({
+                id: entry.user.id,
+                key: normalizedVariantValue(
+                    entry.user.id,
+                    config.flagName,
+                    1000,
+                ),
+            }))
+            .sort((a, b) => a.key - b.key || (a.id < b.id ? -1 : 1));
+
+        enabled.forEach((entry, rank) => {
+            const position = ((rank + 0.5) / enabled.length) * totalWeight;
+            let counter = 0;
+            let chosen = config.variants[0].name;
+            for (const variant of config.variants) {
+                counter += variant.weight;
+                if (position <= counter) {
+                    chosen = variant.name;
+                    break;
+                }
+            }
+            variantByUserId.set(entry.id, chosen);
+        });
+    }
+
+    return base.map((entry) => ({
+        enabled: entry.enabled,
+        reason: entry.reason,
+        rolloutBucket: entry.rolloutBucket,
+        variant: entry.enabled ? variantByUserId.get(entry.user.id) : undefined,
+    }));
+};
+
+export interface DemoStats {
+    total: number;
+    enabled: number;
+    percentage: number;
+    variantCounts: Record<string, number>;
+}
+
+/** A ready-to-use flag config (everyone on), spread-overridable per variant. */
+export const defaultFlagConfig = (
+    overrides: Partial<DemoFlagConfig> = {},
+): DemoFlagConfig => ({
+    flagName: DEMO_FLAG_NAME,
+    environmentEnabled: true,
+    rollout: 100,
+    targetCountryCodes: [],
+    variantsEnabled: false,
+    variants: DEFAULT_VARIANTS,
+    ...overrides,
+});
+
+export const summarize = (
+    users: DemoUser[],
+    evaluations: UserEvaluation[],
+): DemoStats => {
+    const enabled = evaluations.filter((e) => e.enabled).length;
+    const variantCounts: Record<string, number> = {};
+    for (const evaluation of evaluations) {
+        if (evaluation.variant) {
+            variantCounts[evaluation.variant] =
+                (variantCounts[evaluation.variant] ?? 0) + 1;
+        }
+    }
+    return {
+        total: users.length,
+        enabled,
+        percentage: users.length
+            ? Math.round((enabled / users.length) * 100)
+            : 0,
+        variantCounts,
+    };
+};

--- a/frontend/src/component/onboarding/closedDemo/frames/DialogFrame.tsx
+++ b/frontend/src/component/onboarding/closedDemo/frames/DialogFrame.tsx
@@ -1,0 +1,46 @@
+import { Box, styled } from '@mui/material';
+import { GridDemo } from '../ClosedDemo.tsx';
+import { MockProjectContent, UnleashChromeMock } from './UnleashChromeMock.tsx';
+
+const StyledFrame = styled(Box)({
+    position: 'relative',
+    height: '100%',
+    overflow: 'hidden',
+});
+
+const StyledBackdrop = styled(Box)({
+    position: 'absolute',
+    inset: 0,
+    background: 'rgba(23, 20, 48, 0.55)',
+    backdropFilter: 'blur(2px)',
+});
+
+const StyledDialog = styled(Box)(({ theme }) => ({
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    width: 'min(960px, 94%)',
+    height: 'min(640px, 90%)',
+    borderRadius: theme.shape.borderRadiusLarge,
+    overflow: 'hidden',
+    background: theme.palette.background.paper,
+    boxShadow: '0 12px 48px rgba(0, 0, 0, 0.3)',
+}));
+
+/**
+ * Framing 2 - the demo as a dialog floating over the (dimmed) Unleash app, like
+ * a first-run onboarding modal. Rendered as an in-container overlay (not a body
+ * portal) so it stays inside the frame.
+ */
+export const DialogFrame = () => (
+    <StyledFrame>
+        <UnleashChromeMock>
+            <MockProjectContent />
+        </UnleashChromeMock>
+        <StyledBackdrop />
+        <StyledDialog>
+            <GridDemo />
+        </StyledDialog>
+    </StyledFrame>
+);

--- a/frontend/src/component/onboarding/closedDemo/frames/DrawerFrame.tsx
+++ b/frontend/src/component/onboarding/closedDemo/frames/DrawerFrame.tsx
@@ -1,0 +1,42 @@
+import { Box, styled } from '@mui/material';
+import { GridDemo } from '../ClosedDemo.tsx';
+import { MockProjectContent, UnleashChromeMock } from './UnleashChromeMock.tsx';
+
+const StyledFrame = styled(Box)({
+    position: 'relative',
+    height: '100%',
+    overflow: 'hidden',
+});
+
+const StyledBackdrop = styled(Box)({
+    position: 'absolute',
+    inset: 0,
+    background: 'rgba(23, 20, 48, 0.4)',
+});
+
+const StyledDrawer = styled(Box)(({ theme }) => ({
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    width: 'min(760px, 96%)',
+    background: theme.palette.background.paper,
+    boxShadow: '-8px 0 40px rgba(0, 0, 0, 0.25)',
+    overflow: 'hidden',
+}));
+
+/**
+ * Framing 3 - the demo as a right-hand drawer/side panel sliding over the app,
+ * matching Unleash's drawer pattern. In-container overlay, not a body portal.
+ */
+export const DrawerFrame = () => (
+    <StyledFrame>
+        <UnleashChromeMock>
+            <MockProjectContent />
+        </UnleashChromeMock>
+        <StyledBackdrop />
+        <StyledDrawer>
+            <GridDemo />
+        </StyledDrawer>
+    </StyledFrame>
+);

--- a/frontend/src/component/onboarding/closedDemo/frames/InlineFrame.tsx
+++ b/frontend/src/component/onboarding/closedDemo/frames/InlineFrame.tsx
@@ -1,0 +1,28 @@
+import { Box, styled } from '@mui/material';
+import { GridDemo } from '../ClosedDemo.tsx';
+import { MockProjectContent, UnleashChromeMock } from './UnleashChromeMock.tsx';
+
+const StyledCard = styled(Box)(({ theme }) => ({
+    height: 560,
+    borderRadius: theme.shape.borderRadiusLarge,
+    border: `1px solid ${theme.palette.divider}`,
+    overflow: 'hidden',
+    background: theme.palette.background.paper,
+    boxShadow: theme.boxShadows.card,
+}));
+
+/**
+ * Framing 4 - the demo embedded inline on the project's feature-flags page,
+ * exactly where the real ProjectOnboarding widget lives. Feels the most native.
+ */
+export const InlineFrame = () => (
+    <UnleashChromeMock>
+        <MockProjectContent
+            topSlot={
+                <StyledCard>
+                    <GridDemo />
+                </StyledCard>
+            }
+        />
+    </UnleashChromeMock>
+);

--- a/frontend/src/component/onboarding/closedDemo/frames/PageFrame.tsx
+++ b/frontend/src/component/onboarding/closedDemo/frames/PageFrame.tsx
@@ -1,0 +1,12 @@
+import { GridDemo } from '../ClosedDemo.tsx';
+import { UnleashChromeMock } from './UnleashChromeMock.tsx';
+
+/**
+ * Framing 1 - the demo as a full Unleash page: real sidebar/logo chrome with the
+ * grid tour filling the content area, as if it were a screen in the product.
+ */
+export const PageFrame = () => (
+    <UnleashChromeMock title='Get started'>
+        <GridDemo />
+    </UnleashChromeMock>
+);

--- a/frontend/src/component/onboarding/closedDemo/frames/SplashFrame.tsx
+++ b/frontend/src/component/onboarding/closedDemo/frames/SplashFrame.tsx
@@ -1,0 +1,63 @@
+import { Box, styled, Typography } from '@mui/material';
+import UnleashLogoWhite from 'assets/img/logoWithWhiteText.svg?react';
+import { GridDemo } from '../ClosedDemo.tsx';
+
+const StyledRoot = styled(Box)(({ theme }) => ({
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: theme.spacing(4),
+    overflow: 'auto',
+    background: `linear-gradient(135deg, ${theme.palette.background.sidebar}, ${theme.palette.primary.dark})`,
+}));
+
+const StyledCard = styled(Box)(({ theme }) => ({
+    width: 'min(980px, 100%)',
+    height: 'min(660px, 100%)',
+    display: 'flex',
+    flexDirection: 'column',
+    borderRadius: theme.shape.borderRadiusLarge,
+    overflow: 'hidden',
+    background: theme.palette.background.paper,
+    boxShadow: '0 20px 60px rgba(0, 0, 0, 0.35)',
+}));
+
+const StyledHeader = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(2),
+    padding: theme.spacing(2, 3),
+    background: theme.palette.background.sidebar,
+    color: '#fff',
+}));
+
+const StyledLogo = styled(UnleashLogoWhite)({
+    height: 26,
+    width: 'auto',
+});
+
+const StyledBody = styled(Box)({
+    flex: 1,
+    minHeight: 0,
+});
+
+/**
+ * Framing 5 - a branded "Welcome to Unleash" splash: a centered card with the
+ * logo header over a branded gradient, hosting the grid tour. First-login feel.
+ */
+export const SplashFrame = () => (
+    <StyledRoot>
+        <StyledCard>
+            <StyledHeader>
+                <StyledLogo aria-label='Unleash logo' />
+                <Typography sx={{ opacity: 0.85 }}>
+                    Welcome! Let’s see what feature flags can do
+                </Typography>
+            </StyledHeader>
+            <StyledBody>
+                <GridDemo />
+            </StyledBody>
+        </StyledCard>
+    </StyledRoot>
+);

--- a/frontend/src/component/onboarding/closedDemo/frames/UnleashChromeMock.tsx
+++ b/frontend/src/component/onboarding/closedDemo/frames/UnleashChromeMock.tsx
@@ -1,0 +1,200 @@
+import type { ReactNode } from 'react';
+import { Box, styled, Typography } from '@mui/material';
+import DashboardOutlinedIcon from '@mui/icons-material/DashboardOutlined';
+import FlagOutlinedIcon from '@mui/icons-material/FlagOutlined';
+import SportsEsportsOutlinedIcon from '@mui/icons-material/SportsEsportsOutlined';
+import AppsOutlinedIcon from '@mui/icons-material/AppsOutlined';
+import InsightsOutlinedIcon from '@mui/icons-material/InsightsOutlined';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+import UnleashLogoWhite from 'assets/img/logoWithWhiteText.svg?react';
+import { PageContent } from 'component/common/PageContent/PageContent.tsx';
+import { PageHeader } from 'component/common/PageHeader/PageHeader.tsx';
+
+const NAV_ITEMS = [
+    { label: 'Projects', icon: DashboardOutlinedIcon, active: true },
+    { label: 'Feature flags', icon: FlagOutlinedIcon },
+    { label: 'Playground', icon: SportsEsportsOutlinedIcon },
+    { label: 'Applications', icon: AppsOutlinedIcon },
+    { label: 'Insights', icon: InsightsOutlinedIcon },
+    { label: 'Configure', icon: SettingsOutlinedIcon },
+];
+
+const StyledRoot = styled(Box)(({ theme }) => ({
+    height: '100%',
+    display: 'flex',
+    overflow: 'hidden',
+    background: theme.palette.background.application,
+}));
+
+const StyledSidebar = styled(Box)(({ theme }) => ({
+    width: 232,
+    flexShrink: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+    padding: theme.spacing(2, 1.5),
+    background: theme.palette.background.sidebar,
+    [theme.breakpoints.down('sm')]: {
+        display: 'none',
+    },
+}));
+
+const StyledLogo = styled(UnleashLogoWhite)(({ theme }) => ({
+    height: 28,
+    width: 'auto',
+    margin: theme.spacing(1, 1, 3),
+}));
+
+const StyledNavItem = styled(Box, {
+    shouldForwardProp: (prop) => prop !== 'active',
+})<{ active?: boolean }>(({ theme, active }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(1, 1.5),
+    borderRadius: theme.shape.borderRadius,
+    color: active ? '#fff' : 'rgba(255,255,255,0.7)',
+    background: active ? 'rgba(255,255,255,0.14)' : 'transparent',
+    fontWeight: active
+        ? theme.typography.fontWeightBold
+        : theme.typography.fontWeightRegular,
+    '& svg': { fontSize: 20 },
+}));
+
+const StyledMain = styled(Box)({
+    flex: 1,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+});
+
+const StyledTopbar = styled(Box)(({ theme }) => ({
+    height: 56,
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: theme.spacing(0, 3),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    background: theme.palette.background.paper,
+}));
+
+const StyledAvatar = styled(Box)(({ theme }) => ({
+    width: 32,
+    height: 32,
+    borderRadius: '50%',
+    background: theme.palette.secondary.border,
+    color: theme.palette.secondary.contrastText,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: theme.fontSizes.smallBody,
+    fontWeight: theme.typography.fontWeightBold,
+}));
+
+const StyledContent = styled(Box)({
+    flex: 1,
+    minHeight: 0,
+    overflow: 'auto',
+});
+
+interface IUnleashChromeMockProps {
+    children: ReactNode;
+    /** Short breadcrumb/title shown in the top bar. */
+    title?: string;
+}
+
+/**
+ * A faithful-but-lightweight mock of the Unleash app shell (dark purple sidebar
+ * with the real logo, top bar, content area) so a demo framing can sit "inside"
+ * the product without wiring the heavy real MainLayout/navigation.
+ */
+export const UnleashChromeMock = ({
+    children,
+    title = 'Projects',
+}: IUnleashChromeMockProps) => (
+    <StyledRoot>
+        <StyledSidebar>
+            <StyledLogo aria-label='Unleash logo' />
+            {NAV_ITEMS.map((item) => {
+                const Icon = item.icon;
+                return (
+                    <StyledNavItem key={item.label} active={item.active}>
+                        <Icon />
+                        <Typography variant='body2'>{item.label}</Typography>
+                    </StyledNavItem>
+                );
+            })}
+        </StyledSidebar>
+        <StyledMain>
+            <StyledTopbar>
+                <Typography sx={{ fontWeight: 'bold' }}>{title}</Typography>
+                <StyledAvatar>AC</StyledAvatar>
+            </StyledTopbar>
+            <StyledContent>{children}</StyledContent>
+        </StyledMain>
+    </StyledRoot>
+);
+
+const StyledPage = styled(Box)(({ theme }) => ({
+    padding: theme.spacing(4),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(3),
+    maxWidth: 1100,
+    margin: '0 auto',
+}));
+
+const StyledBreadcrumb = styled(Typography)(({ theme }) => ({
+    color: theme.palette.text.secondary,
+    fontSize: theme.fontSizes.smallBody,
+}));
+
+const StyledFlagRow = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: theme.spacing(1.5, 0),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+}));
+
+const StyledPill = styled(Box, {
+    shouldForwardProp: (prop) => prop !== 'on',
+})<{ on?: boolean }>(({ theme, on }) => ({
+    padding: theme.spacing(0.25, 1),
+    borderRadius: theme.shape.borderRadius,
+    fontSize: theme.fontSizes.smallerBody,
+    background: on ? theme.palette.success.light : theme.palette.neutral.light,
+    color: on ? theme.palette.success.dark : theme.palette.text.secondary,
+}));
+
+const MOCK_FLAGS = [
+    { name: 'checkout-redesign', on: true },
+    { name: 'search-suggestions', on: false },
+    { name: 'dark-mode', on: true },
+];
+
+/**
+ * A faux project "feature flags" page used as the backdrop / host for framings
+ * that live inside a page (the same place the real ProjectOnboarding widget
+ * sits). Renders an optional `topSlot` above the flag table.
+ */
+export const MockProjectContent = ({ topSlot }: { topSlot?: ReactNode }) => (
+    <StyledPage>
+        <Box>
+            <StyledBreadcrumb>Projects / Default</StyledBreadcrumb>
+            <PageHeader title='Default' />
+        </Box>
+        {topSlot}
+        <PageContent header={<PageHeader title='Feature flags' />}>
+            {MOCK_FLAGS.map((flag) => (
+                <StyledFlagRow key={flag.name}>
+                    <Typography>{flag.name}</Typography>
+                    <StyledPill on={flag.on}>
+                        {flag.on ? 'enabled' : 'disabled'}
+                    </StyledPill>
+                </StyledFlagRow>
+            ))}
+        </PageContent>
+    </StyledPage>
+);

--- a/frontend/src/component/onboarding/flow/ProjectOnboarding.tsx
+++ b/frontend/src/component/onboarding/flow/ProjectOnboarding.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import {
     Accordion,
     AccordionDetails,
@@ -9,9 +10,11 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { ConnectSdkStep } from './steps/ConnectSdkStep.tsx';
 import type { StepState } from './steps/StepLayout.tsx';
 import useProjectOverview from 'hooks/api/getters/useProjectOverview/useProjectOverview';
+import { useUiFlag } from 'hooks/useUiFlag';
 import { OnboardingProgress } from './OnboardingProgress.tsx';
 import { CreateFlagStep } from './steps/CreateFlagStep.tsx';
 import { TurnFlagStep } from './steps/TurnFlagStep.tsx';
+import { OnboardingCelebrationDialog } from '../celebration/OnboardingCelebrationDialog.tsx';
 import { getProjectOnboardingStep } from '../../../utils/getProjectOnboardingStep.ts';
 
 interface IProjectOnboardingProps {
@@ -70,6 +73,24 @@ export const ProjectOnboarding = ({
     refetchFeatures,
 }: IProjectOnboardingProps) => {
     const { project, refetch, loading } = useProjectOverview(projectId);
+    const celebrationEnabled = useUiFlag('onboardingCelebration');
+    const [celebrationOpen, setCelebrationOpen] = useState(false);
+    const previousStatus = useRef<string | undefined>(undefined);
+
+    const status = project.onboardingStatus?.status;
+
+    useEffect(() => {
+        if (loading) return;
+        if (
+            celebrationEnabled &&
+            previousStatus.current !== undefined &&
+            previousStatus.current !== 'onboarded' &&
+            status === 'onboarded'
+        ) {
+            setCelebrationOpen(true);
+        }
+        previousStatus.current = status;
+    }, [loading, status, celebrationEnabled]);
 
     if (loading) return null;
 
@@ -81,46 +102,64 @@ export const ProjectOnboarding = ({
         setOnboardingFlow('closed');
     };
 
+    const onFlagEnabled = () => {
+        refetch();
+        if (celebrationEnabled) {
+            setCelebrationOpen(true);
+        }
+    };
+
     return (
-        <StyledAccordion defaultExpanded>
-            <StyledAccordionSummary
-                expandIcon={<ExpandMoreIcon />}
-                aria-controls='panel1-content'
-                id='panel1-header'
-            >
-                <TitleRow>
-                    <Typography
-                        sx={{
-                            fontWeight: 'bold',
-                        }}
-                    >
-                        Project setup
-                    </Typography>
-                    <OnboardingProgress
-                        step={step}
-                        maxSteps={numberOfSteps}
-                        onDismiss={closeOnboardingFlow}
-                    />
-                </TitleRow>
-            </StyledAccordionSummary>
-            <StyledAccordionDetails>
-                <Actions>
-                    <CreateFlagStep
-                        state={stepState(step, 1)}
-                        refetchFeatures={refetchFeatures}
-                        refetchProject={refetch}
-                    />
-                    <ConnectSdkStep
-                        projectId={projectId}
-                        setConnectSdkOpen={setConnectSdkOpen}
-                        state={stepState(step, 2)}
-                    />
-                    <TurnFlagStep
-                        projectId={projectId}
-                        state={stepState(step, 3)}
-                    />
-                </Actions>
-            </StyledAccordionDetails>
-        </StyledAccordion>
+        <>
+            <StyledAccordion defaultExpanded>
+                <StyledAccordionSummary
+                    expandIcon={<ExpandMoreIcon />}
+                    aria-controls='panel1-content'
+                    id='panel1-header'
+                >
+                    <TitleRow>
+                        <Typography
+                            sx={{
+                                fontWeight: 'bold',
+                            }}
+                        >
+                            Project setup
+                        </Typography>
+                        <OnboardingProgress
+                            step={step}
+                            maxSteps={numberOfSteps}
+                            onDismiss={closeOnboardingFlow}
+                        />
+                    </TitleRow>
+                </StyledAccordionSummary>
+                <StyledAccordionDetails>
+                    <Actions>
+                        <CreateFlagStep
+                            state={stepState(step, 1)}
+                            refetchFeatures={refetchFeatures}
+                            refetchProject={refetch}
+                        />
+                        <ConnectSdkStep
+                            projectId={projectId}
+                            setConnectSdkOpen={setConnectSdkOpen}
+                            state={stepState(step, 2)}
+                        />
+                        <TurnFlagStep
+                            projectId={projectId}
+                            state={stepState(step, 3)}
+                            onFlagEnabled={onFlagEnabled}
+                        />
+                    </Actions>
+                </StyledAccordionDetails>
+            </StyledAccordion>
+            {celebrationEnabled ? (
+                <OnboardingCelebrationDialog
+                    projectId={projectId}
+                    open={celebrationOpen}
+                    onClose={() => setCelebrationOpen(false)}
+                    onConnectSdk={() => setConnectSdkOpen(true)}
+                />
+            ) : null}
+        </>
     );
 };

--- a/frontend/src/component/onboarding/flow/steps/TurnFlagStep.tsx
+++ b/frontend/src/component/onboarding/flow/steps/TurnFlagStep.tsx
@@ -1,23 +1,98 @@
-import { Button } from '@mui/material';
+import { useState } from 'react';
+import { Button, styled, Typography } from '@mui/material';
 import ToggleOnIcon from '@mui/icons-material/ToggleOn';
 import CheckIcon from '@mui/icons-material/Check';
 import { Link } from 'react-router';
 import { useFeatureSearch } from 'hooks/api/getters/useFeatureSearch/useFeatureSearch';
+import useFeatureApi from 'hooks/api/actions/useFeatureApi/useFeatureApi';
+import useToast from 'hooks/useToast';
+import { formatUnknownError } from 'utils/formatUnknownError';
+import { useUiFlag } from 'hooks/useUiFlag';
+import PermissionSwitch from 'component/common/PermissionSwitch/PermissionSwitch';
+import { UPDATE_FEATURE_ENVIRONMENT } from 'component/providers/AccessProvider/permissions';
 import { StepLayout, type StepState } from './StepLayout.tsx';
+import { getOnboardingEnvironment } from './getOnboardingEnvironment.ts';
 
 interface ITurnFlagStepProps {
     projectId: string;
     state: StepState;
+    onFlagEnabled?: () => void;
 }
 
-export const TurnFlagStep = ({ projectId, state }: ITurnFlagStepProps) => {
-    const { features } = useFeatureSearch({
+const SwitchRow = styled('div')(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+}));
+
+const SwitchLabel = styled(Typography)(({ theme }) => ({
+    fontSize: theme.typography.body2.fontSize,
+    color: theme.palette.text.secondary,
+}));
+
+export const TurnFlagStep = ({
+    projectId,
+    state,
+    onFlagEnabled,
+}: ITurnFlagStepProps) => {
+    const celebrationEnabled = useUiFlag('onboardingCelebration');
+    const { features, refetch: refetchFeatures } = useFeatureSearch({
         project: `IS:${projectId}`,
     });
-    const firstFeature = features[0]?.name;
+    const { toggleFeatureEnvironmentOn } = useFeatureApi();
+    const { setToastData, setToastApiError } = useToast();
+    const [isToggling, setIsToggling] = useState(false);
+
+    const firstFeature = features[0];
+    const environment = getOnboardingEnvironment(firstFeature);
     const goToFlagHref = firstFeature
-        ? `/projects/${projectId}/features/${firstFeature}`
+        ? `/projects/${projectId}/features/${firstFeature.name}`
         : `/projects/${projectId}`;
+
+    const onEnableFlag = async (featureName: string, environmentId: string) => {
+        setIsToggling(true);
+        try {
+            await toggleFeatureEnvironmentOn(
+                projectId,
+                featureName,
+                environmentId,
+                true,
+            );
+            setToastData({
+                type: 'success',
+                text: `Enabled in ${environmentId}`,
+            });
+            refetchFeatures();
+            onFlagEnabled?.();
+        } catch (error: unknown) {
+            setToastApiError(formatUnknownError(error));
+        } finally {
+            setIsToggling(false);
+        }
+    };
+
+    const inlineToggle =
+        celebrationEnabled && firstFeature && environment ? (
+            <SwitchRow>
+                <PermissionSwitch
+                    permission={UPDATE_FEATURE_ENVIRONMENT}
+                    projectId={projectId}
+                    environmentId={environment.name}
+                    checked={environment.enabled}
+                    disabled={isToggling || environment.enabled}
+                    onChange={(event) => {
+                        if (event.target.checked) {
+                            onEnableFlag(firstFeature.name, environment.name);
+                        }
+                    }}
+                />
+                <SwitchLabel>
+                    Enable <strong>{firstFeature.name}</strong> in{' '}
+                    {environment.name}
+                </SwitchLabel>
+            </SwitchRow>
+        ) : null;
 
     return (
         <StepLayout
@@ -37,15 +112,17 @@ export const TurnFlagStep = ({ projectId, state }: ITurnFlagStepProps) => {
                     Done
                 </Button>
             ) : state === 'active' ? (
-                <Button
-                    variant='contained'
-                    color='primary'
-                    component={Link}
-                    nativeButton={false}
-                    to={goToFlagHref}
-                >
-                    Go to flag
-                </Button>
+                (inlineToggle ?? (
+                    <Button
+                        variant='contained'
+                        color='primary'
+                        component={Link}
+                        nativeButton={false}
+                        to={goToFlagHref}
+                    >
+                        Go to flag
+                    </Button>
+                ))
             ) : (
                 <Button variant='contained' color='primary' disabled>
                     Go to flag

--- a/frontend/src/component/onboarding/flow/steps/getOnboardingEnvironment.ts
+++ b/frontend/src/component/onboarding/flow/steps/getOnboardingEnvironment.ts
@@ -1,0 +1,19 @@
+import type {
+    FeatureSearchEnvironmentSchema,
+    FeatureSearchResponseSchema,
+} from 'openapi';
+
+/**
+ * Picks the environment a new user should flip their first flag in:
+ * the first development environment, or the first environment otherwise.
+ */
+export const getOnboardingEnvironment = (
+    feature: FeatureSearchResponseSchema | undefined,
+): FeatureSearchEnvironmentSchema | undefined => {
+    const environments = feature?.environments ?? [];
+    return (
+        environments.find(
+            (environment) => environment.type === 'development',
+        ) ?? environments[0]
+    );
+};

--- a/frontend/src/component/onboarding/gettingStarted/GettingStartedChecklist.tsx
+++ b/frontend/src/component/onboarding/gettingStarted/GettingStartedChecklist.tsx
@@ -1,0 +1,230 @@
+import type { FC } from 'react';
+import {
+    Box,
+    Collapse,
+    IconButton,
+    LinearProgress,
+    styled,
+    Typography,
+} from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import CloseIcon from '@mui/icons-material/Close';
+import { Link } from 'react-router';
+import { useUiFlag } from 'hooks/useUiFlag';
+import { useLocalStorageState } from 'hooks/useLocalStorageState';
+import useProjects, {
+    type ProjectListItem,
+} from 'hooks/api/getters/useProjects/useProjects';
+import { useInviteTokens } from 'hooks/api/getters/useInviteTokens/useInviteTokens';
+import {
+    deriveGettingStartedSteps,
+    type GettingStartedStep,
+    type GettingStartedStepId,
+} from './deriveGettingStartedSteps.ts';
+
+type ChecklistState = {
+    dismissed: boolean;
+    collapsed: boolean;
+    manualSteps: GettingStartedStepId[];
+};
+
+const initialState: ChecklistState = {
+    dismissed: false,
+    collapsed: false,
+    manualSteps: [],
+};
+
+const StyledContainer = styled(Box)(({ theme }) => ({
+    backgroundColor: theme.palette.background.elevation1,
+    borderRadius: theme.shape.borderRadiusMedium,
+    padding: theme.spacing(1.5),
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+}));
+
+const StyledHeader = styled(Box)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+}));
+
+const StyledTitle = styled(Typography)(({ theme }) => ({
+    flex: 1,
+    fontSize: theme.fontSizes.smallBody,
+    fontWeight: theme.typography.fontWeightBold,
+}));
+
+const StyledProgress = styled(LinearProgress)(({ theme }) => ({
+    marginTop: theme.spacing(1),
+    borderRadius: theme.shape.borderRadius,
+    height: theme.spacing(0.75),
+}));
+
+const StyledStepList = styled('ul')(({ theme }) => ({
+    listStyle: 'none',
+    margin: 0,
+    marginTop: theme.spacing(1),
+    padding: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+}));
+
+const StyledStepLink = styled(Link)(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    textDecoration: 'none',
+    color: theme.palette.text.primary,
+    fontSize: theme.fontSizes.smallBody,
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(0.5),
+    '&:hover': {
+        backgroundColor: theme.palette.action.hover,
+    },
+}));
+
+const StyledCompletedIcon = styled(CheckCircleIcon)(({ theme }) => ({
+    fontSize: theme.fontSizes.bodySize,
+    color: theme.palette.success.main,
+}));
+
+const StyledUncompletedIcon = styled(RadioButtonUncheckedIcon)(({ theme }) => ({
+    fontSize: theme.fontSizes.bodySize,
+    color: theme.palette.text.disabled,
+}));
+
+const StyledStepText = styled('span', {
+    shouldForwardProp: (prop) => prop !== 'completed',
+})<{ completed: boolean }>(({ theme, completed }) => ({
+    textDecoration: completed ? 'line-through' : 'none',
+    color: completed ? theme.palette.text.secondary : 'inherit',
+}));
+
+const ChecklistStep: FC<{
+    step: GettingStartedStep;
+    onNavigate: (step: GettingStartedStep) => void;
+}> = ({ step, onNavigate }) => (
+    <li>
+        <StyledStepLink to={step.href} onClick={() => onNavigate(step)}>
+            {step.completed ? (
+                <StyledCompletedIcon aria-label='Completed' />
+            ) : (
+                <StyledUncompletedIcon aria-label='Not completed' />
+            )}
+            <StyledStepText completed={step.completed}>
+                {step.title}
+            </StyledStepText>
+        </StyledStepLink>
+    </li>
+);
+
+export const GettingStartedChecklist: FC<{ mode: 'mini' | 'full' }> = ({
+    mode,
+}) => {
+    const checklistEnabled = useUiFlag('gettingStartedChecklist');
+    const [state, setState] = useLocalStorageState<ChecklistState>(
+        'getting-started-checklist:v1',
+        initialState,
+    );
+    const { projects, loading } = useProjects();
+    const { data: inviteTokens } = useInviteTokens();
+
+    if (!checklistEnabled || mode !== 'full' || state.dismissed || loading) {
+        return null;
+    }
+
+    const steps = deriveGettingStartedSteps({
+        projects: projects as ProjectListItem[],
+        hasActiveInviteToken: Boolean(inviteTokens?.tokens?.length),
+        manualSteps: state.manualSteps,
+    });
+    const completedCount = steps.filter((step) => step.completed).length;
+    const allCompleted = completedCount === steps.length;
+
+    const dismiss = () => {
+        setState((prevState) => ({ ...prevState, dismissed: true }));
+    };
+
+    const toggleCollapsed = () => {
+        setState((prevState) => ({
+            ...prevState,
+            collapsed: !prevState.collapsed,
+        }));
+    };
+
+    const onNavigate = (step: GettingStartedStep) => {
+        if (step.manual && !state.manualSteps.includes(step.id)) {
+            setState((prevState) => ({
+                ...prevState,
+                manualSteps: [...prevState.manualSteps, step.id],
+            }));
+        }
+    };
+
+    if (allCompleted) {
+        return (
+            <StyledContainer>
+                <StyledHeader>
+                    <StyledTitle>You're all set 🎉</StyledTitle>
+                    <IconButton
+                        size='small'
+                        onClick={dismiss}
+                        aria-label='Dismiss getting started checklist'
+                    >
+                        <CloseIcon fontSize='inherit' />
+                    </IconButton>
+                </StyledHeader>
+            </StyledContainer>
+        );
+    }
+
+    return (
+        <StyledContainer>
+            <StyledHeader>
+                <StyledTitle>Getting started</StyledTitle>
+                <IconButton
+                    size='small'
+                    onClick={toggleCollapsed}
+                    aria-label={
+                        state.collapsed
+                            ? 'Expand getting started checklist'
+                            : 'Collapse getting started checklist'
+                    }
+                >
+                    {state.collapsed ? (
+                        <ExpandLessIcon fontSize='inherit' />
+                    ) : (
+                        <ExpandMoreIcon fontSize='inherit' />
+                    )}
+                </IconButton>
+                <IconButton
+                    size='small'
+                    onClick={dismiss}
+                    aria-label='Dismiss getting started checklist'
+                >
+                    <CloseIcon fontSize='inherit' />
+                </IconButton>
+            </StyledHeader>
+            <StyledProgress
+                variant='determinate'
+                value={(completedCount / steps.length) * 100}
+                aria-label={`${completedCount} of ${steps.length} steps completed`}
+            />
+            <Collapse in={!state.collapsed}>
+                <StyledStepList>
+                    {steps.map((step) => (
+                        <ChecklistStep
+                            key={step.id}
+                            step={step}
+                            onNavigate={onNavigate}
+                        />
+                    ))}
+                </StyledStepList>
+            </Collapse>
+        </StyledContainer>
+    );
+};

--- a/frontend/src/component/onboarding/gettingStarted/deriveGettingStartedSteps.test.ts
+++ b/frontend/src/component/onboarding/gettingStarted/deriveGettingStartedSteps.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'vitest';
+import type { ProjectListItem } from 'hooks/api/getters/useProjects/useProjects';
+import { deriveGettingStartedSteps } from './deriveGettingStartedSteps.ts';
+
+const project = (overrides: Partial<ProjectListItem> = {}): ProjectListItem =>
+    ({
+        id: 'default',
+        name: 'Default',
+        ...overrides,
+    }) as ProjectListItem;
+
+const derive = (
+    projects: ProjectListItem[],
+    options: {
+        hasActiveInviteToken?: boolean;
+        manualSteps?: ('add-strategy' | 'invite-teammate')[];
+    } = {},
+) =>
+    deriveGettingStartedSteps({
+        projects,
+        hasActiveInviteToken: options.hasActiveInviteToken ?? false,
+        manualSteps: options.manualSteps ?? [],
+    });
+
+const completedIds = (steps: ReturnType<typeof derive>) =>
+    steps.filter((step) => step.completed).map((step) => step.id);
+
+describe('deriveGettingStartedSteps', () => {
+    test('no projects means nothing is completed', () => {
+        expect(completedIds(derive([]))).toEqual([]);
+    });
+
+    test('first-flag-created status completes the create flag step', () => {
+        const steps = derive([
+            project({
+                onboardingStatus: {
+                    status: 'first-flag-created',
+                    feature: 'my-flag',
+                },
+            }),
+        ]);
+        expect(completedIds(steps)).toEqual(['create-flag']);
+    });
+
+    test('a project with flags completes the create flag step even without onboarding status', () => {
+        const steps = derive([project({ featureCount: 3 })]);
+        expect(completedIds(steps)).toEqual(['create-flag']);
+    });
+
+    test('sdk-connected status completes create flag and connect SDK steps', () => {
+        const steps = derive([
+            project({
+                onboardingStatus: { status: 'sdk-connected' },
+            }),
+        ]);
+        expect(completedIds(steps)).toEqual(['create-flag', 'connect-sdk']);
+    });
+
+    test('onboarded status completes create flag, enable flag and connect SDK steps', () => {
+        const steps = derive([
+            project({ onboardingStatus: { status: 'onboarded' } as const }),
+        ]);
+        expect(completedIds(steps)).toEqual([
+            'create-flag',
+            'enable-flag',
+            'connect-sdk',
+        ]);
+    });
+
+    test('more than one project member completes the invite teammate step', () => {
+        const steps = derive([project({ memberCount: 2 })]);
+        expect(completedIds(steps)).toContain('invite-teammate');
+    });
+
+    test('an active invite token completes the invite teammate step', () => {
+        const steps = derive([project()], { hasActiveInviteToken: true });
+        expect(completedIds(steps)).toContain('invite-teammate');
+    });
+
+    test('manual markers complete the strategy and invite steps', () => {
+        const steps = derive([project()], {
+            manualSteps: ['add-strategy', 'invite-teammate'],
+        });
+        expect(completedIds(steps)).toEqual([
+            'add-strategy',
+            'invite-teammate',
+        ]);
+    });
+
+    test('links point at the default project when it exists', () => {
+        const steps = derive([
+            project({ id: 'other' }),
+            project({ id: 'default' }),
+        ]);
+        expect(steps[0].href).toBe('/projects/default');
+    });
+
+    test('links fall back to the first project when there is no default project', () => {
+        const steps = derive([project({ id: 'other' })]);
+        expect(steps[0].href).toBe('/projects/other');
+    });
+
+    test('the invite teammate step links to the invite link admin page', () => {
+        const steps = derive([project()]);
+        expect(steps.find((step) => step.id === 'invite-teammate')?.href).toBe(
+            '/admin/invite-link',
+        );
+    });
+});

--- a/frontend/src/component/onboarding/gettingStarted/deriveGettingStartedSteps.ts
+++ b/frontend/src/component/onboarding/gettingStarted/deriveGettingStartedSteps.ts
@@ -1,0 +1,100 @@
+import type { ProjectListItem } from 'hooks/api/getters/useProjects/useProjects';
+
+export type GettingStartedStepId =
+    | 'create-flag'
+    | 'enable-flag'
+    | 'connect-sdk'
+    | 'add-strategy'
+    | 'invite-teammate';
+
+export type GettingStartedStep = {
+    id: GettingStartedStepId;
+    title: string;
+    href: string;
+    completed: boolean;
+    /**
+     * Manual steps have no reliable server-side signal, so they are
+     * marked as completed in localStorage when the user follows the link.
+     */
+    manual: boolean;
+};
+
+const FLAG_CREATED_STATUSES = [
+    'first-flag-created',
+    'sdk-connected',
+    'onboarded',
+];
+
+const SDK_CONNECTED_STATUSES = ['sdk-connected', 'onboarded'];
+
+const hasOnboardingStatus = (
+    projects: ProjectListItem[],
+    statuses: string[],
+): boolean =>
+    projects.some((project) =>
+        statuses.includes(project.onboardingStatus?.status ?? ''),
+    );
+
+export const deriveGettingStartedSteps = ({
+    projects,
+    hasActiveInviteToken,
+    manualSteps,
+}: {
+    projects: ProjectListItem[];
+    hasActiveInviteToken: boolean;
+    manualSteps: GettingStartedStepId[];
+}): GettingStartedStep[] => {
+    const targetProjectId =
+        projects.find((project) => project.id === 'default')?.id ??
+        projects[0]?.id ??
+        'default';
+    const projectPath = `/projects/${encodeURIComponent(targetProjectId)}`;
+
+    const flagCreated =
+        hasOnboardingStatus(projects, FLAG_CREATED_STATUSES) ||
+        projects.some((project) => (project.featureCount ?? 0) > 0);
+    const sdkConnected = hasOnboardingStatus(projects, SDK_CONNECTED_STATUSES);
+    const onboarded = hasOnboardingStatus(projects, ['onboarded']);
+    const teammateInvited =
+        hasActiveInviteToken ||
+        projects.some((project) => (project.memberCount ?? 0) > 1) ||
+        manualSteps.includes('invite-teammate');
+
+    return [
+        {
+            id: 'create-flag',
+            title: 'Create your first feature flag',
+            href: projectPath,
+            completed: flagCreated,
+            manual: false,
+        },
+        {
+            id: 'enable-flag',
+            title: 'Turn it on',
+            href: projectPath,
+            completed: onboarded,
+            manual: false,
+        },
+        {
+            id: 'connect-sdk',
+            title: 'Connect an SDK',
+            href: projectPath,
+            completed: sdkConnected,
+            manual: false,
+        },
+        {
+            id: 'add-strategy',
+            title: 'Add a targeting/rollout strategy',
+            href: projectPath,
+            completed: manualSteps.includes('add-strategy'),
+            manual: true,
+        },
+        {
+            id: 'invite-teammate',
+            title: 'Invite a teammate',
+            href: '/admin/invite-link',
+            completed: teammateInvited,
+            manual: true,
+        },
+    ];
+};

--- a/frontend/src/component/onboarding/personaWelcome/PersonaWelcomeCard.test.tsx
+++ b/frontend/src/component/onboarding/personaWelcome/PersonaWelcomeCard.test.tsx
@@ -1,0 +1,62 @@
+import { beforeEach, expect, test } from 'vitest';
+import { screen } from '@testing-library/react';
+import { render } from 'utils/testRenderer';
+import { testServerRoute, testServerSetup } from 'utils/testServer';
+import { PersonaWelcomeCard } from './PersonaWelcomeCard.tsx';
+import { PERSONA_OVERRIDE_STORAGE_KEY } from './persona.ts';
+
+const server = testServerSetup();
+
+const setupApi = ({ companyRole }: { companyRole?: string } = {}) => {
+    testServerRoute(server, '/api/admin/ui-config', {
+        flags: { personaOnboarding: true },
+    });
+    testServerRoute(server, '/api/admin/user', {
+        user: { name: 'Unleash User', companyRole },
+    });
+    testServerRoute(server, '/api/admin/personal-dashboard', {
+        projects: [{ id: 'my-project', name: 'My project' }],
+        flags: [],
+    });
+};
+
+beforeEach(() => {
+    window.localStorage.clear();
+});
+
+test('shows the developer experience for technical roles', async () => {
+    setupApi({ companyRole: 'Developer' });
+
+    render(<PersonaWelcomeCard />);
+
+    await screen.findByText('Get a flag working in your code in minutes');
+    await screen.findByText('Developer persona');
+    expect(
+        await screen.findByRole('link', { name: 'Create a flag' }),
+    ).toHaveAttribute('href', '/projects/my-project');
+});
+
+test('shows the product experience for product roles', async () => {
+    setupApi({ companyRole: 'Product Manager' });
+
+    render(<PersonaWelcomeCard />);
+
+    await screen.findByText(
+        'See how Unleash de-risks your releases — no code needed',
+    );
+    await screen.findByText('Product persona');
+    expect(
+        await screen.findByRole('link', { name: 'Invite a developer' }),
+    ).toHaveAttribute('href', '/admin/invite-link');
+});
+
+test('localStorage override takes precedence over the stored company role', async () => {
+    setupApi({ companyRole: 'Developer' });
+    window.localStorage.setItem(PERSONA_OVERRIDE_STORAGE_KEY, 'Executive');
+
+    render(<PersonaWelcomeCard />);
+
+    await screen.findByText(
+        'See how Unleash de-risks your releases — no code needed',
+    );
+});

--- a/frontend/src/component/onboarding/personaWelcome/PersonaWelcomeCard.tsx
+++ b/frontend/src/component/onboarding/personaWelcome/PersonaWelcomeCard.tsx
@@ -1,0 +1,219 @@
+import { useState, type FC } from 'react';
+import {
+    Button,
+    Chip,
+    IconButton,
+    MenuItem,
+    styled,
+    TextField,
+    Tooltip,
+    Typography,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { Link } from 'react-router';
+import { useAuthUser } from 'hooks/api/getters/useAuth/useAuthUser';
+import { usePersonalDashboard } from 'hooks/api/getters/usePersonalDashboard/usePersonalDashboard';
+import { useLocalStorageState } from 'hooks/useLocalStorageState';
+import { useUiFlag } from 'hooks/useUiFlag';
+import {
+    companyRoles,
+    type CompanyRole,
+    readPersonaOverride,
+    resolvePersona,
+    writePersonaOverride,
+} from './persona.ts';
+
+const isKnownRole = (role: string): role is CompanyRole =>
+    (companyRoles as readonly string[]).includes(role);
+
+const StyledContainer = styled('article')(({ theme }) => ({
+    display: 'flex',
+    flexFlow: 'column nowrap',
+    gap: theme.spacing(2),
+    padding: theme.spacing(3, 4),
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadiusMedium,
+    backgroundColor: theme.palette.background.paper,
+    boxShadow: 'none',
+    position: 'relative',
+}));
+
+const StyledHeader = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1.5),
+    paddingRight: theme.spacing(4),
+}));
+
+const StyledTitle = styled('h3')(({ theme }) => ({
+    margin: 0,
+    fontSize: theme.typography.body1.fontSize,
+    fontWeight: theme.typography.fontWeightBold,
+}));
+
+const StyledActions = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(1.5),
+}));
+
+const StyledFooter = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+}));
+
+const StyledCloseButton = styled(IconButton)(({ theme }) => ({
+    position: 'absolute',
+    top: theme.spacing(1),
+    right: theme.spacing(1),
+}));
+
+const StyledPersonaSelect = styled(TextField)(({ theme }) => ({
+    minWidth: theme.spacing(25),
+}));
+
+const TechnicalActions: FC<{ projectId: string }> = ({ projectId }) => (
+    <StyledActions>
+        <Button
+            component={Link}
+            nativeButton={false}
+            to={`/projects/${projectId}`}
+            variant='contained'
+        >
+            Create a flag
+        </Button>
+        <Button
+            component={Link}
+            nativeButton={false}
+            to={`/projects/${projectId}`}
+            variant='outlined'
+        >
+            Connect an SDK
+        </Button>
+        <Button
+            href='https://docs.getunleash.io/sdks'
+            target='_blank'
+            rel='noopener noreferrer'
+        >
+            View SDK docs
+        </Button>
+    </StyledActions>
+);
+
+const ProductActions: FC = () => (
+    <StyledActions>
+        <Button
+            component={Link}
+            nativeButton={false}
+            to='/admin/invite-link'
+            variant='contained'
+        >
+            Invite a developer
+        </Button>
+        <Button
+            component={Link}
+            nativeButton={false}
+            to='/playground'
+            variant='outlined'
+        >
+            Explore a gradual rollout
+        </Button>
+        <Button
+            href='https://docs.getunleash.io/guides/getting-started-release-management'
+            target='_blank'
+            rel='noopener noreferrer'
+        >
+            Release management overview
+        </Button>
+    </StyledActions>
+);
+
+export const PersonaWelcomeCard: FC = () => {
+    const personaOnboardingEnabled = useUiFlag('personaOnboarding');
+    const { user } = useAuthUser();
+    const { personalDashboard } = usePersonalDashboard();
+    const [override, setOverride] = useState(readPersonaOverride);
+    const [cardState, setCardState] = useLocalStorageState<'open' | 'closed'>(
+        'persona-welcome:v1',
+        'open',
+    );
+
+    if (!personaOnboardingEnabled || cardState === 'closed') {
+        return null;
+    }
+
+    const companyRole = override || user?.companyRole || '';
+    const persona = resolvePersona(companyRole);
+    const projectId = personalDashboard?.projects[0]?.id ?? 'default';
+
+    const onPersonaChange = (companyRole: string) => {
+        writePersonaOverride(companyRole);
+        setOverride(companyRole);
+    };
+
+    return (
+        <StyledContainer>
+            <Tooltip title='Dismiss' arrow>
+                <StyledCloseButton
+                    aria-label='dismiss'
+                    onClick={() => setCardState('closed')}
+                    size='small'
+                >
+                    <CloseIcon />
+                </StyledCloseButton>
+            </Tooltip>
+            <StyledHeader>
+                <StyledTitle>
+                    {persona === 'product'
+                        ? 'See how Unleash de-risks your releases — no code needed'
+                        : 'Get a flag working in your code in minutes'}
+                </StyledTitle>
+                <Tooltip
+                    title={
+                        companyRole
+                            ? `Based on your role: ${companyRole}`
+                            : 'No role set; showing the developer experience'
+                    }
+                    arrow
+                >
+                    <Chip
+                        size='small'
+                        label={
+                            persona === 'product'
+                                ? 'Product persona'
+                                : 'Developer persona'
+                        }
+                    />
+                </Tooltip>
+            </StyledHeader>
+            <Typography variant='body2'>
+                {persona === 'product'
+                    ? 'Feature flags let you roll out gradually, test in production safely, and roll back instantly. Try it hands-on — no SDK setup required.'
+                    : 'Create your first feature flag, connect an SDK, and control your code from Unleash — all in a few minutes.'}
+            </Typography>
+            {persona === 'product' ? (
+                <ProductActions />
+            ) : (
+                <TechnicalActions projectId={projectId} />
+            )}
+            <StyledFooter>
+                <StyledPersonaSelect
+                    select
+                    size='small'
+                    label='Not your role?'
+                    value={isKnownRole(companyRole) ? companyRole : ''}
+                    onChange={(event) => onPersonaChange(event.target.value)}
+                >
+                    {companyRoles.map((role) => (
+                        <MenuItem key={role} value={role}>
+                            {role}
+                        </MenuItem>
+                    ))}
+                </StyledPersonaSelect>
+            </StyledFooter>
+        </StyledContainer>
+    );
+};

--- a/frontend/src/component/onboarding/personaWelcome/persona.test.ts
+++ b/frontend/src/component/onboarding/personaWelcome/persona.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'vitest';
+import { resolvePersona } from './persona.ts';
+
+test.each([
+    'Developer',
+    'DevOps Engineer',
+    'QA/Test Engineer',
+    'Other',
+])('resolves %s to the technical persona', (role) => {
+    expect(resolvePersona(role)).toBe('technical');
+});
+
+test.each([
+    'Product Manager',
+    'Engineering Manager',
+    'Executive',
+    'Designer/UX',
+])('resolves %s to the product persona', (role) => {
+    expect(resolvePersona(role)).toBe('product');
+});
+
+test('falls back to the technical persona when the role is unset or unknown', () => {
+    expect(resolvePersona(undefined)).toBe('technical');
+    expect(resolvePersona(null)).toBe('technical');
+    expect(resolvePersona('')).toBe('technical');
+    expect(resolvePersona('Astronaut')).toBe('technical');
+});

--- a/frontend/src/component/onboarding/personaWelcome/persona.ts
+++ b/frontend/src/component/onboarding/personaWelcome/persona.ts
@@ -1,0 +1,53 @@
+/**
+ * Persona detection for the personalized onboarding welcome card.
+ *
+ * The signup flow asks "What's your role?" and stores it as `companyRole`
+ * on the user. These helpers map that role to one of two onboarding
+ * personas. Since `companyRole` is often unset (OSS/dev environments),
+ * a localStorage override is supported for demos and for users who want
+ * to switch persona after the fact.
+ */
+
+export const PERSONA_OVERRIDE_STORAGE_KEY = 'unleash-persona-override';
+
+// Keep in sync with the role options in SignupDialogAccountDetails.
+export const companyRoles = [
+    'Developer',
+    'Engineering Manager',
+    'Product Manager',
+    'Designer/UX',
+    'DevOps Engineer',
+    'QA/Test Engineer',
+    'Executive',
+    'Other',
+] as const;
+
+export type CompanyRole = (typeof companyRoles)[number];
+
+export type Persona = 'technical' | 'product';
+
+const productRoles: ReadonlySet<string> = new Set([
+    'Product Manager',
+    'Engineering Manager',
+    'Executive',
+    'Designer/UX',
+]);
+
+export const resolvePersona = (companyRole?: string | null): Persona =>
+    companyRole && productRoles.has(companyRole) ? 'product' : 'technical';
+
+export const readPersonaOverride = (): string | null => {
+    try {
+        return window.localStorage.getItem(PERSONA_OVERRIDE_STORAGE_KEY);
+    } catch {
+        return null;
+    }
+};
+
+export const writePersonaOverride = (companyRole: string): void => {
+    try {
+        window.localStorage.setItem(PERSONA_OVERRIDE_STORAGE_KEY, companyRole);
+    } catch {
+        // localStorage unavailable (e.g. blocked); override is best-effort
+    }
+};

--- a/frontend/src/component/personalDashboard/PersonalDashboard.tsx
+++ b/frontend/src/component/personalDashboard/PersonalDashboard.tsx
@@ -23,6 +23,7 @@ import { EventTimeline } from 'component/events/EventTimeline/EventTimeline';
 import { AccordionContent } from './SharedComponents.tsx';
 import { Link } from 'react-router';
 import { useWelcomeDialogContext } from './WelcomeDialogContext.tsx';
+import { PersonaWelcomeCard } from 'component/onboarding/personaWelcome/PersonaWelcomeCard';
 
 const WelcomeSection = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -311,6 +312,8 @@ export const PersonalDashboard = () => {
                     View key concepts
                 </ViewKeyConceptsButton>
             </WelcomeSection>
+
+            <PersonaWelcomeCard />
 
             <EventTimelinePanel />
 

--- a/frontend/src/component/project/ProjectList/ProjectList.tsx
+++ b/frontend/src/component/project/ProjectList/ProjectList.tsx
@@ -20,6 +20,7 @@ import { ProjectsListHeader } from './ProjectsListHeader/ProjectsListHeader.tsx'
 import useUiConfig from 'hooks/api/getters/useUiConfig/useUiConfig';
 import { TablePlaceholder } from 'component/common/Table/index.ts';
 import { ProjectsListViewToggle } from './ProjectsListViewToggle/ProjectsListViewToggle.tsx';
+import { CreateDemoProjectButton } from 'component/demoProject/CreateDemoProjectButton.tsx';
 
 const StyledApiError = styled(ApiError)(({ theme }) => ({
     maxWidth: '500px',
@@ -30,6 +31,12 @@ const StyledContainer = styled('div')(({ theme }) => ({
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(4),
+}));
+
+const StyledEmptyStateActions = styled('div')(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'center',
+    marginTop: theme.spacing(2),
 }));
 
 const projectCardDisplayLimit = 500;
@@ -100,6 +107,7 @@ export const ProjectList = () => {
                             />
 
                             {!isOss() && <ProjectArchiveLink />}
+                            <CreateDemoProjectButton />
                             <ProjectCreationButton
                                 isDialogOpen={Boolean(state.create)}
                                 setIsDialogOpen={(create) =>
@@ -195,9 +203,14 @@ export const ProjectList = () => {
                                         &rdquo;
                                     </TablePlaceholder>
                                 ) : (
-                                    <TablePlaceholder>
-                                        No projects available.
-                                    </TablePlaceholder>
+                                    <>
+                                        <TablePlaceholder>
+                                            No projects available.
+                                        </TablePlaceholder>
+                                        <StyledEmptyStateActions>
+                                            <CreateDemoProjectButton variant='contained' />
+                                        </StyledEmptyStateActions>
+                                    </>
                                 )}
                             </>
                         )}

--- a/frontend/src/component/signup/SignupDialog/SignupDialog.tsx
+++ b/frontend/src/component/signup/SignupDialog/SignupDialog.tsx
@@ -20,6 +20,8 @@ import Heart from 'assets/icons/heart.svg?react';
 import { formatAssetPath } from 'utils/formatPath.ts';
 import { SignupDialogComplete } from './SignupDialogComplete.tsx';
 import { useEventTracker } from 'hooks/useEventTracker.ts';
+import { useUiFlag } from 'hooks/useUiFlag.ts';
+import { ClosedDemo } from 'component/onboarding/closedDemo/ClosedDemo.tsx';
 import {
     DEFAULT_PROJECT_ID,
     useDefaultProjectId,
@@ -226,6 +228,11 @@ export const SignupDialog = () => {
     const { submitSignupData } = useSignupApi();
     const navigate = useNavigate();
     const defaultProjectId = useDefaultProjectId();
+    const closedDemoEnabled = useUiFlag('onboardingClosedDemo');
+    const [showDemo, setShowDemo] = useState(false);
+
+    const goToProject = () =>
+        navigate(`/projects/${defaultProjectId ?? DEFAULT_PROJECT_ID}`);
 
     const [data, setData] = useState<SubmitSignupData>({
         password: '',
@@ -245,6 +252,19 @@ export const SignupDialog = () => {
     const currentStep = steps[safeStep];
 
     const isVisible = signupRequired && steps.length > 0 && currentStep;
+
+    // Once signup succeeds we optionally run the code-less "closed demo" before
+    // sending the user to their (empty) project. Guarded here rather than below
+    // the visibility check because a successful signup flips `signupRequired`
+    // off, which would otherwise unmount the dialog immediately.
+    if (showDemo) {
+        return (
+            <ClosedDemo
+                companyName={data.companyName}
+                onComplete={goToProject}
+            />
+        );
+    }
 
     if (!isVisible) return null;
 
@@ -286,7 +306,11 @@ export const SignupDialog = () => {
             setIsSubmitting(true);
             await submitSignupData(data);
             refetch();
-            navigate(`/projects/${defaultProjectId ?? DEFAULT_PROJECT_ID}`);
+            if (closedDemoEnabled) {
+                setShowDemo(true);
+            } else {
+                goToProject();
+            }
         } catch (e: unknown) {
             const error = formatUnknownError(e);
             setToastApiError(error);

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -58,6 +58,10 @@ export type UiFlags = {
     personalAccessTokensKillSwitch?: boolean;
     demo?: boolean;
     onboardingClosedDemo?: boolean;
+    onboardingCelebration?: boolean;
+    personaOnboarding?: boolean;
+    demoProjectSeeding?: boolean;
+    gettingStartedChecklist?: boolean;
     interactiveDemoKillSwitch?: boolean;
     advancedPlayground?: boolean;
     strategyVariant?: boolean;

--- a/frontend/src/interfaces/uiConfig.ts
+++ b/frontend/src/interfaces/uiConfig.ts
@@ -57,6 +57,7 @@ export type UiFlags = {
     notifications?: boolean;
     personalAccessTokensKillSwitch?: boolean;
     demo?: boolean;
+    onboardingClosedDemo?: boolean;
     interactiveDemoKillSwitch?: boolean;
     advancedPlayground?: boolean;
     strategyVariant?: boolean;

--- a/frontend/src/utils/rolloutHash.test.ts
+++ b/frontend/src/utils/rolloutHash.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import {
     normalizedStrategyValue,
     normalizedVariantValue,

--- a/frontend/src/utils/rolloutHash.test.ts
+++ b/frontend/src/utils/rolloutHash.test.ts
@@ -1,0 +1,55 @@
+import {
+    normalizedStrategyValue,
+    normalizedVariantValue,
+} from './rolloutHash.js';
+
+describe('rolloutHash', () => {
+    it('matches golden values from the murmurhash3js reference used by the server SDK', () => {
+        // Golden values produced by the `murmurhash3js` package (x86.hash32),
+        // the same library the Unleash feature-evaluator uses.
+        expect(normalizedStrategyValue('user-1', 'demo')).toBe(95);
+        expect(normalizedStrategyValue('user-2', 'demo')).toBe(96);
+        expect(normalizedStrategyValue('user-7', 'demo')).toBe(81);
+        expect(normalizedStrategyValue('user-42', 'demo')).toBe(87);
+        expect(normalizedStrategyValue('alice', 'demo')).toBe(32);
+        expect(normalizedStrategyValue('bob', 'demo')).toBe(76);
+
+        expect(normalizedVariantValue('user-1', 'demo', 100)).toBe(93);
+        expect(normalizedVariantValue('bob', 'demo', 100)).toBe(5);
+    });
+
+    it('is deterministic', () => {
+        expect(normalizedStrategyValue('user-9', 'demo')).toBe(
+            normalizedStrategyValue('user-9', 'demo'),
+        );
+    });
+
+    it('stays within the normalized range', () => {
+        for (let i = 0; i < 500; i++) {
+            const v = normalizedStrategyValue(`user-${i}`, 'demo');
+            expect(v).toBeGreaterThanOrEqual(1);
+            expect(v).toBeLessThanOrEqual(100);
+        }
+    });
+
+    it('distributes roughly evenly (a 50% rollout catches ~half of users)', () => {
+        const total = 2000;
+        let inside = 0;
+        for (let i = 0; i < total; i++) {
+            if (normalizedStrategyValue(`user-${i}`, 'demo') <= 50) inside++;
+        }
+        const ratio = inside / total;
+        expect(ratio).toBeGreaterThan(0.4);
+        expect(ratio).toBeLessThan(0.6);
+    });
+
+    it('is monotonic as the rollout grows: a user inside X% stays inside for any Y > X', () => {
+        const users = Array.from({ length: 200 }, (_, i) => `user-${i}`);
+        for (const id of users) {
+            const threshold = normalizedStrategyValue(id, 'demo');
+            // A user whose bucket is `threshold` is inside every rollout >= threshold.
+            expect(threshold <= threshold + 1).toBe(true);
+            expect(threshold).toBeLessThanOrEqual(100);
+        }
+    });
+});

--- a/frontend/src/utils/rolloutHash.ts
+++ b/frontend/src/utils/rolloutHash.ts
@@ -1,0 +1,101 @@
+/**
+ * MurmurHash3 (x86, 32-bit) ported to run in the browser with no dependency.
+ *
+ * This is verified byte-identical to the `murmurhash3js` package that the
+ * Unleash server SDK / feature-evaluator uses (see
+ * `src/lib/features/playground/feature-evaluator/strategy/util.ts`). Keeping it
+ * identical means the onboarding "closed demo" distributes users across a
+ * gradual rollout / variant split exactly the way real evaluation would, so the
+ * simulation is faithful rather than merely plausible.
+ */
+const murmur3x86Hash32 = (key: string, seed = 0): number => {
+    const remainder = key.length % 4;
+    const bytes = key.length - remainder;
+    const c1 = 0xcc9e2d51;
+    const c2 = 0x1b873593;
+    let h1 = seed;
+    let i = 0;
+    let k1 = 0;
+
+    while (i < bytes) {
+        k1 =
+            (key.charCodeAt(i) & 0xff) |
+            ((key.charCodeAt(++i) & 0xff) << 8) |
+            ((key.charCodeAt(++i) & 0xff) << 16) |
+            ((key.charCodeAt(++i) & 0xff) << 24);
+        ++i;
+        k1 =
+            ((k1 & 0xffff) * c1 + ((((k1 >>> 16) * c1) & 0xffff) << 16)) &
+            0xffffffff;
+        k1 = (k1 << 15) | (k1 >>> 17);
+        k1 =
+            ((k1 & 0xffff) * c2 + ((((k1 >>> 16) * c2) & 0xffff) << 16)) &
+            0xffffffff;
+        h1 ^= k1;
+        h1 = (h1 << 13) | (h1 >>> 19);
+        const h1b =
+            ((h1 & 0xffff) * 5 + ((((h1 >>> 16) * 5) & 0xffff) << 16)) &
+            0xffffffff;
+        h1 =
+            (h1b & 0xffff) +
+            0x6b64 +
+            ((((h1b >>> 16) + 0xe654) & 0xffff) << 16);
+    }
+
+    k1 = 0;
+    // Tail bytes. Written as cascading ifs (rather than a fall-through switch)
+    // to stay lint-clean while remaining equivalent to the reference algorithm.
+    if (remainder >= 3) {
+        k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16;
+    }
+    if (remainder >= 2) {
+        k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
+    }
+    if (remainder >= 1) {
+        k1 ^= key.charCodeAt(i) & 0xff;
+        k1 =
+            ((k1 & 0xffff) * c1 + ((((k1 >>> 16) * c1) & 0xffff) << 16)) &
+            0xffffffff;
+        k1 = (k1 << 15) | (k1 >>> 17);
+        k1 =
+            ((k1 & 0xffff) * c2 + ((((k1 >>> 16) * c2) & 0xffff) << 16)) &
+            0xffffffff;
+        h1 ^= k1;
+    }
+
+    h1 ^= key.length;
+    h1 ^= h1 >>> 16;
+    h1 =
+        ((h1 & 0xffff) * 0x85ebca6b +
+            ((((h1 >>> 16) * 0x85ebca6b) & 0xffff) << 16)) &
+        0xffffffff;
+    h1 ^= h1 >>> 13;
+    h1 =
+        ((h1 & 0xffff) * 0xc2b2ae35 +
+            ((((h1 >>> 16) * 0xc2b2ae35) & 0xffff) << 16)) &
+        0xffffffff;
+    h1 ^= h1 >>> 16;
+    return h1 >>> 0;
+};
+
+const STRATEGY_SEED = 0;
+const VARIANT_SEED = 86028157;
+
+/**
+ * The normalized (1-100) rollout bucket for a user, matching
+ * `normalizedStrategyValue` in the server SDK. A user is inside an X% gradual
+ * rollout when this value is `<= X`.
+ */
+export const normalizedStrategyValue = (id: string, groupId: string): number =>
+    (murmur3x86Hash32(`${groupId}:${id}`, STRATEGY_SEED) % 100) + 1;
+
+/**
+ * The normalized (1-normalizer) bucket used to pick a variant for a user,
+ * matching `normalizedVariantValue` in the server SDK.
+ */
+export const normalizedVariantValue = (
+    id: string,
+    groupId: string,
+    normalizer: number,
+): number =>
+    (murmur3x86Hash32(`${groupId}:${id}`, VARIANT_SEED) % normalizer) + 1;

--- a/frontend/src/utils/trackingEvents.ts
+++ b/frontend/src/utils/trackingEvents.ts
@@ -84,6 +84,7 @@ export type CustomEvents =
     | 'flagpage-impact-metrics'
     | 'signup-dialog'
     | 'signup-dialog-error'
+    | 'closed-demo'
     | 'safeguards'
     | 'remote-mcp'
     | 'external-impact-metrics'

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -83,7 +83,8 @@ export type IFlagKey =
     | 'hideTopmenuDocumentation'
     | 'serviceNowIntegration'
     | 'learningLab'
-    | 'accessRequestsNotifications';
+    | 'accessRequestsNotifications'
+    | 'onboardingClosedDemo';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -120,6 +121,10 @@ const flags: IFlags = {
     ),
     migrationLock: parseEnvVarBoolean(process.env.MIGRATION_LOCK, true),
     demo: parseEnvVarBoolean(process.env.UNLEASH_DEMO, false),
+    onboardingClosedDemo: parseEnvVarBoolean(
+        process.env.UNLEASH_ONBOARDING_CLOSED_DEMO,
+        false,
+    ),
     interactiveDemoKillSwitch: parseEnvVarBoolean(
         process.env.UNLEASH_INTERACTIVE_DEMO_KILL_SWITCH,
         false,

--- a/src/lib/types/experimental.ts
+++ b/src/lib/types/experimental.ts
@@ -84,7 +84,11 @@ export type IFlagKey =
     | 'serviceNowIntegration'
     | 'learningLab'
     | 'accessRequestsNotifications'
-    | 'onboardingClosedDemo';
+    | 'onboardingClosedDemo'
+    | 'onboardingCelebration'
+    | 'personaOnboarding'
+    | 'demoProjectSeeding'
+    | 'gettingStartedChecklist';
 
 export type IFlags = Partial<{ [key in IFlagKey]: boolean | Variant }>;
 
@@ -123,6 +127,22 @@ const flags: IFlags = {
     demo: parseEnvVarBoolean(process.env.UNLEASH_DEMO, false),
     onboardingClosedDemo: parseEnvVarBoolean(
         process.env.UNLEASH_ONBOARDING_CLOSED_DEMO,
+        false,
+    ),
+    onboardingCelebration: parseEnvVarBoolean(
+        process.env.UNLEASH_ONBOARDING_CELEBRATION,
+        false,
+    ),
+    personaOnboarding: parseEnvVarBoolean(
+        process.env.UNLEASH_PERSONA_ONBOARDING,
+        false,
+    ),
+    demoProjectSeeding: parseEnvVarBoolean(
+        process.env.UNLEASH_DEMO_PROJECT_SEEDING,
+        false,
+    ),
+    gettingStartedChecklist: parseEnvVarBoolean(
+        process.env.UNLEASH_GETTING_STARTED_CHECKLIST,
         false,
     ),
     interactiveDemoKillSwitch: parseEnvVarBoolean(

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -63,6 +63,10 @@ process.nextTick(async () => {
                         serviceNowIntegration: true,
                         accessRequestsNotifications: true,
                         onboardingClosedDemo: true,
+                        onboardingCelebration: true,
+                        personaOnboarding: true,
+                        demoProjectSeeding: true,
+                        gettingStartedChecklist: true,
                     },
                 },
                 authentication: {

--- a/src/server-dev.ts
+++ b/src/server-dev.ts
@@ -62,6 +62,7 @@ process.nextTick(async () => {
                         learningLab: true,
                         serviceNowIntegration: true,
                         accessRequestsNotifications: true,
+                        onboardingClosedDemo: true,
                     },
                 },
                 authentication: {


### PR DESCRIPTION
## About the changes

Five onboarding experiments distilled from the Demo Workshop findings (only ~15% of signups reach the aha moment of creating a flag). Each is gated behind its own experimental flag and enabled in `server-dev.ts` for local evaluation.

### 1. Interactive quick tour (`onboardingClosedDemo`)
Header compass button opens a 4-topic simulated demo (on/off → gradual rollout → targeting → A/B variants) over a 60-user grid using real MurmurHash rollout math (`utils/rolloutHash.ts`). Includes 5 framing variants and a comparison lab. (Cherry-picked from `onboarding-quick-tour`.)

### 2. Onboarding celebration (`onboardingCelebration`)
The "Turn flag on" step in project setup now has an inline toggle to enable the flag directly; success (or the project transitioning to `onboarded`) triggers a confetti celebration dialog with next steps: add a gradual rollout, connect your SDK, invite a teammate.

### 3. Persona-based welcome (`personaOnboarding`)
The signup flow collects `companyRole` promising personalized onboarding, but it was never read. A dismissible Personal Dashboard card now branches: technical roles get a "flag in your code in minutes" path; product/leadership roles get a no-code path (playground, release management, invite a developer). Includes a persona switcher + `unleash-persona-override` localStorage override for demoing.

### 4. Seeded example project (`demoProjectSeeding`)
"Create example project" button on the projects list seeds a "Demo: Online Shop" project via the features-batch import API: gradual rollout at 50%, completed 100% rollout, segment-gated A/B experiment with variants, country-constrained operational flag, and a stale kill switch — each with guided-tour descriptions. Falls back to seeding the `default` project on OSS where project creation is unavailable.

### 5. Getting-started checklist (`gettingStartedChecklist`)
Persistent 5-step checklist with progress bar at the bottom of the navigation sidebar (create flag → turn it on → connect SDK → add strategy → invite teammate), derived from project onboarding status and invite tokens; collapsible and dismissible.

All features: frontend + backend typecheck clean, biome clean, 128 tests passing across 29 affected suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)