### PR TITLE
refactor: give each users tab its own loading overlay

### DIFF
--- a/frontend/src/component/admin/users/InactiveUsersList/InactiveUsersListBody.tsx
+++ b/frontend/src/component/admin/users/InactiveUsersList/InactiveUsersListBody.tsx
@@ -25,6 +25,7 @@ import { DateCell } from 'component/common/Table/cells/DateCell/DateCell';
 import { InactiveUsersActionCell } from './InactiveUsersActionCell/InactiveUsersActionCell.tsx';
 import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
 import DeleteUser from './DeleteUser/DeleteUser.tsx';
+import useLoading from 'hooks/useLoading';
 
 type InactiveUserRow = IInactiveUser & { rootRole?: number };
 
@@ -33,6 +34,7 @@ export const InactiveUsersListBody = () => {
     const { setToastData, setToastApiError } = useToast();
     const { inactiveUsers, refetchInactiveUsers } = useInactiveUsers();
     const { users, roles, loading: usersLoading } = useUsers();
+    const ref = useLoading(usersLoading);
     const [delDialog, setDelDialog] = useState(false);
     const [delUser, setDelUser] = useState<IInactiveUser>();
     const closeDelDialog = () => {
@@ -162,7 +164,7 @@ export const InactiveUsersListBody = () => {
     const rowCount = table.getRowModel().rows.length;
 
     return (
-        <>
+        <div ref={ref}>
             <VirtualizedTable tableInstance={table} />
             <ConditionallyRender
                 condition={rowCount === 0}
@@ -185,6 +187,6 @@ export const InactiveUsersListBody = () => {
                     />
                 }
             />
-        </>
+        </div>
     );
 };

--- a/frontend/src/component/admin/users/UsersList/UsersList.tsx
+++ b/frontend/src/component/admin/users/UsersList/UsersList.tsx
@@ -8,6 +8,7 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 import ConfirmUserAdded from '../ConfirmUserAdded/ConfirmUserAdded.tsx';
 import { useUsers } from 'hooks/api/getters/useUsers/useUsers';
 import useAdminUsersApi from 'hooks/api/actions/useAdminUsersApi/useAdminUsersApi';
+import useLoading from 'hooks/useLoading';
 import type { IUser } from 'interfaces/user';
 import type { IRole } from 'interfaces/role';
 import useToast from 'hooks/useToast';
@@ -50,7 +51,8 @@ interface IUsersListProps {
 const UsersList = ({ searchValue }: IUsersListProps) => {
     const navigate = useNavigate();
     const { isOss } = useUiConfig();
-    const { users, roles, refetch } = useUsers();
+    const { users, roles, refetch, loading } = useUsers();
+    const ref = useLoading(loading);
     const { setToastData, setToastApiError } = useToast();
     const { removeUser, userLoading, userApiErrors } = useAdminUsersApi();
     const [pwDialog, setPwDialog] = useState<{ open: boolean; user?: IUser }>({
@@ -299,7 +301,7 @@ const UsersList = ({ searchValue }: IUsersListProps) => {
     const rowCount = table.getRowModel().rows.length;
 
     return (
-        <>
+        <div ref={ref}>
             <UserLimitWarning />
             <UsersHeader />
             <AccessRequestsTable />
@@ -375,7 +377,7 @@ const UsersList = ({ searchValue }: IUsersListProps) => {
             />
 
             {showSSOUpgrade ? <UpgradeSSO /> : null}
-        </>
+        </div>
     );
 };
 

--- a/frontend/src/component/admin/users/UsersTabs/UsersTabs.tsx
+++ b/frontend/src/component/admin/users/UsersTabs/UsersTabs.tsx
@@ -41,7 +41,7 @@ const UsersTabsView = () => {
     usePageTitle('Users');
     const { pathname } = useLocation();
     const { isEnterprise } = useUiConfig();
-    const { users, loading } = useUsers();
+    const { users } = useUsers();
 
     const [searchValue, setSearchValue] = useState('');
 
@@ -73,8 +73,7 @@ const UsersTabsView = () => {
     return (
         <PageContent
             withTabs
-            isLoading={loading}
-            disableLoading={pathname.endsWith('/access-log')}
+            disableLoading
             withStickyFooter
             header={
                 <>


### PR DESCRIPTION
Follow-up to #12580 (alternative to #12587).

Instead of one shared `PageContent isLoading={usersLoading}` overlay that reached into — and stripped — the nested Access log's skeleton, the shared overlay is turned off (`disableLoading`) and each tab owns its own `useLoading`: UsersList and Inactive get their own, and the Access log keeps the one it already had. No tab's loading can clobber another's.

3 files, +11/−8. Verified: access-log skeleton holds through load (no flash), Users tab still skeletons, loaded state clean.