### PR TITLE
feat: user access log endpoint (backend)

### DIFF
--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -47,6 +47,7 @@ import { DependentFeaturesStore } from '../features/dependent-features/dependent
 import LastSeenStore from '../features/metrics/last-seen/last-seen-store.js';
 import FeatureSearchStore from '../features/feature-search/feature-search-store.js';
 import { InactiveUsersStore } from '../users/inactive/inactive-users-store.js';
+import { UserAccessLogReadModel } from '../features/user-access-log/user-access-log-read-model.js';
 import { TrafficDataUsageStore } from '../features/traffic-data-usage/traffic-data-usage-store.js';
 import { SegmentReadModel } from '../features/segment/segment-read-model.js';
 import { ProjectOwnersReadModel } from '../features/project/project-owners-read-model.js';
@@ -181,6 +182,7 @@ export const createStores = (
             config.flagResolver,
         ),
         inactiveUsersStore: new InactiveUsersStore(db, eventBus, getLogger),
+        userAccessLogReadModel: new UserAccessLogReadModel(db),
         trafficDataUsageStore: new TrafficDataUsageStore(db, getLogger),
         segmentReadModel: new SegmentReadModel(db),
         projectOwnersReadModel: new ProjectOwnersReadModel(db),

--- a/src/lib/features/user-access-log/createUserAccessLogService.ts
+++ b/src/lib/features/user-access-log/createUserAccessLogService.ts
@@ -1,0 +1,32 @@
+import type { Db, IUnleashConfig } from '../../types/index.js';
+import type { AccessService } from '../../services/access-service.js';
+import { UserAccessLogReadModel } from './user-access-log-read-model.js';
+import { FakeUserAccessLogReadModel } from './fake-user-access-log-read-model.js';
+import { UserAccessLogService } from './user-access-log-service.js';
+
+export const createUserAccessLogService = (
+    db: Db,
+    config: IUnleashConfig,
+    accessService: AccessService,
+): UserAccessLogService => {
+    const userAccessLogReadModel = new UserAccessLogReadModel(db);
+
+    return new UserAccessLogService(
+        { userAccessLogReadModel },
+        { getLogger: config.getLogger },
+        { accessService },
+    );
+};
+
+export const createFakeUserAccessLogService = (
+    config: Pick<IUnleashConfig, 'getLogger'>,
+    accessService: AccessService,
+): UserAccessLogService => {
+    const userAccessLogReadModel = new FakeUserAccessLogReadModel();
+
+    return new UserAccessLogService(
+        { userAccessLogReadModel },
+        { getLogger: config.getLogger },
+        { accessService },
+    );
+};

--- a/src/lib/features/user-access-log/fake-user-access-log-read-model.ts
+++ b/src/lib/features/user-access-log/fake-user-access-log-read-model.ts
@@ -1,0 +1,74 @@
+import type {
+    IUserAccessLogParams,
+    IUserAccessLogReadModel,
+    IUserAccessLogResult,
+    IUserAccessLogRow,
+    UserAccessLogSortBy,
+} from './user-access-log-read-model-type.js';
+
+const compareBy = (
+    a: IUserAccessLogRow,
+    b: IUserAccessLogRow,
+    sortBy: UserAccessLogSortBy,
+): number => {
+    const nullsLast = (
+        av: number | string | null,
+        bv: number | string | null,
+    ): number | undefined => {
+        if (av === null && bv === null) return 0;
+        if (av === null) return 1;
+        if (bv === null) return -1;
+        return undefined;
+    };
+
+    switch (sortBy) {
+        case 'createdAt': {
+            const av = a.createdAt ? a.createdAt.getTime() : null;
+            const bv = b.createdAt ? b.createdAt.getTime() : null;
+            return nullsLast(av, bv) ?? (av as number) - (bv as number);
+        }
+        case 'removedAt': {
+            const av = a.removedAt ? a.removedAt.getTime() : null;
+            const bv = b.removedAt ? b.removedAt.getTime() : null;
+            return nullsLast(av, bv) ?? (av as number) - (bv as number);
+        }
+        case 'name': {
+            const av = a.name;
+            const bv = b.name;
+            return (
+                nullsLast(av, bv) ?? (av as string).localeCompare(bv as string)
+            );
+        }
+        case 'status':
+            return Number(a.removed) - Number(b.removed);
+        default:
+            return 0;
+    }
+};
+
+export class FakeUserAccessLogReadModel implements IUserAccessLogReadModel {
+    private rows: IUserAccessLogRow[];
+
+    constructor(rows: IUserAccessLogRow[] = []) {
+        this.rows = rows;
+    }
+
+    async getAccessLog(
+        params: IUserAccessLogParams,
+    ): Promise<IUserAccessLogResult> {
+        const { offset, limit, sortBy, sortOrder } = params;
+        const factor = sortOrder === 'asc' ? 1 : -1;
+
+        const sorted = [...this.rows].sort((a, b) => {
+            const primary = factor * compareBy(a, b, sortBy);
+            if (primary !== 0) return primary;
+            // NULLS LAST is not flipped by direction in SQL; the fake keeps
+            // stable ordering by user_id for ties which is sufficient for tests.
+            return a.userId - b.userId;
+        });
+
+        const page = sorted.slice(offset, offset + limit);
+
+        return { rows: page, total: this.rows.length };
+    }
+}

