### PR TITLE
fix(feature-toggle-store): don't log benign transaction race in getProjectId

### DIFF
--- a/src/lib/features/feature-toggle/feature-toggle-store.ts
+++ b/src/lib/features/feature-toggle/feature-toggle-store.ts
@@ -76,6 +76,11 @@ const commonSelectColumns = [
 const TABLE = 'features';
 const FEATURE_ENVIRONMENTS_TABLE = 'feature_environments';
 
+// knex throws this when a query runs on a transaction that already committed/rolled back
+const isTransactionAlreadyCompleteError = (e: unknown): boolean =>
+    e instanceof Error &&
+    e.message.includes('Transaction query already complete');
+
 export default class FeatureToggleStore implements IFeatureToggleStore {
     private db: Db;
 
@@ -325,7 +330,17 @@ export default class FeatureToggleStore implements IFeatureToggleStore {
             .where({ name })
             .then((r) => (r ? r.project : undefined))
             .catch((e) => {
-                this.logger.error(e);
+                // This best-effort lookup can run on a transactional store (e.g.
+                // during an import); if that transaction has already completed,
+                // knex throws and undefined is the correct fallback. Don't flood
+                // error logs with that benign race, but still surface real failures.
+                if (isTransactionAlreadyCompleteError(e)) {
+                    this.logger.debug(
+                        'getProjectId query ran after its transaction completed; returning undefined',
+                    );
+                } else {
+                    this.logger.error(e);
+                }
                 return undefined;
             });
     }


### PR DESCRIPTION
## What

The deprecated `FeatureToggleStore.getProjectId()` (used by the RBAC middleware to resolve a feature's project) swallows any query error, logs it at **`error`** level, and returns `undefined`. When this best-effort lookup runs on a **transactional** store instance — e.g. during a bulk feature **import**, which runs inside a transaction (`withTransactional`) — and the underlying transaction has already committed, knex throws:

```
Transaction query already complete, run with DEBUG=knex:tx for more info
```

`undefined` is the correct fallback there, but logging it at `error` **floods error dashboards during imports** with a non-actionable message.

Observed in production: ~200 of these in a **~10-minute window** on a single instance, all coinciding with one customer's config import (dozens of `createFeature` calls in one transaction). No functional failure — the import completed — just error-log noise. Zero on all other instances (it's a code path, not infra, so it can recur on any instance during a large import).

## Change

In the `getProjectId` catch, detect the knex "Transaction query already complete" race and log it at **`debug`** (returning `undefined` as before), while still logging genuine errors at `error`.

## Why this (small) shape

`getProjectId` is already `@deprecated` and slated for removal, so this is intentionally a minimal, low-risk mitigation of the log noise rather than a rework. The query rides a transaction because transactional service clones pass `trx` as the store's `db` (`db/transaction.ts`), and a knex `trx` exposes no clean non-transactional handle to route the read around it.

**Open for discussion:** a deeper fix would make RBAC/project lookups read via a non-transactional connection (so they never ride a request/import transaction), or finish removing the deprecated path entirely. Happy to take it that direction if preferred — hence draft.

## Notes

- No test added yet — the race is integration-level (needs a completed trx). Suggestions on the preferred test approach welcome.