### PR TITLE
Responsiveness FF page

### DIFF
--- a/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
@@ -27,7 +27,7 @@ const StyledContainer = styled('div')(({ theme }) => ({
     display: 'flex',
     width: '100%',
     gap: theme.spacing(2),
-    [theme.breakpoints.down('md')]: {
+    [theme.breakpoints.down(1350)]: {
         flexDirection: 'column',
     },
 }));

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/MilestoneTransitionDisplay.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/MilestoneTransitionDisplay.tsx
@@ -49,6 +49,9 @@ const StyledContentGroup = styled('div')(({ theme }) => ({
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(1),
+    [theme.breakpoints.down(600)]: {
+        flexWrap: 'wrap',
+    },
 }));
 
 const StyledIcon = styled(BoltIcon, {

--- a/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
+++ b/frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx
@@ -79,6 +79,9 @@ const StyledTitle = styled('span', {
 const StyledSecondaryLabel = styled('span')(({ theme }) => ({
     color: theme.palette.text.secondary,
     fontSize: theme.fontSizes.smallBody,
+    [theme.breakpoints.down(450)]: {
+        display: 'none',
+    },
 }));
 
 const StyledStartedAt = styled('span')(({ theme }) => ({


### PR DESCRIPTION
Fixed some breakpoints on the FF page where safeguards where over-floating already at 1300px.

Files changed:
- frontend/src/component/feature/FeatureView/FeatureOverview/FeatureOverview.tsx
- frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/MilestoneTransitionDisplay.tsx
- frontend/src/component/feature/FeatureView/FeatureOverview/ReleasePlan/ReleasePlanMilestone/ReleasePlanMilestone.tsx

🤖 Drafted from the UX Tweak extension — please review.