--- a/src/lib/features/user-access-log/user-access-log-controller.ts
+++ b/src/lib/features/user-access-log/user-access-log-controller.ts
@@ -1,0 +1,107 @@
+import type { Response } from 'express';
+import Controller from '../../routes/controller.js';
+import { ADMIN, type IUnleashConfig } from '../../types/index.js';
+import { serializeDates } from '../../types/serialize-dates.js';
+import type { IUnleashServices, OpenApiService } from '../../services/index.js';
+import type { UserAccessLogService } from './user-access-log-service.js';
+import type { IAuthRequest } from '../../routes/unleash-types.js';
+import { createResponseSchema } from '../../openapi/util/create-response-schema.js';
+import {
+    type UserAccessLogSchema,
+    userAccessLogSchema,
+} from '../../openapi/spec/user-access-log-schema.js';
+import {
+    type UserAccessLogQueryParameters,
+    userAccessLogQueryParameters,
+} from '../../openapi/spec/user-access-log-query-parameters.js';
+import { normalizeQueryParams } from '../feature-search/search-utils.js';
+import type { UserAccessLogSortBy } from './user-access-log-read-model-type.js';
+
+const SORT_BY_VALUES: UserAccessLogSortBy[] = [
+    'createdAt',
+    'removedAt',
+    'name',
+    'status',
+];
+
+export class UserAccessLogController extends Controller {
+    private userAccessLogService: UserAccessLogService;
+
+    private openApiService: OpenApiService;
+
+    constructor(
+        config: IUnleashConfig,
+        {
+            userAccessLogService,
+            openApiService,
+        }: Pick<IUnleashServices, 'userAccessLogService' | 'openApiService'>,
+    ) {
+        super(config);
+        this.userAccessLogService = userAccessLogService;
+        this.openApiService = openApiService;
+
+        this.route({
+            method: 'get',
+            path: '',
+            handler: this.getAccessLog,
+            permission: ADMIN,
+            middleware: [
+                openApiService.validPath({
+                    release: { beta: '8.1.0' },
+                    operationId: 'getUserAccessLog',
+                    summary: 'Gets the user access log',
+                    description:
+                        'Returns a paginated log of when users were added to and/or removed from the instance, derived from audit events.',
+                    tags: ['Users'],
+                    parameters: [...userAccessLogQueryParameters],
+                    responses: {
+                        200: createResponseSchema('userAccessLogSchema'),
+                    },
+                }),
+            ],
+        });
+    }
+
+    async getAccessLog(
+        req: IAuthRequest<
+            unknown,
+            unknown,
+            unknown,
+            UserAccessLogQueryParameters
+        >,
+        res: Response<UserAccessLogSchema>,
+    ): Promise<void> {
+        const { normalizedLimit, normalizedOffset, normalizedSortOrder } =
+            normalizeQueryParams(req.query, {
+                limitDefault: 25,
+                maxLimit: 100,
+            });
+
+        const sortBy: UserAccessLogSortBy = SORT_BY_VALUES.includes(
+            req.query.sortBy as UserAccessLogSortBy,
+        )
+            ? (req.query.sortBy as UserAccessLogSortBy)
+            : 'createdAt';
+
+        // normalizeQueryParams defaults sortOrder to 'asc'; this endpoint
+        // defaults to 'desc' when the caller did not specify a valid order.
+        const sortOrder =
+            req.query.sortOrder === 'asc' || req.query.sortOrder === 'desc'
+                ? normalizedSortOrder
+                : 'desc';
+
+        const { items, total } = await this.userAccessLogService.getAccessLog({
+            offset: normalizedOffset,
+            limit: normalizedLimit,
+            sortBy,
+            sortOrder,
+        });
+
+        this.openApiService.respondWithValidation(
+            200,
+            res,
+            userAccessLogSchema.$id,
+            serializeDates({ items: serializeDates(items), total }),
+        );
+    }
+}

