### PR TITLE
fix: keep the access log list visible while changing sort order

### DIFF
--- a/frontend/src/component/admin/users/UserAccessLog/UserAccessLog.tsx
+++ b/frontend/src/component/admin/users/UserAccessLog/UserAccessLog.tsx
@@ -99,20 +99,23 @@ export const UserAccessLog = () => {
                 .map((_, index) => ({
                     user: {
                         id: index,
-                        name: '',
-                        username: '',
-                        email: '',
+                        name: 'Loading user',
+                        email: 'loading@example.com',
                         imageUrl: '',
                     },
                     status: 'added',
-                    performedBy: { id: 0, name: '', imageUrl: '' },
+                    createdAt: new Date(2024, 0, 1).toISOString(),
+                    performedBy: { id: 0, name: 'Loading user', imageUrl: '' },
                 })),
         [tableState.limit],
     );
 
     const bodyLoadingRef = useLoading(isPlaceholder);
 
-    const data = isPlaceholder ? placeholderData : items;
+    const data = useMemo(
+        () => (isPlaceholder ? placeholderData : items),
+        [isPlaceholder, placeholderData, items],
+    );
 
     const columns = useMemo(
         () => [
@@ -161,11 +164,8 @@ export const UserAccessLog = () => {
             columnHelper.accessor('status', {
                 id: 'status',
                 header: 'Status',
-                cell: ({ row }) => {
-                    if (isPlaceholder) {
-                        return <TextCell>{''}</TextCell>;
-                    }
-                    return row.original.status === 'removed' ? (
+                cell: ({ row }) =>
+                    row.original.status === 'removed' ? (
                         <TextCell>
                             <Badge color='error'>Removed</Badge>
                         </TextCell>
@@ -173,8 +173,7 @@ export const UserAccessLog = () => {
                         <TextCell>
                             <Badge color='success'>Added</Badge>
                         </TextCell>
-                    );
-                },
+                    ),
                 enableSorting: false,
                 meta: { maxWidth: 120 },
             }),
@@ -210,7 +209,7 @@ export const UserAccessLog = () => {
                 meta: { minWidth: 180 },
             }),
         ],
-        [roles, isPlaceholder],
+        [roles],
     );
 
     const table = useReactTable(

--- a/frontend/src/component/admin/users/UserAccessLog/UserAccessLog.tsx
+++ b/frontend/src/component/admin/users/UserAccessLog/UserAccessLog.tsx
@@ -99,12 +99,13 @@ export const UserAccessLog = () => {
                 .map((_, index) => ({
                     user: {
                         id: index,
-                        name: 'Loading user',
-                        email: 'loading@example.com',
+                        name: '',
+                        username: '',
+                        email: '',
+                        imageUrl: '',
                     },
                     status: 'added',
-                    createdAt: new Date(2024, 0, 1).toISOString(),
-                    performedBy: { id: 0, name: 'Loading user' },
+                    performedBy: { id: 0, name: '', imageUrl: '' },
                 })),
         [tableState.limit],
     );
@@ -160,8 +161,11 @@ export const UserAccessLog = () => {
             columnHelper.accessor('status', {
                 id: 'status',
                 header: 'Status',
-                cell: ({ row }) =>
-                    row.original.status === 'removed' ? (
+                cell: ({ row }) => {
+                    if (isPlaceholder) {
+                        return <TextCell>{''}</TextCell>;
+                    }
+                    return row.original.status === 'removed' ? (
                         <TextCell>
                             <Badge color='error'>Removed</Badge>
                         </TextCell>
@@ -169,7 +173,8 @@ export const UserAccessLog = () => {
                         <TextCell>
                             <Badge color='success'>Added</Badge>
                         </TextCell>
-                    ),
+                    );
+                },
                 enableSorting: false,
                 meta: { maxWidth: 120 },
             }),
@@ -205,7 +210,7 @@ export const UserAccessLog = () => {
                 meta: { minWidth: 180 },
             }),
         ],
-        [roles],
+        [roles, isPlaceholder],
     );
 
     const table = useReactTable(

--- a/frontend/src/component/admin/users/UserAccessLog/UserAccessLog.tsx
+++ b/frontend/src/component/admin/users/UserAccessLog/UserAccessLog.tsx
@@ -90,7 +90,28 @@ export const UserAccessLog = () => {
         sortOrder: tableState.sortOrder === 'asc' ? 'asc' : 'desc',
     });
 
-    const bodyLoadingRef = useLoading(loading);
+    const isPlaceholder = loading;
+
+    const placeholderData = useMemo<UserAccessLogEntrySchema[]>(
+        () =>
+            Array(tableState.limit)
+                .fill(null)
+                .map((_, index) => ({
+                    user: {
+                        id: index,
+                        name: 'Loading user',
+                        email: 'loading@example.com',
+                    },
+                    status: 'added',
+                    createdAt: new Date(2024, 0, 1).toISOString(),
+                    performedBy: { id: 0, name: 'Loading user' },
+                })),
+        [tableState.limit],
+    );
+
+    const bodyLoadingRef = useLoading(isPlaceholder);
+
+    const data = isPlaceholder ? placeholderData : items;
 
     const columns = useMemo(
         () => [
@@ -190,7 +211,7 @@ export const UserAccessLog = () => {
     const table = useReactTable(
         withTableState(tableState, setTableState, {
             columns,
-            data: items,
+            data,
         }),
     );
 
@@ -201,7 +222,7 @@ export const UserAccessLog = () => {
             <div ref={bodyLoadingRef}>
                 <PaginatedTable tableInstance={table} totalItems={total} />
             </div>
-            {rows.length === 0 && !loading ? (
+            {rows.length === 0 && !isPlaceholder ? (
                 <Box sx={(theme) => ({ padding: theme.spacing(0, 2, 2) })}>
                     <TablePlaceholder>
                         No user access log entries found.

--- a/frontend/src/hooks/api/getters/usePaginatedData/usePaginatedData.ts
+++ b/frontend/src/hooks/api/getters/usePaginatedData/usePaginatedData.ts
@@ -13,6 +13,7 @@ type GenericSearchOutput<T> = {
 export function createPaginatedHook<T extends { total?: number }>(
     customFallbackData: T,
     defaultPrefixKey = '',
+    cacheSize = 1,
 ) {
     return (
         params: Record<string, any> = {},
@@ -32,6 +33,7 @@ export function createPaginatedHook<T extends { total?: number }>(
         useClearSWRCache({
             currentKey: KEY,
             clearPrefix: prefix,
+            cacheSize,
         });
 
         const fetcher = async () => {

--- a/frontend/src/hooks/api/getters/useUserAccessLog/useUserAccessLog.ts
+++ b/frontend/src/hooks/api/getters/useUserAccessLog/useUserAccessLog.ts
@@ -12,4 +12,4 @@ const useParameterizedUserAccessLog = createPaginatedHook<UserAccessLogSchema>(
 );
 
 export const useUserAccessLog = (params: GetUsersAccessLogParams) =>
-    useParameterizedUserAccessLog(params);
+    useParameterizedUserAccessLog(params, '', { keepPreviousData: true });

--- a/frontend/src/hooks/api/getters/useUserAccessLog/useUserAccessLog.ts
+++ b/frontend/src/hooks/api/getters/useUserAccessLog/useUserAccessLog.ts
@@ -12,4 +12,4 @@ const useParameterizedUserAccessLog = createPaginatedHook<UserAccessLogSchema>(
 );
 
 export const useUserAccessLog = (params: GetUsersAccessLogParams) =>
-    useParameterizedUserAccessLog(params, '', { keepPreviousData: true });
+    useParameterizedUserAccessLog(params);

--- a/frontend/src/hooks/api/getters/useUserAccessLog/useUserAccessLog.ts
+++ b/frontend/src/hooks/api/getters/useUserAccessLog/useUserAccessLog.ts
@@ -3,12 +3,15 @@ import { createPaginatedHook } from '../usePaginatedData/usePaginatedData.js';
 
 export const DEFAULT_PAGE_LIMIT = 25;
 
+const SWR_CACHE_SIZE = 10;
+
 const useParameterizedUserAccessLog = createPaginatedHook<UserAccessLogSchema>(
     {
         items: [],
         total: 0,
     },
     'api/admin/users/access-log?',
+    SWR_CACHE_SIZE,
 );
 
 export const useUserAccessLog = (params: GetUsersAccessLogParams) =>


### PR DESCRIPTION
Stops the access log list from blanking when the sort order changes by rendering placeholder skeleton rows while a page loads and caching recent pages so toggling direction is instant.