### PR TITLE
feat: clone context field definitions

### DIFF
--- a/frontend/src/component/context/CloneContext/CloneContext.test.tsx
+++ b/frontend/src/component/context/CloneContext/CloneContext.test.tsx
@@ -1,0 +1,96 @@
+import { expect, test, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Route, Routes } from 'react-router';
+import { render } from 'utils/testRenderer';
+import { testServerRoute, testServerSetup } from 'utils/testServer';
+import { CloneContext } from './CloneContext.tsx';
+import {
+    CREATE_CONTEXT_FIELD,
+    UPDATE_CONTEXT_FIELD,
+} from 'component/providers/AccessProvider/permissions';
+
+const server = testServerSetup();
+
+const sourceContextField = {
+    name: 'appName',
+    description: 'Allows you to constrain on application name',
+    sortOrder: 2,
+    stickiness: true,
+    createdAt: '2023-05-24T06:23:07.797Z',
+    legalValues: [
+        { value: 'mobile', description: 'Our mobile app' },
+        { value: 'web', description: 'Our web app' },
+    ],
+};
+
+const setupApi = () => {
+    testServerRoute(server, '/api/admin/ui-config', {});
+    testServerRoute(server, '/api/admin/context', []);
+    testServerRoute(server, '/api/admin/context/appName', sourceContextField);
+    testServerRoute(server, '/api/admin/context/validate', {}, 'post');
+    return testServerRoute(server, '/api/admin/context', {}, 'post');
+};
+
+const renderCloneContext = (onSubmit = () => {}) =>
+    render(
+        <Routes>
+            <Route
+                path='/context/clone/:name'
+                element={
+                    <CloneContext onSubmit={onSubmit} onCancel={() => {}} />
+                }
+            />
+        </Routes>,
+        {
+            route: '/context/clone/appName',
+            permissions: [
+                { permission: CREATE_CONTEXT_FIELD },
+                { permission: UPDATE_CONTEXT_FIELD },
+            ],
+        },
+    );
+
+test('prefills the form with the source context field', async () => {
+    setupApi();
+
+    renderCloneContext();
+
+    await screen.findByText('Clone appName');
+    await waitFor(() => {
+        expect(screen.getByLabelText(/Context name/)).toHaveValue(
+            'appName_clone',
+        );
+    });
+    expect(screen.getByLabelText(/Context description/)).toHaveValue(
+        sourceContextField.description,
+    );
+    await screen.findByText('mobile');
+    await screen.findByText('web');
+});
+
+test('creates a new context field with the legal values of the source', async () => {
+    const { requests } = setupApi();
+    const onSubmit = vi.fn();
+
+    renderCloneContext(onSubmit);
+
+    const nameInput = await screen.findByLabelText(/Context name/);
+    await waitFor(() => expect(nameInput).toHaveValue('appName_clone'));
+
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'applicationName');
+    await userEvent.click(
+        screen.getByRole('button', { name: 'Create context' }),
+    );
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(requests).toEqual([
+        {
+            name: 'applicationName',
+            description: sourceContextField.description,
+            legalValues: sourceContextField.legalValues,
+            stickiness: true,
+        },
+    ]);
+});