--- a/src/lib/features/user-access-log/user-access-log-read-model-type.ts
+++ b/src/lib/features/user-access-log/user-access-log-read-model-type.ts
@@ -1,0 +1,36 @@
+export type UserAccessLogSortBy = 'createdAt' | 'removedAt' | 'name' | 'status';
+
+export interface IUserAccessLogParams {
+    offset: number;
+    limit: number;
+    sortBy: UserAccessLogSortBy;
+    sortOrder: 'asc' | 'desc';
+}
+
+/**
+ * A raw row as returned by the read model. Role names are NOT resolved here;
+ * the service enriches the rows with the current/at-removal role name.
+ */
+export interface IUserAccessLogRow {
+    userId: number;
+    name: string | null;
+    username: string | null;
+    email: string | null;
+    imageUrl: string | null;
+    removed: boolean;
+    createdAt: Date | null;
+    removedAt: Date | null;
+    deletedRoleId: number | null;
+    performedById: number | null;
+    performedByName: string | null;
+    performedByImageUrl: string | null;
+}
+
+export interface IUserAccessLogResult {
+    rows: IUserAccessLogRow[];
+    total: number;
+}
+
+export interface IUserAccessLogReadModel {
+    getAccessLog(params: IUserAccessLogParams): Promise<IUserAccessLogResult>;
+}

--- a/src/lib/features/user-access-log/user-access-log-read-model.ts
+++ b/src/lib/features/user-access-log/user-access-log-read-model.ts
@@ -1,0 +1,152 @@
+import type { Db } from '../../db/db.js';
+import { USER_CREATED, USER_DELETED } from '../../events/index.js';
+import type {
+    IUserAccessLogParams,
+    IUserAccessLogReadModel,
+    IUserAccessLogResult,
+    IUserAccessLogRow,
+    UserAccessLogSortBy,
+} from './user-access-log-read-model-type.js';
+
+/**
+ * Whitelist mapping the API-facing sortBy value to the underlying SQL column.
+ * User input MUST NOT be interpolated directly into the query; only values
+ * present in this map are ever placed into the ORDER BY clause.
+ */
+const SORT_COLUMNS: Record<UserAccessLogSortBy, string> = {
+    createdAt: 'created_at',
+    removedAt: 'removed_at',
+    name: 'name',
+    status: 'removed',
+};
+
+const CTES = `
+    WITH created AS (
+        SELECT DISTINCT ON ((data->>'id')::int)
+            (data->>'id')::int AS user_id,
+            created_at,
+            created_by_user_id,
+            data->>'name' AS name,
+            data->>'email' AS email,
+            data->>'username' AS username
+        FROM events
+        WHERE type = :userCreated AND data->>'id' IS NOT NULL
+        ORDER BY (data->>'id')::int, created_at DESC
+    ),
+    deleted AS (
+        SELECT DISTINCT ON ((pre_data->>'id')::int)
+            (pre_data->>'id')::int AS user_id,
+            created_at AS removed_at,
+            created_by_user_id AS removed_by_user_id,
+            pre_data->>'name' AS name,
+            pre_data->>'email' AS email,
+            pre_data->>'username' AS username,
+            NULLIF(pre_data->>'rootRole', '')::int AS role_id
+        FROM events
+        WHERE type = :userDeleted AND pre_data->>'id' IS NOT NULL
+        ORDER BY (pre_data->>'id')::int, created_at DESC
+    ),
+    combined AS (
+        SELECT
+            COALESCE(c.user_id, d.user_id) AS user_id,
+            COALESCE(c.name, d.name) AS name,
+            COALESCE(c.email, d.email) AS email,
+            COALESCE(c.username, d.username) AS username,
+            c.created_at AS created_at,
+            d.removed_at AS removed_at,
+            (d.user_id IS NOT NULL) AS removed,
+            d.role_id AS deleted_role_id,
+            CASE
+                WHEN d.user_id IS NOT NULL THEN d.removed_by_user_id
+                ELSE c.created_by_user_id
+            END AS performed_by_id
+        FROM created c
+        FULL OUTER JOIN deleted d ON c.user_id = d.user_id
+    )
+`;
+
+export class UserAccessLogReadModel implements IUserAccessLogReadModel {
+    private db: Db;
+
+    constructor(db: Db) {
+        this.db = db;
+    }
+
+    async getAccessLog(
+        params: IUserAccessLogParams,
+    ): Promise<IUserAccessLogResult> {
+        const { offset, limit, sortBy, sortOrder } = params;
+
+        const sortColumn = SORT_COLUMNS[sortBy] ?? SORT_COLUMNS.createdAt;
+        const direction = sortOrder === 'asc' ? 'ASC' : 'DESC';
+
+        const bindings = {
+            userCreated: USER_CREATED,
+            userDeleted: USER_DELETED,
+            limit,
+            offset,
+        };
+
+        const itemsQuery = `
+            ${CTES}
+            SELECT
+                combined.user_id AS user_id,
+                combined.name AS name,
+                combined.email AS email,
+                combined.username AS username,
+                combined.created_at AS created_at,
+                combined.removed_at AS removed_at,
+                combined.removed AS removed,
+                combined.deleted_role_id AS deleted_role_id,
+                combined.performed_by_id AS performed_by_id,
+                su.image_url AS image_url,
+                pu.name AS performed_by_name,
+                pu.image_url AS performed_by_image_url
+            FROM combined
+            LEFT JOIN users su ON su.id = combined.user_id
+            LEFT JOIN users pu ON pu.id = combined.performed_by_id
+            ORDER BY ${sortColumn} ${direction} NULLS LAST, combined.user_id ASC
+            LIMIT :limit OFFSET :offset
+        `;
+
+        const countQuery = `
+            ${CTES}
+            SELECT count(*)::int AS total FROM combined
+        `;
+
+        const [itemsResult, countResult] = await Promise.all([
+            this.db.raw(itemsQuery, bindings),
+            this.db.raw(countQuery, {
+                userCreated: USER_CREATED,
+                userDeleted: USER_DELETED,
+            }),
+        ]);
+
+        const rows: IUserAccessLogRow[] = itemsResult.rows.map((row) => ({
+            userId: Number(row.user_id),
+            name: row.name ?? null,
+            username: row.username ?? null,
+            email: row.email ?? null,
+            imageUrl: row.image_url ?? null,
+            removed: Boolean(row.removed),
+            createdAt: row.created_at ?? null,
+            removedAt: row.removed_at ?? null,
+            deletedRoleId:
+                row.deleted_role_id !== null &&
+                row.deleted_role_id !== undefined
+                    ? Number(row.deleted_role_id)
+                    : null,
+            performedById:
+                row.performed_by_id !== null &&
+                row.performed_by_id !== undefined
+                    ? Number(row.performed_by_id)
+                    : null,
+            performedByName: row.performed_by_name ?? null,
+            performedByImageUrl: row.performed_by_image_url ?? null,
+        }));
+
+        const total = countResult.rows[0]?.total ?? 0;
+
+        return { rows, total: Number(total) };
+    }
+}

