### PR TITLE
ci: remove unused sync workflow cache setup

### DIFF
--- a/.github/workflows/notify_enterprise.yaml
+++ b/.github/workflows/notify_enterprise.yaml
@@ -16,14 +16,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - name: Use Node.js 22
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22.x
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
       - name: Trigger sync
         uses: actions/github-script@v9
         with:


### PR DESCRIPTION
## Summary
- Remove checkout, pnpm setup, and setup-node from notify_enterprise.yaml.
- Keep the workflow focused on dispatching the enterprise sync workflow.

## Problem
The workflow configured actions/setup-node with cache: pnpm but never ran pnpm install. On runs where setup-node attempted to save a missing pnpm store during post-job cleanup, the job failed after the dispatch had already succeeded with: Path Validation Error: Path(s) specified in the action for caching do(es) not exist. Example: https://github.com/Unleash/unleash/actions/runs/29926722488/job/88945679352
