### PR TITLE
fix: keep typed text in the SDK selector while filtering

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.test.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.test.tsx
@@ -25,4 +25,21 @@ describe('SelectSdk', () => {
 
         expect(onChange).toHaveBeenCalledWith('Go');
     });
+
+    it('keeps typed text when the parent re-renders', async () => {
+        const user = userEvent.setup();
+        const { rerender } = render(
+            <SelectSdk value='Node.js' onChange={vi.fn()} />,
+        );
+
+        const input = screen.getByRole('combobox');
+        await user.click(input);
+        await user.clear(input);
+        await user.type(input, 'Pyth');
+
+        rerender(<SelectSdk value='Node.js' onChange={vi.fn()} />);
+
+        expect(input).toHaveValue('Pyth');
+        expect(screen.getByText('Python')).toBeInTheDocument();
+    });
 });

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx
@@ -20,6 +20,25 @@ type SdkOption = {
     group: string;
 };
 
+const options: SdkOption[] = allSdks
+    .map((sdk) => ({
+        ...sdk,
+        group: backendNames.has(sdk.name) ? 'Backend SDKs' : 'Frontend SDKs',
+    }))
+    .sort(
+        (a, b) =>
+            a.group.localeCompare(b.group) || a.name.localeCompare(b.name),
+    );
+
+const optionsByName = new Map<SdkName, SdkOption>(
+    options.map((option) => [option.name, option]),
+);
+
+const getOptionLabel = (option: SdkOption) => option.name;
+const getOptionGroup = (option: SdkOption) => option.group;
+const isOptionEqualToValue = (option: SdkOption, value: SdkOption) =>
+    option.name === value.name;
+
 const StyledAutocompleteWrapper = styled('div')(({ theme }) => ({
     minWidth: theme.spacing(20),
     maxWidth: theme.spacing(32.5),
@@ -44,19 +63,8 @@ const StyledSdkName = styled('span')({
 });
 
 export const SelectSdk = ({ value, onChange }: SelectSdkProps) => {
-    const options: SdkOption[] = allSdks
-        .map((sdk) => ({
-            ...sdk,
-            group: backendNames.has(sdk.name)
-                ? 'Backend SDKs'
-                : 'Frontend SDKs',
-        }))
-        .sort(
-            (a, b) =>
-                a.group.localeCompare(b.group) || a.name.localeCompare(b.name),
-        );
-
-    const icon = options.find((opt) => opt.name === value)?.icon;
+    const selectedOption = optionsByName.get(value);
+    const icon = selectedOption?.icon;
 
     return (
         <StyledAutocompleteWrapper>
@@ -65,10 +73,10 @@ export const SelectSdk = ({ value, onChange }: SelectSdkProps) => {
                 size='small'
                 disableClearable
                 options={options}
-                value={options.find((opt) => opt.name === value)}
-                groupBy={(option) => option.group}
-                getOptionLabel={(option) => option.name}
-                isOptionEqualToValue={(option, val) => option.name === val.name}
+                value={selectedOption}
+                groupBy={getOptionGroup}
+                getOptionLabel={getOptionLabel}
+                isOptionEqualToValue={isOptionEqualToValue}
                 onChange={(_, newValue) => {
                     if (newValue?.name) {
                         onChange(newValue.name);


### PR DESCRIPTION
## Summary

In the "Use the flag in your code" dialog, typing in the SDK selector to filter to something other than the default (Node.js) would have the text wiped after an unpredictable delay, snapping the field back to the current selection. Selecting any non-default SDK was a matter of racing the reset, which made the flag onboarding flow feel broken on the first few attempts.

<img width="1624" height="1061" alt="Screenshot 2026-07-21 at 13 37 18" src="https://github.com/user-attachments/assets/dcac6478-206c-41c6-bb7d-b28604298044" />


## Root cause

`SelectSdk` rebuilt its option list in the component body and derived the Autocomplete's `value` from it with `options.find(...)`, so MUI received a brand-new `value` object on every render even though `allSdks` is a static module constant.

Said re-render seems to be triggered by the metrics polling and the normal re-rendering cadence (not super familiar with it at the moment), hence the "randomness" of the reset.

MUI's `useAutocomplete` compares `value` against the previous render by reference and skips its "reset the input" effect via a `focused && !valueChange` guard, precisely so that background re-renders do not clobber text the user is typing. An always-changing reference made `valueChange` permanently true, so the guard never applied and the input was reset to the selected option's label.

The fix moves the list of SDKs to a constant so the reference is stable.

## Validation

- New regression test types into the field, re-renders the parent, and asserts both the text and the filtered list survive. It fails on the unfixed component (`Expected "Pyth", received "Node.js"`).
- `pnpm vitest run src/component/.../ImplementFlagDialog` — 28 passed
- `pnpm ts:check` and `pnpm biome check` clean

## About the changes

### Important files
- `frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.tsx`
- `frontend/src/component/feature/FeatureView/FeatureOverview/ImplementFlagDialog/SelectSdk.test.tsx`

## Discussion points
- I've noticed that the text is reverted on focus change (I've tried with Cmd+Tab to switch to a different window). But that seems deliberate?

## OSS PR checklist

- [x] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [x] I have added tests or explained why tests are not needed.
- [~] I have updated documentation where relevant.