--- a/src/lib/features/user-access-log/user-access-log-service.ts
+++ b/src/lib/features/user-access-log/user-access-log-service.ts
@@ -1,0 +1,97 @@
+import type { IUnleashConfig } from '../../types/index.js';
+import type { AccessService } from '../../services/access-service.js';
+import type {
+    IUserAccessLogParams,
+    IUserAccessLogReadModel,
+} from './user-access-log-read-model-type.js';
+
+export interface IUserAccessLogPerformedBy {
+    id: number | null;
+    name: string | null;
+    imageUrl: string | null;
+}
+
+export interface IUserAccessLogEntry {
+    id: number;
+    name: string | null;
+    username: string | null;
+    email: string | null;
+    imageUrl: string | null;
+    status: 'added' | 'removed';
+    createdAt: Date | null;
+    removedAt: Date | null;
+    roleName: string | null;
+    performedBy: IUserAccessLogPerformedBy | null;
+}
+
+export interface IUserAccessLogPage {
+    items: IUserAccessLogEntry[];
+    total: number;
+}
+
+export class UserAccessLogService {
+    private readModel: IUserAccessLogReadModel;
+
+    private accessService: AccessService;
+
+    constructor(
+        {
+            userAccessLogReadModel,
+        }: { userAccessLogReadModel: IUserAccessLogReadModel },
+        _config: Pick<IUnleashConfig, 'getLogger'>,
+        { accessService }: { accessService: AccessService },
+    ) {
+        this.readModel = userAccessLogReadModel;
+        this.accessService = accessService;
+    }
+
+    async getAccessLog(
+        params: IUserAccessLogParams,
+    ): Promise<IUserAccessLogPage> {
+        const { rows, total } = await this.readModel.getAccessLog(params);
+
+        const [rootRoles, userRoles] = await Promise.all([
+            this.accessService.getRootRoles(),
+            this.accessService.getRootRoleForAllUsers(),
+        ]);
+
+        const roleNameById = new Map<number, string>(
+            rootRoles.map((role) => [role.id, role.name]),
+        );
+        const currentRoleIdByUserId = new Map<number, number>(
+            userRoles.map((userRole) => [userRole.userId, userRole.roleId]),
+        );
+
+        const items: IUserAccessLogEntry[] = rows.map((row) => {
+            const roleId = row.removed
+                ? row.deletedRoleId
+                : (currentRoleIdByUserId.get(row.userId) ?? null);
+            const roleName =
+                roleId !== null ? (roleNameById.get(roleId) ?? null) : null;
+
+            const performedBy =
+                row.performedById !== null
+                    ? {
+                          id: row.performedById,
+                          name: row.performedByName,
+                          imageUrl: row.performedByImageUrl,
+                      }
+                    : null;
+
+            return {
+                id: row.userId,
+                name: row.name,
+                username: row.username,
+                email: row.email,
+                imageUrl: row.imageUrl,
+                status: row.removed ? 'removed' : 'added',
+                createdAt: row.createdAt,
+                removedAt: row.removedAt,
+                roleName,
+                performedBy,
+            };
+        });
+
+        return { items, total };
+    }
+}

