### PR TITLE
style: polish floating onboarding checklist styling

### DIFF
--- a/frontend/src/component/onboarding/floatingChecklist/ChecklistSteps.tsx
+++ b/frontend/src/component/onboarding/floatingChecklist/ChecklistSteps.tsx
@@ -15,14 +15,10 @@ const StepContainer = styled('div')(({ theme }) => ({
 const Chevron = styled(KeyboardArrowDownIcon, {
     shouldForwardProp: (prop) => prop !== 'expanded',
 })<{ expanded?: boolean }>(({ theme, expanded }) => ({
-    // Styled to mirror the header's `IconButton size='medium'` (close/minimize):
-    // a 30px square with a 20px glyph. Kept a decorative icon rather than a real
-    // IconButton because the row (`StepHeader`) is itself a <button> and nesting
-    // buttons is invalid — the hover highlight is driven by `StepHeader:hover`.
     boxSizing: 'content-box',
     flexShrink: 0,
     fontSize: 20,
-    padding: theme.spacing(0.625), // 20px glyph + 5px*2 = 30px box
+    padding: theme.spacing(0.625),
     borderRadius: theme.shape.borderRadius,
     color: theme.palette.text.secondary,
     transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',

--- a/frontend/src/component/onboarding/floatingChecklist/ChecklistSteps.tsx
+++ b/frontend/src/component/onboarding/floatingChecklist/ChecklistSteps.tsx
@@ -15,9 +15,14 @@ const StepContainer = styled('div')(({ theme }) => ({
 const Chevron = styled(KeyboardArrowDownIcon, {
     shouldForwardProp: (prop) => prop !== 'expanded',
 })<{ expanded?: boolean }>(({ theme, expanded }) => ({
+    // Styled to mirror the header's `IconButton size='medium'` (close/minimize):
+    // a 30px square with a 20px glyph. Kept a decorative icon rather than a real
+    // IconButton because the row (`StepHeader`) is itself a <button> and nesting
+    // buttons is invalid — the hover highlight is driven by `StepHeader:hover`.
     boxSizing: 'content-box',
     flexShrink: 0,
-    padding: theme.spacing(0.25),
+    fontSize: 20,
+    padding: theme.spacing(0.625), // 20px glyph + 5px*2 = 30px box
     borderRadius: theme.shape.borderRadius,
     color: theme.palette.text.secondary,
     transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
@@ -34,6 +39,7 @@ const StepHeader = styled('button')(({ theme }) => ({
     cursor: 'pointer',
     [`&:hover ${Chevron}`]: {
         backgroundColor: theme.palette.action.hover,
+        color: theme.palette.text.primary,
     },
     '&:focus-visible': {
         ...focusOutline(theme),

--- a/frontend/src/component/onboarding/floatingChecklist/ChecklistSteps.tsx
+++ b/frontend/src/component/onboarding/floatingChecklist/ChecklistSteps.tsx
@@ -12,6 +12,17 @@ const StepContainer = styled('div')(({ theme }) => ({
     },
 }));
 
+const Chevron = styled(KeyboardArrowDownIcon, {
+    shouldForwardProp: (prop) => prop !== 'expanded',
+})<{ expanded?: boolean }>(({ theme, expanded }) => ({
+    boxSizing: 'content-box',
+    flexShrink: 0,
+    padding: theme.spacing(0.25),
+    borderRadius: theme.shape.borderRadius,
+    color: theme.palette.text.secondary,
+    transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+}));
+
 const StepHeader = styled('button')(({ theme }) => ({
     all: 'unset',
     boxSizing: 'border-box',
@@ -21,9 +32,9 @@ const StepHeader = styled('button')(({ theme }) => ({
     gap: theme.spacing(1.5),
     padding: theme.spacing(1, 1.5),
     cursor: 'pointer',
-    // '&:hover': {
-    //     backgroundColor: theme.palette.action.hover,
-    // },
+    [`&:hover ${Chevron}`]: {
+        backgroundColor: theme.palette.action.hover,
+    },
     '&:focus-visible': {
         ...focusOutline(theme),
         outlineOffset: -2,
@@ -66,19 +77,11 @@ const StepTitle = styled(Typography, {
     textDecoration: done ? 'line-through' : 'none',
 }));
 
-const Chevron = styled(KeyboardArrowDownIcon, {
-    shouldForwardProp: (prop) => prop !== 'expanded',
-})<{ expanded?: boolean }>(({ theme, expanded }) => ({
-    color: theme.palette.text.secondary,
-    transition: theme.transitions.create('transform'),
-    transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
-}));
-
 const StepBody = styled('div')(({ theme }) => ({
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(2),
-    padding: theme.spacing(0.25, 2, 3, 5.5),
+    padding: theme.spacing(0, 2, 3, 5.5),
 }));
 
 const StepBodyText = styled(Typography)(({ theme }) => ({

--- a/frontend/src/component/onboarding/floatingChecklist/ChecklistSteps.tsx
+++ b/frontend/src/component/onboarding/floatingChecklist/ChecklistSteps.tsx
@@ -19,11 +19,11 @@ const StepHeader = styled('button')(({ theme }) => ({
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(1.5),
-    padding: theme.spacing(1.5),
+    padding: theme.spacing(1, 1.5),
     cursor: 'pointer',
-    '&:hover': {
-        backgroundColor: theme.palette.action.hover,
-    },
+    // '&:hover': {
+    //     backgroundColor: theme.palette.action.hover,
+    // },
     '&:focus-visible': {
         ...focusOutline(theme),
         outlineOffset: -2,
@@ -77,8 +77,8 @@ const Chevron = styled(KeyboardArrowDownIcon, {
 const StepBody = styled('div')(({ theme }) => ({
     display: 'flex',
     flexDirection: 'column',
-    gap: theme.spacing(1.5),
-    padding: theme.spacing(0, 2, 2, 5.5),
+    gap: theme.spacing(2),
+    padding: theme.spacing(0.25, 2, 3, 5.5),
 }));
 
 const StepBodyText = styled(Typography)(({ theme }) => ({

--- a/frontend/src/component/onboarding/floatingChecklist/FloatingOnboardingChecklist.tsx
+++ b/frontend/src/component/onboarding/floatingChecklist/FloatingOnboardingChecklist.tsx
@@ -402,18 +402,18 @@ const EligibleFloatingOnboardingChecklist = () => {
                         <OnboardingProgressBadge showLabel />
                     </TitleRow>
                     <IconButton
-                        size='small'
+                        size='medium'
                         aria-label={state.minimized ? 'Expand' : 'Minimize'}
                         onClick={toggleMinimized}
                     >
-                        <MinimizeIcon fontSize='small' />
+                        <MinimizeIcon fontSize='medium' />
                     </IconButton>
                     <IconButton
-                        size='small'
+                        size='medium'
                         aria-label='Close'
                         onClick={handleDismiss}
                     >
-                        <CloseIcon fontSize='small' />
+                        <CloseIcon fontSize='medium' />
                     </IconButton>
                 </Header>
 

--- a/frontend/src/component/onboarding/floatingChecklist/FloatingOnboardingChecklist.tsx
+++ b/frontend/src/component/onboarding/floatingChecklist/FloatingOnboardingChecklist.tsx
@@ -90,7 +90,7 @@ const Window = styled('aside', {
 const Header = styled('div')(({ theme }) => ({
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(1),
+    gap: theme.spacing(0.125),
     padding: theme.spacing(1, 1.5, 1, 1.5),
     background: theme.palette.background.elevation1,
     flexShrink: 0,


### PR DESCRIPTION
## What

Visual polish on the floating onboarding checklist. No behavioral changes.

- **Spacing** — tidied up padding/gaps across the checklist.
- **Chevron hover** — moved the hover highlight onto the chevron (driven by hovering the whole step header row) and dropped the rotation animation.
- **Header controls sizing** — bumped the close/minimize icon buttons to `size='medium'` and matched the step-header chevron pseudo-button to the same 30px box / 20px glyph, so all header controls share the medium control-scale sizing. The chevron glyph also darkens on row hover to mirror the icon button hover.

## Why

The header controls were rendering at mixed sizes (chevron at MUI's default 24px vs. the small icon buttons), which read as inconsistent stroke weights / icon families. This aligns them on the design-system control scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)