### PR TITLE
fix: bound client features response cache to prevent unbounded memory growth

### DIFF
--- a/src/lib/create-config.test.ts
+++ b/src/lib/create-config.test.ts
@@ -392,6 +392,7 @@ test('Should enable client feature caching with .6 seconds max age by default', 
     const config = createConfig({});
     expect(config.clientFeatureCaching.enabled).toBe(true);
     expect(config.clientFeatureCaching.maxAge).toBe(3600000);
+    expect(config.clientFeatureCaching.max).toBe(100);
 });
 
 test('Should use overrides from options for client feature caching', () => {
@@ -399,20 +400,25 @@ test('Should use overrides from options for client feature caching', () => {
         clientFeatureCaching: {
             enabled: false,
             maxAge: 120,
+            max: 20,
         },
     });
     expect(config.clientFeatureCaching.enabled).toBe(false);
     expect(config.clientFeatureCaching.maxAge).toBe(120);
+    expect(config.clientFeatureCaching.max).toBe(20);
 });
 
 test('Should be able to set client features caching using environment variables', () => {
     process.env.CLIENT_FEATURE_CACHING_ENABLED = 'false';
     process.env.CLIENT_FEATURE_CACHING_MAXAGE = '120';
+    process.env.CLIENT_FEATURE_CACHING_MAX = '20';
     const config = createConfig({});
     expect(config.clientFeatureCaching.enabled).toBe(false);
     expect(config.clientFeatureCaching.maxAge).toBe(120);
+    expect(config.clientFeatureCaching.max).toBe(20);
     delete process.env.CLIENT_FEATURE_CACHING_ENABLED;
     delete process.env.CLIENT_FEATURE_CACHING_MAXAGE;
+    delete process.env.CLIENT_FEATURE_CACHING_MAX;
 });
 
 test('Environment variables for client features caching takes priority over options', () => {

--- a/src/lib/create-config.ts
+++ b/src/lib/create-config.ts
@@ -88,6 +88,7 @@ function loadExperimental(options: IUnleashOptions): IExperimentalOptions {
 const defaultClientCachingOptions: IClientCachingOption = {
     enabled: true,
     maxAge: hoursToMilliseconds(1),
+    max: 100,
 };
 
 function loadClientCachingOptions(
@@ -104,6 +105,12 @@ function loadClientCachingOptions(
         envs.enabled = parseEnvVarBoolean(
             process.env.CLIENT_FEATURE_CACHING_ENABLED,
             true,
+        );
+    }
+    if (process.env.CLIENT_FEATURE_CACHING_MAX) {
+        envs.max = parseEnvVarNumber(
+            process.env.CLIENT_FEATURE_CACHING_MAX,
+            100,
         );
     }
 

--- a/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
@@ -143,6 +143,7 @@ export default class FeatureController extends Controller {
                 {
                     promise: true,
                     maxAge: clientFeatureCaching.maxAge,
+                    max: clientFeatureCaching.max,
                     normalizer([_query, etag]) {
                         return etag;
                     },

--- a/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle.controller.ts
@@ -28,6 +28,7 @@ import {
     type ClientFeaturesSchema,
 } from '../../openapi/spec/client-features-schema.js';
 import type ConfigurationRevisionService from '../feature-toggle/configuration-revision-service.js';
+import { UPDATE_REVISION } from '../feature-toggle/configuration-revision-service.js';
 import type { ClientFeatureToggleService } from './client-feature-toggle-service.js';
 import {
     CLIENT_METRICS_NAMEPREFIX,
@@ -137,7 +138,7 @@ export default class FeatureController extends Controller {
         });
 
         if (clientFeatureCaching.enabled) {
-            this.featuresAndSegments = memoizee(
+            const cachedFeaturesAndSegments = memoizee(
                 (query: IFeatureToggleQuery, _etag: string) =>
                     this.resolveFeaturesAndSegments(query),
                 {
@@ -149,6 +150,10 @@ export default class FeatureController extends Controller {
                     },
                 },
             );
+            this.configurationRevisionService.on(UPDATE_REVISION, () => {
+                cachedFeaturesAndSegments.clear();
+            });
+            this.featuresAndSegments = cachedFeaturesAndSegments;
         } else {
             this.featuresAndSegments = this.resolveFeaturesAndSegments;
         }

--- a/src/lib/features/client-feature-toggles/tests/client-feature-toggle.e2e.test.ts
+++ b/src/lib/features/client-feature-toggles/tests/client-feature-toggle.e2e.test.ts
@@ -10,6 +10,8 @@ import { ClientSpecService } from '../../../services/client-spec-service.js';
 import type { Application } from 'express';
 import type { IFlagResolver } from '../../../types/index.js';
 import type TestAgent from 'supertest/lib/agent.d.ts';
+import EventEmitter from 'events';
+import { UPDATE_REVISION } from '../../feature-toggle/configuration-revision-service.js';
 
 import { vi } from 'vitest';
 
@@ -94,7 +96,9 @@ test('if caching is enabled should memoize', async () => {
         getActiveSegmentsForClient,
     };
     const featureToggleService = { getClientFeatures };
-    const configurationRevisionService = { getMaxRevisionId: () => 1 };
+    const configurationRevisionService = Object.assign(new EventEmitter(), {
+        getMaxRevisionId: () => 1,
+    });
 
     const controller = new FeatureController(
         {
@@ -121,6 +125,54 @@ test('if caching is enabled should memoize', async () => {
     await callGetAll(controller);
     await callGetAll(controller);
     expect(getClientFeatures).toHaveBeenCalledTimes(1);
+});
+
+test('cache is cleared when the revision updates', async () => {
+    const getClientFeatures = vi.fn().mockReturnValue([]);
+    const getActiveSegmentsForClient = vi.fn().mockReturnValue([]);
+    const respondWithValidation = vi.fn().mockReturnValue({});
+    const validPath = vi.fn().mockReturnValue(vi.fn());
+    const clientSpecService = new ClientSpecService({ getLogger });
+    const openApiService = { respondWithValidation, validPath };
+    const clientFeatureToggleService = {
+        getClientFeatures,
+        getActiveSegmentsForClient,
+    };
+    const featureToggleService = { getClientFeatures };
+    const configurationRevisionService = Object.assign(new EventEmitter(), {
+        getMaxRevisionId: () => 1,
+    });
+
+    const controller = new FeatureController(
+        {
+            clientSpecService,
+            // @ts-expect-error due to partial implementation
+            openApiService,
+            // @ts-expect-error due to partial implementation
+            clientFeatureToggleService,
+            // @ts-expect-error due to partial implementation
+            featureToggleService,
+            // @ts-expect-error due to partial implementation
+            configurationRevisionService,
+        },
+        {
+            getLogger,
+            clientFeatureCaching: {
+                enabled: true,
+                maxAge: secondsToMilliseconds(10),
+            },
+            flagResolver,
+        },
+    );
+
+    await callGetAll(controller);
+    await callGetAll(controller);
+    expect(getClientFeatures).toHaveBeenCalledTimes(1);
+
+    configurationRevisionService.emit(UPDATE_REVISION);
+
+    await callGetAll(controller);
+    expect(getClientFeatures).toHaveBeenCalledTimes(2);
 });
 
 test('if caching is not enabled all calls goes to service', async () => {

--- a/src/lib/types/option.ts
+++ b/src/lib/types/option.ts
@@ -119,6 +119,7 @@ export interface IServerOption {
 export interface IClientCachingOption {
     enabled: boolean;
     maxAge: number;
+    max: number;
 }
 
 export interface ICustomStrategySettings {


### PR DESCRIPTION
## Problem

The `/api/client/features` response memoize cache (`client-feature-toggle.controller.ts`) is keyed on an etag:

```js
const etag = `"${queryHash}:${revisionId}:v1"`;
```

Because the key embeds `revisionId`, **every write bumps the revision** and causes the next poll for each query shape to compute and store a **brand-new full copy** of the features + segments payload. The previous-revision entries become permanently unreachable the instant the revision advances — `calculateMeta` always derives the etag from the *current* revision, so no future request will ever carry an old revision's etag — yet they linger for the full `maxAge` (default 1h) because eviction is purely time-based. With `memoizee` configured with **no `max` bound**, its count-based LRU never activates either, so resident entries accumulate as roughly `revisions-per-hour × distinct-query-shapes`, each holding a complete flag set. On instances with many flags and frequent writes this is a large, write-driven memory footprint that can push memory-constrained deployments into an OOM.

## Fix

Two complementary changes:

1. **Clear the cache on `UPDATE_REVISION` (primary).** When the revision advances, every cached entry is already dead, so the cache is cleared and only ever holds the current revision's working set. This removes the stale copies immediately instead of hours later. It causes **no extra cache misses** — the first request at a new revision is a miss regardless of whether the old entries are still resident — so it is pure memory reclamation with no hit-rate cost.

2. **Add a `max` bound (backstop).** Default **100**, configurable via `CLIENT_FEATURE_CACHING_MAX`. With clear-on-revision handling the revision dimension, `max` is now only a safety limit against a single revision fanning out into a pathological number of distinct query shapes. `memoizee`'s LRU keeps the hot entries and evicts the rest. The cache is a pure performance optimization — a given etag always maps to the same content — so a miss simply recomputes from the DB and correctness is unaffected.

## Changes

- Clear the client-features memoize cache on `UPDATE_REVISION`.
- `IClientCachingOption` gains a `max` field; `defaultClientCachingOptions.max = 100`, overridable via the `CLIENT_FEATURE_CACHING_MAX` environment variable; the controller passes `max: clientFeatureCaching.max` to `memoizee`.
- Tests: config defaults/override/env var for `max`, and a controller test asserting the cache is cleared on revision update.