--- a/src/lib/openapi/spec/index.ts
+++ b/src/lib/openapi/spec/index.ts
@@ -232,6 +232,8 @@ export * from './update-tag-type-schema.js';
 export * from './update-tags-schema.js';
 export * from './update-user-schema.js';
 export * from './upsert-segment-schema.js';
+export * from './user-access-log-entry-schema.js';
+export * from './user-access-log-schema.js';
 export * from './user-access-overview-schema.js';
 export * from './user-schema.js';
 export * from './users-groups-base-schema.js';

--- a/src/lib/openapi/spec/user-access-log-entry-schema.ts
+++ b/src/lib/openapi/spec/user-access-log-entry-schema.ts
@@ -1,0 +1,107 @@
+import type { FromSchema } from 'json-schema-to-ts';
+
+export const userAccessLogEntrySchema = {
+    $id: '#/components/schemas/userAccessLogEntrySchema',
+    type: 'object',
+    additionalProperties: false,
+    description:
+        'A single entry in the user access log, describing when a user was added to and/or removed from the Unleash instance.',
+    required: ['id', 'status'],
+    properties: {
+        id: {
+            description: 'The id of the user this entry describes.',
+            type: 'integer',
+            example: 123,
+        },
+        name: {
+            description: 'The name of the user.',
+            type: 'string',
+            nullable: true,
+            example: 'Ned Ryerson',
+        },
+        username: {
+            description: 'The username of the user.',
+            type: 'string',
+            nullable: true,
+            example: 'nedryerson',
+        },
+        email: {
+            description: 'The email of the user.',
+            type: 'string',
+            nullable: true,
+            example: 'user@example.com',
+        },
+        imageUrl: {
+            description:
+                'The URL of the user profile image. Only available while the user still exists.',
+            type: 'string',
+            nullable: true,
+            example:
+                'https://gravatar.com/avatar/21232f297a57a5a743894a0e4a801fc3',
+        },
+        status: {
+            description:
+                'Whether the user is currently added to the instance, or has been removed.',
+            type: 'string',
+            enum: ['added', 'removed'],
+            example: 'added',
+        },
+        createdAt: {
+            description: 'When the user was added to the instance.',
+            type: 'string',
+            format: 'date-time',
+            nullable: true,
+            example: '2023-12-31T23:59:59.999Z',
+        },
+        removedAt: {
+            description:
+                'When the user was removed from the instance. Null if the user is still active.',
+            type: 'string',
+            format: 'date-time',
+            nullable: true,
+            example: '2024-01-25T11:42:00.345Z',
+        },
+        roleName: {
+            description:
+                'The root role name of the user. For active users this is their current role; for removed users it is the role they had when they were removed. Null if it could not be resolved.',
+            type: 'string',
+            nullable: true,
+            example: 'Admin',
+        },
+        performedBy: {
+            description:
+                'The user who performed the last action on this user (removal if removed, otherwise creation).',
+            type: 'object',
+            nullable: true,
+            additionalProperties: false,
+            required: ['id', 'name', 'imageUrl'],
+            properties: {
+                id: {
+                    description: 'The id of the acting user, if known.',
+                    type: 'integer',
+                    nullable: true,
+                    example: 1,
+                },
+                name: {
+                    description: 'The name of the acting user, if known.',
+                    type: 'string',
+                    nullable: true,
+                    example: 'Admin',
+                },
+                imageUrl: {
+                    description:
+                        'The profile image URL of the acting user, if known.',
+                    type: 'string',
+                    nullable: true,
+                    example:
+                        'https://gravatar.com/avatar/21232f297a57a5a743894a0e4a801fc3',
+                },
+            },
+        },
+    },
+    components: {},
+} as const;
+
+export type UserAccessLogEntrySchema = FromSchema<
+    typeof userAccessLogEntrySchema
+>;

--- a/src/lib/openapi/spec/user-access-log-query-parameters.ts
+++ b/src/lib/openapi/spec/user-access-log-query-parameters.ts
@@ -1,0 +1,59 @@
+import type { FromQueryParams } from '../util/from-query-params.js';
+
+export const userAccessLogQueryParameters = [
+    {
+        name: 'offset',
+        schema: {
+            type: 'string',
+            example: '50',
+            default: '0',
+        },
+        description:
+            'The number of access log entries to skip when returning a page. By default it is set to 0.',
+        in: 'query',
+    },
+    {
+        name: 'limit',
+        schema: {
+            type: 'string',
+            example: '25',
+            default: '25',
+        },
+        description:
+            'The number of access log entries to return in a page. By default it is set to 25. The maximum is 100.',
+        in: 'query',
+    },
+    {
+        name: 'sortBy',
+        schema: {
+            type: 'string',
+            enum: ['createdAt', 'removedAt', 'name', 'status'] satisfies (
+                | 'createdAt'
+                | 'removedAt'
+                | 'name'
+                | 'status'
+            )[],
+            example: 'createdAt',
+            default: 'createdAt',
+        },
+        description:
+            'The field to sort the results by. By default it is set to "createdAt".',
+        in: 'query',
+    },
+    {
+        name: 'sortOrder',
+        schema: {
+            type: 'string',
+            enum: ['asc', 'desc'] satisfies ('asc' | 'desc')[],
+            example: 'desc',
+            default: 'desc',
+        },
+        description:
+            'The sort order for the sortBy field. By default it is set to "desc".',
+        in: 'query',
+    },
+] as const;
+
+export type UserAccessLogQueryParameters = Partial<
+    FromQueryParams<typeof userAccessLogQueryParameters>
+>;

