### PR TITLE
fix(frontend): dedupe react and mui in vite to prevent duplicate copies

### DIFF
--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -102,6 +102,15 @@ export default defineConfig(({ mode }) => {
             },
             resolve: {
                 tsconfigPaths: true,
+                dedupe: [
+                    'react',
+                    'react-dom',
+                    '@mui/material',
+                    '@mui/system',
+                    '@mui/utils',
+                    '@emotion/react',
+                    '@emotion/styled',
+                ],
             },
             plugins: [
                 {


### PR DESCRIPTION
Adds `resolve.dedupe` for React, MUI and Emotion to the frontend Vite config so a single copy of each is always loaded, preventing the duplicate-`@mui/material` scenario that surfaces when the OSS frontend is built inside the enterprise monorepo (where `oss/node_modules` and the enterprise root `node_modules` each resolved their own MUI). Two MUI copies mean two `useForkRef` modules, which produced a "Maximum update depth exceeded" loop on the users page; deduping fixes it and is a no-op for the standalone OSS build (already a single copy).