### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ We provide guides for deploying to services like Heroku and DigitalOcean:
 
 [![Deploy to Heroku](./.github/deploy-heroku-20.png)](https://www.heroku.com/deploy/?template=https://github.com/Unleash/unleash) [![Deploy to DigitalOcean](./.github/deploy-digital.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/Unleash/unleash/tree/main&refcode=0e1d75187044)
 
+Or skip the server entirely with one-click fully managed hosting:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/unleash)
+
 For more advanced configurations options, check out our documentation on:
 - [Getting started with self-hosting](https://docs.getunleash.io/deploy/getting-started)
 - [Unleash configuration options](https://docs.getunleash.io/deploy/configuring-unleash)


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added
Unleash to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the
"Deploying to a production server" section (links to https://zenith.hosting/host/unleash).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

disclosure: this docs change was prepared with AI assistance, and reviewed before submitting.

## About the changes

Closes #

Adds a "Deploy with Zenith" badge to the README's "Deploying to a production server" section, alongside the existing Heroku and DigitalOcean deploy buttons, offering readers a one-click fully managed hosting option.

### Important files

- `README.md`

## Discussion points

Docs-only change. No code, tests, or build impact.

## OSS PR checklist

- [x] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [x] I have added tests or explained why tests are not needed. (N/A: documentation-only change.)
- [x] I have updated documentation where relevant.
