### PR TITLE
docs: fix dead Code Kitchen podcast link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@ Unleash has evolved significantly over the past few years, and we know how hard 
 
 - [The Unleash YouTube channel](https://www.youtube.com/channel/UCJjGVOc5QBbEje-r7nZEa4A)
 - [_Feature toggles — Why and how to add to your software_ — freeCodeCamp (YouTube)](https://www.youtube.com/watch?v=-yHZ9uLVSp4&t=0s)
-- [_Feature flags with Unleash_ — The Code Kitchen (podcast)](https://divanv.com/podcast/)
 - [_Feature Flags og Unleash med Fredrik Oseberg_ — Utviklerpodden (podcast; Norwegian)](https://pod.space/utviklerpodden/feature-flags-og-unleash-med-fredrik-oseberg)
 
 ### Articles and more

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Unleash has evolved significantly over the past few years, and we know how hard 
 
 - [The Unleash YouTube channel](https://www.youtube.com/channel/UCJjGVOc5QBbEje-r7nZEa4A)
 - [_Feature toggles — Why and how to add to your software_ — freeCodeCamp (YouTube)](https://www.youtube.com/watch?v=-yHZ9uLVSp4&t=0s)
-- [_Feature flags with Unleash_ — The Code Kitchen (podcast)](https://share.fireside.fm/episode/zD-4e4KI+Pr379KBv)
+- [_Feature flags with Unleash_ — The Code Kitchen (podcast)](https://divanv.com/podcast/)
 - [_Feature Flags og Unleash med Fredrik Oseberg_ — Utviklerpodden (podcast; Norwegian)](https://pod.space/utviklerpodden/feature-flags-og-unleash-med-fredrik-oseberg)
 
 ### Articles and more


### PR DESCRIPTION
The Code Kitchen podcast episode link is dead — Fireside's episode-share feature is gone (`share.fireside.fm` 404s entirely). The episode ("Feature flags with Unleash", with Egil and Ivar Østhus) is live on the podcast's site, which embeds the identical Fireside episode id in its player: `https://divanv.com/podcast/` (HTTP 200).
