### PR TITLE
feat: make the access log pagination bar stick to the bottom

### DIFF
--- a/frontend/src/component/admin/users/UsersTabs/UsersTabs.tsx
+++ b/frontend/src/component/admin/users/UsersTabs/UsersTabs.tsx
@@ -46,6 +46,7 @@ const UsersTabsView = () => {
     const [searchValue, setSearchValue] = useState('');
 
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
+    const isAccessLog = pathname === '/admin/users/access-log';
 
     const tabs = [
         {
@@ -74,6 +75,7 @@ const UsersTabsView = () => {
         <PageContent
             withTabs
             isLoading={loading}
+            bodyClass={isAccessLog ? 'noop' : undefined}
             header={
                 <>
                     <StyledHeader>

--- a/frontend/src/component/admin/users/UsersTabs/UsersTabs.tsx
+++ b/frontend/src/component/admin/users/UsersTabs/UsersTabs.tsx
@@ -46,7 +46,6 @@ const UsersTabsView = () => {
     const [searchValue, setSearchValue] = useState('');
 
     const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
-    const isAccessLog = pathname === '/admin/users/access-log';
 
     const tabs = [
         {
@@ -75,7 +74,7 @@ const UsersTabsView = () => {
         <PageContent
             withTabs
             isLoading={loading}
-            scrollWithPage={isAccessLog}
+            scrollWithPage
             header={
                 <>
                     <StyledHeader>

--- a/frontend/src/component/admin/users/UsersTabs/UsersTabs.tsx
+++ b/frontend/src/component/admin/users/UsersTabs/UsersTabs.tsx
@@ -75,7 +75,7 @@ const UsersTabsView = () => {
         <PageContent
             withTabs
             isLoading={loading}
-            bodyClass={isAccessLog ? 'noop' : undefined}
+            scrollWithPage={isAccessLog}
             header={
                 <>
                     <StyledHeader>

--- a/frontend/src/component/admin/users/UsersTabs/UsersTabs.tsx
+++ b/frontend/src/component/admin/users/UsersTabs/UsersTabs.tsx
@@ -74,7 +74,7 @@ const UsersTabsView = () => {
         <PageContent
             withTabs
             isLoading={loading}
-            enableStickyFooter
+            withStickyFooter
             header={
                 <>
                     <StyledHeader>

--- a/frontend/src/component/admin/users/UsersTabs/UsersTabs.tsx
+++ b/frontend/src/component/admin/users/UsersTabs/UsersTabs.tsx
@@ -74,7 +74,7 @@ const UsersTabsView = () => {
         <PageContent
             withTabs
             isLoading={loading}
-            scrollWithPage
+            enableStickyFooter
             header={
                 <>
                     <StyledHeader>

--- a/frontend/src/component/common/PageContent/PageContent.styles.ts
+++ b/frontend/src/component/common/PageContent/PageContent.styles.ts
@@ -23,4 +23,7 @@ export const useStyles = makeStyles()((theme) => ({
     borderDisabled: {
         border: 'none',
     },
+    scrollWithPage: {
+        overflowX: 'visible',
+    },
 }));

--- a/frontend/src/component/common/PageContent/PageContent.styles.ts
+++ b/frontend/src/component/common/PageContent/PageContent.styles.ts
@@ -23,7 +23,7 @@ export const useStyles = makeStyles()((theme) => ({
     borderDisabled: {
         border: 'none',
     },
-    scrollWithPage: {
+    stickyFooter: {
         overflowX: 'visible',
     },
 }));

--- a/frontend/src/component/common/PageContent/PageContent.tsx
+++ b/frontend/src/component/common/PageContent/PageContent.tsx
@@ -22,7 +22,7 @@ interface IPageContentProps extends PaperProps {
     bodyClass?: string;
     headerClass?: string;
     withTabs?: boolean;
-    enableStickyFooter?: boolean;
+    withStickyFooter?: boolean;
 }
 
 const StyledHeader = styled('div')(({ theme }) => ({
@@ -63,7 +63,7 @@ export const PageContent: FC<IPageContentProps> = ({
     disableLoading = false,
     className,
     withTabs,
-    enableStickyFooter = false,
+    withStickyFooter = false,
     ...rest
 }) => {
     const { classes: styles } = useStyles();
@@ -84,7 +84,7 @@ export const PageContent: FC<IPageContentProps> = ({
         {
             [styles.paddingDisabled]: disablePadding,
             [styles.borderDisabled]: disableBorder,
-            [styles.stickyFooter]: enableStickyFooter,
+            [styles.stickyFooter]: withStickyFooter,
         },
     );
 

--- a/frontend/src/component/common/PageContent/PageContent.tsx
+++ b/frontend/src/component/common/PageContent/PageContent.tsx
@@ -22,8 +22,7 @@ interface IPageContentProps extends PaperProps {
     bodyClass?: string;
     headerClass?: string;
     withTabs?: boolean;
-    /** Let the body scroll with the page instead of in its own scroll box, so a sticky footer/pagination bar attaches to the window scroll. */
-    scrollWithPage?: boolean;
+    enableStickyFooter?: boolean;
 }
 
 const StyledHeader = styled('div')(({ theme }) => ({
@@ -64,7 +63,7 @@ export const PageContent: FC<IPageContentProps> = ({
     disableLoading = false,
     className,
     withTabs,
-    scrollWithPage = false,
+    enableStickyFooter = false,
     ...rest
 }) => {
     const { classes: styles } = useStyles();
@@ -85,7 +84,7 @@ export const PageContent: FC<IPageContentProps> = ({
         {
             [styles.paddingDisabled]: disablePadding,
             [styles.borderDisabled]: disableBorder,
-            [styles.scrollWithPage]: scrollWithPage,
+            [styles.stickyFooter]: enableStickyFooter,
         },
     );
 

--- a/frontend/src/component/common/PageContent/PageContent.tsx
+++ b/frontend/src/component/common/PageContent/PageContent.tsx
@@ -22,6 +22,8 @@ interface IPageContentProps extends PaperProps {
     bodyClass?: string;
     headerClass?: string;
     withTabs?: boolean;
+    /** Let the body scroll with the page instead of in its own scroll box, so a sticky footer/pagination bar attaches to the window scroll. */
+    scrollWithPage?: boolean;
 }
 
 const StyledHeader = styled('div')(({ theme }) => ({
@@ -62,6 +64,7 @@ export const PageContent: FC<IPageContentProps> = ({
     disableLoading = false,
     className,
     withTabs,
+    scrollWithPage = false,
     ...rest
 }) => {
     const { classes: styles } = useStyles();
@@ -82,6 +85,7 @@ export const PageContent: FC<IPageContentProps> = ({
         {
             [styles.paddingDisabled]: disablePadding,
             [styles.borderDisabled]: disableBorder,
+            [styles.scrollWithPage]: scrollWithPage,
         },
     );
 


### PR DESCRIPTION
Gives the access log a sticky-bottom pagination bar like the projects and events tables, via a new `withStickyFooter` prop on `PageContent` that drops the body's default `overflowX` so `position: sticky` attaches to the window scroll instead of being trapped in the (non-scrolling) body.

<img width="1464" height="606" alt="image" src="https://github.com/user-attachments/assets/ca3aaac6-e776-456e-89a8-42b8976271f8"/>