--- a/src/lib/openapi/spec/user-access-log-schema.ts
+++ b/src/lib/openapi/spec/user-access-log-schema.ts
@@ -1,0 +1,34 @@
+import type { FromSchema } from 'json-schema-to-ts';
+import { userAccessLogEntrySchema } from './user-access-log-entry-schema.js';
+
+export const userAccessLogSchema = {
+    $id: '#/components/schemas/userAccessLogSchema',
+    type: 'object',
+    additionalProperties: false,
+    required: ['items', 'total'],
+    description:
+        'A paginated access log describing when users were added to and/or removed from the instance.',
+    properties: {
+        items: {
+            description: 'The list of access log entries on this page.',
+            type: 'array',
+            items: {
+                $ref: userAccessLogEntrySchema.$id,
+            },
+        },
+        total: {
+            type: 'integer',
+            description:
+                'The total number of access log entries matching the query.',
+            minimum: 0,
+            example: 42,
+        },
+    },
+    components: {
+        schemas: {
+            userAccessLogEntrySchema,
+        },
+    },
+} as const;
+
+export type UserAccessLogSchema = FromSchema<typeof userAccessLogSchema>;

--- a/src/lib/routes/admin-api/index.ts
+++ b/src/lib/routes/admin-api/index.ts
@@ -32,6 +32,7 @@ import type { Db } from '../../db/db.js';
 import ExportImportController from '../../features/export-import-toggles/export-import-controller.js';
 import { SegmentsController } from '../../features/segment/segment-controller.js';
 import { InactiveUsersController } from '../../users/inactive/inactive-users-controller.js';
+import { UserAccessLogController } from '../../features/user-access-log/user-access-log-controller.js';
 import { UiObservabilityController } from '../../features/ui-observability-controller/ui-observability-controller.js';
 import { SearchApi } from './search/index.js';
 import PersonalDashboardController from '../../features/personal-dashboard/personal-dashboard-controller.js';
