### PR TITLE
fix: align brace-expansion security overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ overrides:
   esbuild: 0.28.1
   axios: 1.18.0
   body-parser: 1.20.6
-  brace-expansion@^1.1.7: 1.1.16
-  brace-expansion@^2.0.1: 2.1.3
+  brace-expansion@^1.1.7: 1.1.18
+  brace-expansion@^2.0.1: 2.1.4
   brace-expansion@^5.0.0: 5.0.9
   fast-uri: 3.1.4
   form-data: 4.0.6
@@ -2848,11 +2848,11 @@ packages:
     resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.3:
-    resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -9103,12 +9103,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.3:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -11545,11 +11545,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.3
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,8 +64,8 @@ minimumReleaseAgeExclude:
   - http-proxy-middleware@3.0.7
   # Renovate security update: fast-uri@3.1.4
   - fast-uri@3.1.4
-  # Renovate security update: brace-expansion@5.0.8 || 2.1.3 || 5.0.9
-  - brace-expansion@5.0.8 || 2.1.3 || 5.0.9
+  # Security update: brace-expansion@1.1.18 || 2.1.4 || 5.0.9
+  - brace-expansion@1.1.18 || 2.1.4 || 5.0.9
 
 patchedDependencies:
   # Fixes a bug in getAutoSortingFn where `.slice(10)` skips the first 10 rows
@@ -87,8 +87,8 @@ overrides:
   esbuild: "0.28.1"
   axios: "1.18.0"
   body-parser: "1.20.6"
-  "brace-expansion@^1.1.7": "1.1.16"
-  "brace-expansion@^2.0.1": "2.1.3"
+  "brace-expansion@^1.1.7": "1.1.18"
+  "brace-expansion@^2.0.1": "2.1.4"
   "brace-expansion@^5.0.0": "5.0.9"
   fast-uri: "3.1.4"
   form-data: "4.0.6"


### PR DESCRIPTION
## Summary

- align each brace-expansion override with its patched major line
- resolve CVE-2026-69152 across the v1, v2, and v5 consumers
- retain temporary minimum-release-age exceptions for the new patched releases

## Root cause

The Renovate security PR updated only the v1-scoped selector to v2.1.4, while leaving the v2-scoped selector on vulnerable 2.1.3. This change uses the advisory-defined first patched versions: 1.1.18, 2.1.4, and 5.0.9.

## Validation

- `pnpm install --frozen-lockfile`
- `git diff --check`