### PR TITLE
perf: intern constraint operator and contextName

### DIFF
--- a/src/lib/features/client-feature-toggles/client-feature-toggle-store.ts
+++ b/src/lib/features/client-feature-toggles/client-feature-toggle-store.ts
@@ -17,7 +17,7 @@ import {
     ensureStringValue,
     mapValues,
 } from '../../util/index.js';
-import { internFlagField } from './intern-flag-field.js';
+import { internConstraints, internFlagField } from './intern-flag-field.js';
 import type EventEmitter from 'events';
 import FeatureToggleStore from '../feature-toggle/feature-toggle-store.js';
 import type { Db } from '../../db/db.js';
@@ -268,7 +268,7 @@ export default class FeatureToggleClientStore
             id: row.strategy_id,
             name: internFlagField(row.strategy_name),
             title: row.strategy_title,
-            constraints: row.constraints || [],
+            constraints: internConstraints(row.constraints),
             parameters: mapValues(row.parameters || {}, ensureStringValue),
             sortOrder: row.sort_order,
             milestoneId: row.milestone_id,

--- a/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-read-model.ts
+++ b/src/lib/features/client-feature-toggles/delta/client-feature-toggle-delta-read-model.ts
@@ -8,7 +8,7 @@ import {
     ensureStringValue,
     mapValues,
 } from '../../../util/index.js';
-import { internFlagField } from '../intern-flag-field.js';
+import { internConstraints, internFlagField } from '../intern-flag-field.js';
 import type {
     FeatureConfigurationDeltaClient,
     IClientFeatureToggleDeltaReadModel,
@@ -219,7 +219,7 @@ export default class ClientFeatureToggleDeltaReadModel
             id: row.strategy_id,
             name: internFlagField(row.strategy_name),
             title: row.strategy_title,
-            constraints: row.constraints || [],
+            constraints: internConstraints(row.constraints),
             parameters: mapValues(row.parameters || {}, ensureStringValue),
             sortOrder: row.sort_order,
             milestoneId: row.milestone_id,

--- a/src/lib/features/client-feature-toggles/intern-flag-field.ts
+++ b/src/lib/features/client-feature-toggles/intern-flag-field.ts
@@ -15,3 +15,14 @@ export const createFlagFieldInterner = () => {
 };
 
 export const internFlagField = createFlagFieldInterner();
+
+export const internConstraints = (constraints: any) => {
+    if (!Array.isArray(constraints)) {
+        return constraints || [];
+    }
+    return constraints.map((constraint) => ({
+        ...constraint,
+        contextName: internFlagField(constraint.contextName),
+        operator: internFlagField(constraint.operator),
+    }));
+};

--- a/src/lib/features/frontend-api/client-feature-toggle-read-model.ts
+++ b/src/lib/features/frontend-api/client-feature-toggle-read-model.ts
@@ -5,7 +5,10 @@ import type {
     PartialDeep,
 } from '../../types/index.js';
 import { ensureStringValue, mapValues } from '../../util/index.js';
-import { internFlagField } from '../client-feature-toggles/intern-flag-field.js';
+import {
+    internConstraints,
+    internFlagField,
+} from '../client-feature-toggles/intern-flag-field.js';
 import type { Db } from '../../db/db.js';
 import FeatureToggleStore from '../feature-toggle/feature-toggle-store.js';
 type Raw<T = any> = Knex.Raw<T>;
@@ -186,7 +189,7 @@ export default class ClientFeatureToggleReadModel
             id: row.strategy_id,
             name: internFlagField(row.strategy_name),
             title: row.strategy_title,
-            constraints: row.constraints || [],
+            constraints: internConstraints(row.constraints),
             parameters: mapValues(row.parameters || {}, ensureStringValue),
             sortOrder: row.sort_order,
         };


### PR DESCRIPTION
## Context

Follow-up to #12532, which interned the low-cardinality flag fields `type` and `strategy_name` in the client feature caches (validated in prod at **~20 MB average pod-memory drop**).

This extends the same technique to the two **constraint** fields that carry the most duplication. Constraints come back from the `pg` driver as fresh strings per row, and `operator`/`contextName` repeat on essentially every constraint — so the per-environment feature caches (`GlobalFrontendApiCache`, `DeltaCache`) hold tens of thousands of duplicate copies of a tiny set of values.

## Change

In each read model's `rowToStrategy`, intern `operator` + `contextName` via the existing capped `internFlagField` helper (added in #12532):

```ts
constraints: (row.constraints || []).map((constraint) => ({
    ...constraint,
    contextName: internFlagField(constraint.contextName),
    operator: internFlagField(constraint.operator),
})),
```

- `frontend-api/client-feature-toggle-read-model.ts`
- `client-feature-toggles/delta/client-feature-toggle-delta-read-model.ts`
- `client-feature-toggles/client-feature-toggle-store.ts`

## Why these fields are safe

- `operator` is a **closed enum** (~15 values) — bounded by definition.
- `contextName` is user-extensible, but fleet data shows it's low-cardinality in practice: **median 6, p90 16, p99 47, max 320** distinct context fields per instance — all far under `internFlagField`'s 1000-entry cap, so dedupe stays high and the pool can never grow unbounded.