@@ -110,6 +111,10 @@ export class AdminApi extends Controller {
         this.app.use(
             '/user-admin/inactive',
             new InactiveUsersController(config, services).router,
+        ); // Needs to load first, so that /api/admin/user-admin/{id} doesn't hit first
+        this.app.use(
+            '/user-admin/access-log',
+            new UserAccessLogController(config, services).router,
         ); // Needs to load first, so that /api/admin/user-admin/{id} doesn't hit first
         this.app.use(
             '/user-admin',

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -120,6 +120,7 @@ import {
     createInstanceStatsService,
 } from '../features/instance-stats/createInstanceStatsService.js';
 import { InactiveUsersService } from '../users/inactive/inactive-users-service.js';
+import { UserAccessLogService } from '../features/user-access-log/user-access-log-service.js';
 import {
     createFakeFrontendApiService,
     createFrontendApiService,
@@ -472,6 +473,11 @@ export const createServices = (
     const inactiveUsersService = new InactiveUsersService(stores, config, {
         userService,
     });
+    const userAccessLogService = new UserAccessLogService(
+        { userAccessLogReadModel: stores.userAccessLogReadModel },
+        config,
+        { accessService },
+    );
 
     const jobService = new JobService(
         new JobStore(db!, config),
@@ -572,6 +578,7 @@ export const createServices = (
         clientFeatureToggleService,
         featureSearchService,
         inactiveUsersService,
+        userAccessLogService,
         projectInsightsService,
         jobService,
         featureLifecycleService,
@@ -712,6 +719,7 @@ export interface IUnleashServices {
     clientFeatureToggleService: ClientFeatureToggleService;
     featureSearchService: FeatureSearchService;
     inactiveUsersService: InactiveUsersService;
+    userAccessLogService: UserAccessLogService;
     projectInsightsService: ProjectInsightsService;
     jobService: JobService;
     featureLifecycleService: FeatureLifecycleService;

--- a/src/lib/types/stores.ts
+++ b/src/lib/types/stores.ts
@@ -39,6 +39,7 @@ import type { IDependentFeaturesStore } from '../features/dependent-features/dep
 import type { ILastSeenStore } from '../features/metrics/last-seen/types/last-seen-store-type.js';
 import type { IFeatureSearchStore } from '../features/feature-search/feature-search-store-type.js';
 import type { IInactiveUsersStore } from '../users/inactive/types/inactive-users-store-type.js';
+import type { IUserAccessLogReadModel } from '../features/user-access-log/user-access-log-read-model-type.js';
 import type { ITrafficDataUsageStore } from '../features/traffic-data-usage/traffic-data-usage-store-type.js';
 import type { ISegmentReadModel } from '../features/segment/segment-read-model-type.js';
 import type { IProjectOwnersReadModel } from '../features/project/project-owners-read-model.type.js';
@@ -113,6 +114,7 @@ export interface IUnleashStores {
     lastSeenStore: ILastSeenStore;
     featureSearchStore: IFeatureSearchStore;
     inactiveUsersStore: IInactiveUsersStore;
+    userAccessLogReadModel: IUserAccessLogReadModel;
     trafficDataUsageStore: ITrafficDataUsageStore;
     segmentReadModel: ISegmentReadModel;
     projectOwnersReadModel: IProjectOwnersReadModel;

--- a/src/test/e2e/api/admin/user-access-log.e2e.test.ts
+++ b/src/test/e2e/api/admin/user-access-log.e2e.test.ts
@@ -1,0 +1,115 @@
+import {
+    type IUnleashTest,
+    setupAppWithCustomConfig,
+} from '../../helpers/test-helper.js';
+import dbInit, { type ITestDb } from '../../helpers/database-init.js';
+import getLogger from '../../../fixtures/no-logger.js';
+import { RoleName } from '../../../../lib/types/model.js';
+import type { IUnleashStores } from '../../../../lib/types/index.js';
+
+let db: ITestDb;
+let app: IUnleashTest;
+let stores: IUnleashStores;
+let editorRoleId: number;
+let adminRoleId: number;
+
+const createUser = async (email: string, rootRole: number): Promise<number> => {
+    const { body } = await app.request
+        .post('/api/admin/user-admin')
+        .send({ email, name: email.split('@')[0], rootRole })
+        .set('Content-Type', 'application/json')
+        .expect(201);
+    return body.id;
+};
+
+beforeAll(async () => {
+    db = await dbInit('user_access_log_api_serial', getLogger);
+    stores = db.stores;
+    app = await setupAppWithCustomConfig(
+        stores,
+        {
+            experimental: {
+                flags: {
+                    strictSchemaValidation: true,
+                },
+            },
+        },
+        db.rawDatabase,
+    );
+    const roles = await stores.roleStore.getRootRoles();
+    editorRoleId = roles.find((r) => r.name === RoleName.EDITOR)!.id;
+    adminRoleId = roles.find((r) => r.name === RoleName.ADMIN)!.id;
+});
+
+afterAll(async () => {
+    await app.destroy();
+    await db.destroy();
+});
+
+afterEach(async () => {
+    await stores.userStore.deleteAll();
+    await stores.eventStore.deleteAll();
+});
+
+test('returns an access log with added and removed users', async () => {
+    const activeId = await createUser('active@example.com', editorRoleId);
+    const removedId = await createUser('removed@example.com', adminRoleId);
+
+    await app.request.delete(`/api/admin/user-admin/${removedId}`).expect(200);
+
+    const { body } = await app.request
+        .get('/api/admin/user-admin/access-log')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+    expect(body.total).toBe(2);
+    expect(body.items).toHaveLength(2);
+
+    const active = body.items.find((i) => i.id === activeId);
+    const removed = body.items.find((i) => i.id === removedId);
+
+    expect(active).toMatchObject({
+        status: 'added',
+        roleName: RoleName.EDITOR,
+    });
+    expect(active.createdAt).toBeTruthy();
+    expect(active.removedAt).toBeNull();
+
+    expect(removed).toMatchObject({
+        status: 'removed',
+        roleName: RoleName.ADMIN,
+    });
+    expect(removed.createdAt).toBeTruthy();
+    expect(removed.removedAt).toBeTruthy();
+    // performedBy should be the admin actor of the delete
+    expect(removed.performedBy).not.toBeNull();
+});
+
+test('paginates and sorts by createdAt', async () => {
+    const firstId = await createUser('first@example.com', editorRoleId);
+    // ensure distinct created_at ordering
+    await new Promise((r) => setTimeout(r, 20));
+    const secondId = await createUser('second@example.com', editorRoleId);
+
+    const ascPage1 = await app.request
+        .get(
+            '/api/admin/user-admin/access-log?sortBy=createdAt&sortOrder=asc&limit=1&offset=0',
+        )
+        .expect(200);
+    expect(ascPage1.body.total).toBe(2);
+    expect(ascPage1.body.items).toHaveLength(1);
+    expect(ascPage1.body.items[0].id).toBe(firstId);
+
+    const ascPage2 = await app.request
+        .get(
+            '/api/admin/user-admin/access-log?sortBy=createdAt&sortOrder=asc&limit=1&offset=1',
+        )
+        .expect(200);
+    expect(ascPage2.body.items).toHaveLength(1);
+    expect(ascPage2.body.items[0].id).toBe(secondId);
+
+    const desc = await app.request
+        .get('/api/admin/user-admin/access-log?sortBy=createdAt&sortOrder=desc')
+        .expect(200);
+    expect(desc.body.items.map((i) => i.id)).toEqual([secondId, firstId]);
+});

--- a/src/test/fixtures/store.ts
+++ b/src/test/fixtures/store.ts
@@ -45,6 +45,7 @@ import { FakeDependentFeaturesStore } from '../../lib/features/dependent-feature
 import { FakeLastSeenStore } from '../../lib/features/metrics/last-seen/fake-last-seen-store.js';
 import FakeFeatureSearchStore from '../../lib/features/feature-search/fake-feature-search-store.js';
 import { FakeInactiveUsersStore } from '../../lib/users/inactive/fakes/fake-inactive-users-store.js';
+import { FakeUserAccessLogReadModel } from '../../lib/features/user-access-log/fake-user-access-log-read-model.js';
 import { FakeTrafficDataUsageStore } from '../../lib/features/traffic-data-usage/fake-traffic-data-usage-store.js';
 import { FakeSegmentReadModel } from '../../lib/features/segment/fake-segment-read-model.js';
 import { FakeProjectOwnersReadModel } from '../../lib/features/project/fake-project-owners-read-model.js';
@@ -123,6 +124,7 @@ const createStores: () => IUnleashStores = () => {
         lastSeenStore: new FakeLastSeenStore(),
         featureSearchStore: new FakeFeatureSearchStore(),
         inactiveUsersStore: new FakeInactiveUsersStore(),
+        userAccessLogReadModel: new FakeUserAccessLogReadModel(),
         trafficDataUsageStore: new FakeTrafficDataUsageStore(),
         segmentReadModel: new FakeSegmentReadModel(),
         projectOwnersReadModel: new FakeProjectOwnersReadModel(),


### PR DESCRIPTION
Backend for the upcoming **Access log** tab in the Users admin area (frontend follows in a separate PR).

Adds `GET /api/admin/user-admin/access-log` — a server-paginated + sorted overview of when users were **added to** / **removed from** the instance, plus each user's role and who performed the action. Because removed users no longer exist in the `users` table, the data is derived from the `user-created` / `user-deleted` audit **events**.

### What it returns
`{ items: UserAccessLogEntry[], total }`, one entry per user: `id, name, username, email, imageUrl, status ('added'|'removed'), createdAt, removedAt, roleName, performedBy {id,name,imageUrl}`.

Query params (reusing the feature/event-search conventions): `offset`, `limit` (default 25, max 100), `sortBy` ∈ `createdAt|removedAt|name|status` (default `createdAt`), `sortOrder` ∈ `asc|desc` (default `desc`).

### How
- **Read model** (`src/lib/features/user-access-log/`): a knex query with CTEs — `created`/`deleted` (`DISTINCT ON` per user id from each event type) joined via `FULL OUTER JOIN`, then joined to `users` for the subject avatar and the performer. Pagination via `LIMIT/OFFSET`; total via `count(*)` over the same CTE. Sort column comes from a **whitelist** map (never interpolated), direction validated to `ASC/DESC`, and `type`/`limit`/`offset` are parameterized bindings.
- **Service**: resolves role names via `accessService.getRootRoles()` + `getRootRoleForAllUsers()` — current root role for active users, the role stored in the delete event's `preData.rootRole` for removed users (N/A when unavailable, e.g. SCIM bulk deletes).
- **Controller**: `ADMIN` permission, `normalizeQueryParams`, `respondWithValidation` + `serializeDates`. Mounted at `/user-admin/access-log` **before** `/user-admin` so `/:id` doesn't shadow it.
- OpenAPI entry/response/query-param schemas registered; composition wired into `createStores`/`createServices`, `IUnleashStores`/`IUnleashServices`, and the fake store fixture.

The endpoint is plain **OSS `ADMIN`**; the Access log tab is **enterprise-gated in the frontend** (consistent with inactive users).

### Tests
e2e (`src/test/e2e/api/admin/user-access-log.e2e.test.ts`): added vs removed status, role resolution (active = current role, removed = role at removal), `performedBy`, `total`, and `sortBy=createdAt` asc/desc with `limit`/`offset` paging.

Verified locally: `tsc` 0 errors, `pnpm lint` clean, e2e 2/2 pass.