--- a/frontend/src/component/context/CloneContext/CloneContext.tsx
+++ b/frontend/src/component/context/CloneContext/CloneContext.tsx
@@ -17,7 +17,10 @@ export const CloneContext: FC<CloneContextProps> = ({
 }) => {
     const projectId = useOptionalPathParam('projectId');
     const name = useRequiredPathParam('name');
-    const { context, loading, error } = useContext({ name, project: projectId });
+    const { context, loading, error } = useContext({
+        name,
+        project: projectId,
+    });
 
     if (loading) {
         return null;

--- a/frontend/src/component/context/CloneContext/CloneContext.tsx
+++ b/frontend/src/component/context/CloneContext/CloneContext.tsx
@@ -1,0 +1,30 @@
+import type { FC } from 'react';
+import useContext from 'hooks/api/getters/useContext/useContext';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import { useOptionalPathParam } from 'hooks/useOptionalPathParam.ts';
+import { CreateUnleashContext } from '../CreateUnleashContext/CreateUnleashContext.tsx';
+
+type CloneContextProps = {
+    onSubmit: () => void;
+    onCancel: () => void;
+    modal?: boolean;
+};
+
+export const CloneContext: FC<CloneContextProps> = ({
+    onSubmit,
+    onCancel,
+    modal,
+}) => {
+    const projectId = useOptionalPathParam('projectId');
+    const name = useRequiredPathParam('name');
+    const { context } = useContext({ name, project: projectId });
+
+    return (
+        <CreateUnleashContext
+            modal={modal}
+            onSubmit={onSubmit}
+            onCancel={onCancel}
+            cloneFrom={context.name ? context : undefined}
+        />
+    );
+};

--- a/frontend/src/component/context/CloneContext/CloneContext.tsx
+++ b/frontend/src/component/context/CloneContext/CloneContext.tsx
@@ -17,14 +17,22 @@ export const CloneContext: FC<CloneContextProps> = ({
 }) => {
     const projectId = useOptionalPathParam('projectId');
     const name = useRequiredPathParam('name');
-    const { context } = useContext({ name, project: projectId });
+    const { context, loading, error } = useContext({ name, project: projectId });
+
+    if (loading) {
+        return null;
+    }
+
+    if (error) {
+        return <div role='alert'>Failed to load context field "{name}".</div>;
+    }
 
     return (
         <CreateUnleashContext
             modal={modal}
             onSubmit={onSubmit}
             onCancel={onCancel}
-            cloneFrom={context.name ? context : undefined}
+            cloneFrom={context}
         />
     );
 };

--- a/frontend/src/component/context/CloneContext/CloneContextPage.tsx
+++ b/frontend/src/component/context/CloneContext/CloneContextPage.tsx
@@ -1,0 +1,14 @@
+import { useNavigate } from 'react-router';
+import { CloneContext } from 'component/context/CloneContext/CloneContext';
+import { GO_BACK } from 'constants/navigate';
+
+export const CloneContextPage = () => {
+    const navigate = useNavigate();
+
+    return (
+        <CloneContext
+            onSubmit={() => navigate('/context')}
+            onCancel={() => navigate(GO_BACK)}
+        />
+    );
+};

--- a/frontend/src/component/context/ContextList/ContextActionsCell.tsx
+++ b/frontend/src/component/context/ContextList/ContextActionsCell.tsx
@@ -2,10 +2,12 @@ import type { FC } from 'react';
 import { useNavigate } from 'react-router';
 import Delete from '@mui/icons-material/Delete';
 import Edit from '@mui/icons-material/Edit';
+import FileCopy from '@mui/icons-material/FileCopy';
 import PermissionIconButton from 'component/common/PermissionIconButton/PermissionIconButton';
 import { ActionCell } from 'component/common/Table/cells/ActionCell/ActionCell';
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam.ts';
 import {
+    CREATE_CONTEXT_FIELD,
     DELETE_CONTEXT_FIELD,
     UPDATE_CONTEXT_FIELD,
     UPDATE_PROJECT_CONTEXT,
@@ -27,9 +29,24 @@ export const ContextActionsCell: FC<IContextActionsCellProps> = ({
     const updateLocation = projectId
         ? `/projects/${projectId}/settings/context/edit/${name}`
         : `/context/edit/${name}`;
+    const cloneLocation = projectId
+        ? `/projects/${projectId}/settings/context/clone/${name}`
+        : `/context/clone/${name}`;
 
     return (
         <ActionCell>
+            <PermissionIconButton
+                permission={[CREATE_CONTEXT_FIELD, UPDATE_PROJECT_CONTEXT]}
+                projectId={projectId}
+                onClick={() => navigate(cloneLocation)}
+                data-loading
+                aria-label='clone'
+                tooltipProps={{
+                    title: 'Clone context field',
+                }}
+            >
+                <FileCopy />
+            </PermissionIconButton>
             <PermissionIconButton
                 permission={[UPDATE_CONTEXT_FIELD, UPDATE_PROJECT_CONTEXT]}
                 projectId={projectId}

--- a/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
+++ b/frontend/src/component/context/ContextList/ContextList/ContextList.tsx
@@ -140,7 +140,7 @@ const ContextList: FC = () => {
                 ),
                 enableSorting: false,
                 enableGlobalFilter: false,
-                meta: { width: 150, align: 'center' },
+                meta: { width: 200, align: 'center' },
             },
             {
                 id: 'description',

--- a/frontend/src/component/context/CreateUnleashContext/CreateUnleashContext.tsx
+++ b/frontend/src/component/context/CreateUnleashContext/CreateUnleashContext.tsx
@@ -10,17 +10,25 @@ import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { useOptionalPathParam } from 'hooks/useOptionalPathParam.ts';
 import { UPDATE_PROJECT_CONTEXT } from '@server/types/permissions.ts';
+import type { IUnleashContextDefinition } from 'interfaces/context';
 
 interface ICreateContextProps {
     onSubmit: () => void;
     onCancel: () => void;
     modal?: boolean;
+    /**
+     * When set, the form starts out as a copy of this context field. Only
+     * the name differs, so the user doesn't have to retype long lists of
+     * legal values.
+     */
+    cloneFrom?: IUnleashContextDefinition;
 }
 
 export const CreateUnleashContext = ({
     onSubmit,
     onCancel,
     modal,
+    cloneFrom,
 }: ICreateContextProps) => {
     const { setToastData, setToastApiError } = useToast();
     const { uiConfig } = useUiConfig();
@@ -39,7 +47,13 @@ export const CreateUnleashContext = ({
         clearErrors,
         setErrors,
         errors,
-    } = useContextForm({ initialProject: projectId });
+    } = useContextForm({
+        initialContextName: cloneFrom && `${cloneFrom.name}_clone`,
+        initialContextDesc: cloneFrom?.description,
+        initialLegalValues: cloneFrom?.legalValues,
+        initialStickiness: cloneFrom?.stickiness,
+        initialProject: projectId,
+    });
     const { createContext, loading } = useContextsApi(projectId);
     const { refetchUnleashContext } = useScopedUnleashContext();
 
@@ -54,7 +68,9 @@ export const CreateUnleashContext = ({
                 await createContext(payload);
                 refetchUnleashContext();
                 setToastData({
-                    text: 'Context field created',
+                    text: cloneFrom
+                        ? 'Context field cloned'
+                        : 'Context field created',
                     type: 'success',
                 });
                 onSubmit();
@@ -78,7 +94,7 @@ export const CreateUnleashContext = ({
     return (
         <FormTemplate
             loading={loading}
-            title='Create context'
+            title={cloneFrom ? `Clone ${cloneFrom.name}` : 'Create context'}
             description='Context fields are a basic building block used in Unleash to control roll-out.
             They can be used together with strategy constraints as part of the activation strategy evaluation.'
             documentationLink='https://docs.getunleash.io/concepts/unleash-context#custom-context-fields'

--- a/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
+++ b/frontend/src/component/menu/__tests__/__snapshots__/routes.test.tsx.snap
@@ -158,6 +158,13 @@ exports[`returns all baseRoutes 1`] = `
   {
     "menu": {},
     "parent": "/context",
+    "path": "/context/clone/:name",
+    "title": "Clone",
+    "type": "protected",
+  },
+  {
+    "menu": {},
+    "parent": "/context",
     "path": "/context/edit/:name",
     "title": ":name",
     "type": "protected",

--- a/frontend/src/component/menu/routes.ts
+++ b/frontend/src/component/menu/routes.ts
@@ -27,6 +27,7 @@ import { CreateStrategy } from 'component/strategies/CreateStrategy/CreateStrate
 import { EditStrategy } from 'component/strategies/EditStrategy/EditStrategy';
 import { SplashPage } from 'component/splash/SplashPage/SplashPage';
 import { CreateUnleashContextPage } from 'component/context/CreateUnleashContext/CreateUnleashContextPage';
+import { CloneContextPage } from 'component/context/CloneContext/CloneContextPage';
 import { CreateSegment } from 'component/segments/CreateSegment/CreateSegment';
 import { EditSegment } from 'component/segments/EditSegment/EditSegment';
 import type { INavigationMenuItem, IRoute } from 'interfaces/route';
@@ -242,6 +243,14 @@ export const routes: IRoute[] = [
         parent: '/context',
         title: 'Create',
         component: CreateUnleashContextPage,
+        type: 'protected',
+        menu: {},
+    },
+    {
+        path: '/context/clone/:name',
+        parent: '/context',
+        title: 'Clone',
+        component: CloneContextPage,
         type: 'protected',
         menu: {},
     },

--- a/frontend/src/component/project/Project/ProjectSettings/ProjectContextFields.tsx
+++ b/frontend/src/component/project/Project/ProjectSettings/ProjectContextFields.tsx
@@ -7,6 +7,7 @@ import { useProjectOverviewNameOrId } from 'hooks/api/getters/useProjectOverview
 import ContextList from 'component/context/ContextList/ContextList/ContextList';
 import { CreateUnleashContext } from 'component/context/CreateUnleashContext/CreateUnleashContext';
 import { EditContext } from 'component/context/EditContext/EditContext';
+import { CloneContext } from 'component/context/CloneContext/CloneContext';
 
 export const ProjectContextFields = () => {
     const projectId = useRequiredPathParam('projectId');
@@ -26,6 +27,22 @@ export const ProjectContextFields = () => {
                         label='Create segment'
                     >
                         <CreateUnleashContext
+                            modal
+                            onSubmit={() => navigate(GO_BACK)}
+                            onCancel={() => navigate(GO_BACK)}
+                        />
+                    </SidebarModal>
+                }
+            />
+            <Route
+                path='clone/:name'
+                element={
+                    <SidebarModal
+                        open
+                        onClose={() => navigate(GO_BACK)}
+                        label='Clone context field'
+                    >
+                        <CloneContext
                             modal
                             onSubmit={() => navigate(GO_BACK)}
                             onCancel={() => navigate(GO_BACK)}


### PR DESCRIPTION
Adds a clone action to the context field list, both in the global admin view and in project settings. Cloning opens the create form pre-filled with the source field's description, legal values and stickiness, named "<source>_clone" so it can be corrected right away.

This makes it cheap to recover from a typo in a context field name without retyping a long list of legal values.

No API change: a clone is a create with a copied payload, so it reuses the existing create endpoint.

## OSS PR checklist

- [x] I have read and agree to the [Unleash Contributor License Agreement](https://github.com/Unleash/unleash/blob/main/CLA.md).
- [x] I have added tests or explained why tests are not needed.
- [ ] I have updated documentation where relevant.
