### PR TITLE
feat: draggable, narrower, repositioned onboarding checklist

### DIFF
--- a/frontend/src/component/onboarding/floatingChecklist/FloatingOnboardingChecklist.tsx
+++ b/frontend/src/component/onboarding/floatingChecklist/FloatingOnboardingChecklist.tsx
@@ -12,6 +12,8 @@ import {
     keyframes,
     styled,
     Typography,
+    useMediaQuery,
+    useTheme,
 } from '@mui/material';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
@@ -65,7 +67,7 @@ const Window = styled('aside', {
 })<{ pulsing?: boolean }>(({ theme, pulsing }) => ({
     position: 'fixed',
     bottom: theme.spacing(3),
-    right: theme.spacing(3),
+    right: theme.spacing(20),
     width: 320,
     maxWidth: `calc(100vw - ${theme.spacing(4)})`,
     maxHeight: `calc(100vh - ${theme.spacing(6)})`,
@@ -90,22 +92,27 @@ const Window = styled('aside', {
 }));
 
 const Header = styled('div', {
-    shouldForwardProp: (prop) => prop !== 'dragging',
-})<{ dragging?: boolean }>(({ theme, dragging }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(0.125),
-    padding: theme.spacing(1, 1.5, 1, 0.75),
-    background: theme.palette.background.elevation1,
-    flexShrink: 0,
-    cursor: dragging ? 'grabbing' : 'grab',
-    // Keep touch drags from scrolling the page, and text from selecting mid-drag.
-    touchAction: 'none',
-    userSelect: dragging ? 'none' : undefined,
-    '&:hover .drag-handle': {
-        color: theme.palette.text.secondary,
-    },
-}));
+    shouldForwardProp: (prop) => prop !== 'dragging' && prop !== 'draggable',
+})<{ dragging?: boolean; draggable?: boolean }>(
+    ({ theme, dragging, draggable }) => ({
+        display: 'flex',
+        alignItems: 'center',
+        gap: theme.spacing(0.125),
+        padding: theme.spacing(1, 1.5, 1, 0.75),
+        background: theme.palette.background.elevation1,
+        flexShrink: 0,
+        ...(draggable && {
+            cursor: dragging ? 'grabbing' : 'grab',
+            // Keep touch drags from scrolling the page, and text from
+            // selecting mid-drag.
+            touchAction: 'none',
+            userSelect: dragging ? 'none' : undefined,
+            '&:hover .drag-handle': {
+                color: theme.palette.text.secondary,
+            },
+        }),
+    }),
+);
 
 const DragHandle = styled(DragIndicatorIcon)(({ theme }) => ({
     color: theme.palette.text.disabled,
@@ -252,6 +259,12 @@ const EligibleFloatingOnboardingChecklist = () => {
     );
 
     const { windowRef, position, dragging, handleProps } = useDraggableWindow();
+    const theme = useTheme();
+    // Below `sm` the window is full-width (anchored by both left and right), so
+    // dragging it doesn't make sense and applying an absolute position would
+    // collapse it to content width.
+    const draggable = !useMediaQuery(theme.breakpoints.down('sm'));
+    const dragPosition = draggable ? position : null;
 
     const [createFlagOpen, setCreateFlagOpen] = useState(false);
     const [connectSdkOpen, setConnectSdkOpen] = useState(false);
@@ -420,18 +433,22 @@ const EligibleFloatingOnboardingChecklist = () => {
                 pulsing={pulsing}
                 ref={windowRef}
                 style={
-                    position
+                    dragPosition
                         ? {
-                              top: position.y,
-                              left: position.x,
+                              top: dragPosition.y,
+                              left: dragPosition.x,
                               bottom: 'auto',
                               right: 'auto',
                           }
                         : undefined
                 }
             >
-                <Header dragging={dragging} {...handleProps}>
-                    <DragHandle className='drag-handle' />
+                <Header
+                    draggable={draggable}
+                    dragging={dragging}
+                    {...(draggable ? handleProps : {})}
+                >
+                    {draggable ? <DragHandle className='drag-handle' /> : null}
                     <TitleRow>
                         <HeaderTitle>Get started</HeaderTitle>
                         <OnboardingProgressBadge showLabel />

--- a/frontend/src/component/onboarding/floatingChecklist/FloatingOnboardingChecklist.tsx
+++ b/frontend/src/component/onboarding/floatingChecklist/FloatingOnboardingChecklist.tsx
@@ -16,6 +16,7 @@ import {
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
 import MinimizeIcon from '@mui/icons-material/Minimize';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import { Link } from 'react-router';
 import { CreateFeatureDialog } from 'component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureTogglesHeader/CreateFeatureDialog.tsx';
 import { ConnectSdkDialog } from 'component/onboarding/dialog/ConnectSdkDialog/ConnectSdkDialog.tsx';
@@ -30,6 +31,7 @@ import { useFirstProjectFeature } from './useFirstProjectFeature.ts';
 import { useChecklistRouteMatch } from './useChecklistRouteMatch.ts';
 import { ChecklistSteps, type ChecklistStep } from './ChecklistSteps.tsx';
 import { usePendingAction } from './usePendingAction.ts';
+import { useDraggableWindow } from './useDraggableWindow.ts';
 import type { ChecklistStepKey } from './useChecklistContextValue.ts';
 import { ONBOARDING_CHECKLIST_SPLASH_ID } from './useOnboardingChecklistEligibility.ts';
 
@@ -64,7 +66,7 @@ const Window = styled('aside', {
     position: 'fixed',
     bottom: theme.spacing(3),
     right: theme.spacing(3),
-    width: 380,
+    width: 320,
     maxWidth: `calc(100vw - ${theme.spacing(4)})`,
     maxHeight: `calc(100vh - ${theme.spacing(6)})`,
     display: 'flex',
@@ -87,13 +89,29 @@ const Window = styled('aside', {
     }),
 }));
 
-const Header = styled('div')(({ theme }) => ({
+const Header = styled('div', {
+    shouldForwardProp: (prop) => prop !== 'dragging',
+})<{ dragging?: boolean }>(({ theme, dragging }) => ({
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(0.125),
-    padding: theme.spacing(1, 1.5, 1, 1.5),
+    padding: theme.spacing(1, 1.5, 1, 0.75),
     background: theme.palette.background.elevation1,
     flexShrink: 0,
+    cursor: dragging ? 'grabbing' : 'grab',
+    // Keep touch drags from scrolling the page, and text from selecting mid-drag.
+    touchAction: 'none',
+    userSelect: dragging ? 'none' : undefined,
+    '&:hover .drag-handle': {
+        color: theme.palette.text.secondary,
+    },
+}));
+
+const DragHandle = styled(DragIndicatorIcon)(({ theme }) => ({
+    color: theme.palette.text.disabled,
+    fontSize: '1.25rem',
+    flexShrink: 0,
+    transition: theme.transitions.create('color'),
 }));
 
 const TitleRow = styled('div')(({ theme }) => ({
@@ -232,6 +250,8 @@ const EligibleFloatingOnboardingChecklist = () => {
         },
         [trackEvent],
     );
+
+    const { windowRef, position, dragging, handleProps } = useDraggableWindow();
 
     const [createFlagOpen, setCreateFlagOpen] = useState(false);
     const [connectSdkOpen, setConnectSdkOpen] = useState(false);
@@ -395,8 +415,23 @@ const EligibleFloatingOnboardingChecklist = () => {
 
     return (
         <>
-            <Window aria-label='Get started' pulsing={pulsing}>
-                <Header>
+            <Window
+                aria-label='Get started'
+                pulsing={pulsing}
+                ref={windowRef}
+                style={
+                    position
+                        ? {
+                              top: position.y,
+                              left: position.x,
+                              bottom: 'auto',
+                              right: 'auto',
+                          }
+                        : undefined
+                }
+            >
+                <Header dragging={dragging} {...handleProps}>
+                    <DragHandle className='drag-handle' />
                     <TitleRow>
                         <HeaderTitle>Get started</HeaderTitle>
                         <OnboardingProgressBadge showLabel />

--- a/frontend/src/component/onboarding/floatingChecklist/useDraggableWindow.ts
+++ b/frontend/src/component/onboarding/floatingChecklist/useDraggableWindow.ts
@@ -102,18 +102,29 @@ export const useDraggableWindow = () => {
         }
     }, []);
 
-    // Keep the window on-screen if the viewport shrinks under it.
+    // Keep the window on-screen when the viewport shrinks (window resize) or
+    // when the window's own size changes — e.g. minimize/expand or content
+    // growth. Without the latter, a dragged (top-anchored) window could grow
+    // off the bottom of the screen after being expanded.
     useEffect(() => {
-        const onResize = () => {
-            const node = windowRef.current;
+        const node = windowRef.current;
+        const reclamp = () => {
             if (!node || !sharedPosition) return;
             const rect = node.getBoundingClientRect();
             setPosition((prev) =>
                 prev ? clampToViewport(prev, rect.width, rect.height) : prev,
             );
         };
-        window.addEventListener('resize', onResize);
-        return () => window.removeEventListener('resize', onResize);
+        window.addEventListener('resize', reclamp);
+        const observer =
+            typeof ResizeObserver !== 'undefined'
+                ? new ResizeObserver(reclamp)
+                : null;
+        if (node && observer) observer.observe(node);
+        return () => {
+            window.removeEventListener('resize', reclamp);
+            observer?.disconnect();
+        };
     }, []);
 
     const handleProps = {

--- a/frontend/src/component/onboarding/floatingChecklist/useDraggableWindow.ts
+++ b/frontend/src/component/onboarding/floatingChecklist/useDraggableWindow.ts
@@ -1,0 +1,127 @@
+import {
+    type PointerEvent as ReactPointerEvent,
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
+
+interface Position {
+    x: number;
+    y: number;
+}
+
+// Kept at module scope so the dragged position survives the MainLayout
+// remount that happens on route change, but resets to the default anchor on a
+// full page reload (the JS reboots and this goes back to `null`).
+let sharedPosition: Position | null = null;
+
+const VIEWPORT_MARGIN = 8;
+
+const clampToViewport = (
+    { x, y }: Position,
+    width: number,
+    height: number,
+): Position => {
+    const maxX = Math.max(
+        VIEWPORT_MARGIN,
+        window.innerWidth - width - VIEWPORT_MARGIN,
+    );
+    const maxY = Math.max(
+        VIEWPORT_MARGIN,
+        window.innerHeight - height - VIEWPORT_MARGIN,
+    );
+    return {
+        x: Math.min(Math.max(x, VIEWPORT_MARGIN), maxX),
+        y: Math.min(Math.max(y, VIEWPORT_MARGIN), maxY),
+    };
+};
+
+/**
+ * Makes a `position: fixed` window draggable by a handle element via native
+ * pointer events. Until the first drag, `position` is `null` and the window
+ * keeps its CSS-anchored spot; after that it's positioned by `top`/`left`.
+ */
+export const useDraggableWindow = () => {
+    const windowRef = useRef<HTMLElement | null>(null);
+    const [position, setPosition] = useState<Position | null>(sharedPosition);
+    const [dragging, setDragging] = useState(false);
+
+    useEffect(() => {
+        sharedPosition = position;
+    }, [position]);
+
+    // Offset from the window's top-left to the pointer, plus its size, frozen
+    // at drag start so movement math stays stable across the drag.
+    const dragOrigin = useRef<{
+        pointerOffsetX: number;
+        pointerOffsetY: number;
+        width: number;
+        height: number;
+    } | null>(null);
+
+    const onPointerDown = useCallback((event: ReactPointerEvent) => {
+        if (event.button !== 0) return;
+        const node = windowRef.current;
+        if (!node) return;
+        // Let the header's own controls (minimize/close) handle their clicks.
+        if ((event.target as HTMLElement).closest('button')) return;
+
+        const rect = node.getBoundingClientRect();
+        dragOrigin.current = {
+            pointerOffsetX: event.clientX - rect.left,
+            pointerOffsetY: event.clientY - rect.top,
+            width: rect.width,
+            height: rect.height,
+        };
+        setDragging(true);
+        event.currentTarget.setPointerCapture(event.pointerId);
+    }, []);
+
+    const onPointerMove = useCallback((event: ReactPointerEvent) => {
+        const origin = dragOrigin.current;
+        if (!origin) return;
+        setPosition(
+            clampToViewport(
+                {
+                    x: event.clientX - origin.pointerOffsetX,
+                    y: event.clientY - origin.pointerOffsetY,
+                },
+                origin.width,
+                origin.height,
+            ),
+        );
+    }, []);
+
+    const endDrag = useCallback((event: ReactPointerEvent) => {
+        if (!dragOrigin.current) return;
+        dragOrigin.current = null;
+        setDragging(false);
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+    }, []);
+
+    // Keep the window on-screen if the viewport shrinks under it.
+    useEffect(() => {
+        const onResize = () => {
+            const node = windowRef.current;
+            if (!node || !sharedPosition) return;
+            const rect = node.getBoundingClientRect();
+            setPosition((prev) =>
+                prev ? clampToViewport(prev, rect.width, rect.height) : prev,
+            );
+        };
+        window.addEventListener('resize', onResize);
+        return () => window.removeEventListener('resize', onResize);
+    }, []);
+
+    const handleProps = {
+        onPointerDown,
+        onPointerMove,
+        onPointerUp: endDrag,
+        onPointerCancel: endDrag,
+    };
+
+    return { windowRef, position, dragging, handleProps };
+};


### PR DESCRIPTION
## What

Tweaks to the floating onboarding checklist:

- **Narrower** — window width reduced from 380px to 320px to save space.
- **Draggable** — grab the header to move it anywhere; a drag-handle icon on the header hints at the affordance (faint by default, brightening on hover) alongside a grab cursor. Position is held in module scope so it survives the MainLayout remount on route change but resets to the default anchor on a full reload (session-only).
- **Repositioned** — resting position moved to 160px from the right so that it does not fully block CTA-elements. (`theme.spacing(20)`).

### Edge cases handled
- Below the `sm` breakpoint the window is full-width, so dragging is disabled there (no handle, no grab cursor, stored position ignored) to avoid collapsing it to content width.
- Re-clamps into the viewport via a `ResizeObserver` on the window (not just `window` resize), so a dragged, top-anchored window can't grow off the bottom of the screen after being expanded from a minimized state.

## Testing
- Typecheck + biome clean; existing checklist/`ChecklistSteps` unit tests pass.
- Verified live on a fresh local instance: 160px position + drag handle on desktop; full-width with no handle below `sm`.

## Notes
Mouse/touch drag only (no keyboard-drag); the default anchored position remains fully reachable without dragging.

## Video
https://github.com/user-attachments/assets/19869379-b0bc-4fcf-b27e-6ac9fa9a2a40



🤖 Generated with [Claude Code](https://claude.com/claude-code)