### PR TITLE
refactor: give each users tab its own self-contained PageContent

### DIFF
--- a/frontend/src/component/admin/users/UsersTabs/UsersTabs.tsx
+++ b/frontend/src/component/admin/users/UsersTabs/UsersTabs.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import { Tab, Tabs, styled, useMediaQuery } from '@mui/material';
 import { Route, Routes, useLocation } from 'react-router';
 import { ADMIN } from 'component/providers/AccessProvider/permissions';
@@ -70,88 +70,71 @@ const UsersTabsView = () => {
             : []),
     ];
 
+    const pageHeader = (actions: ReactNode, showSearch: boolean) => (
+        <>
+            <StyledHeader>
+                <StyledTabsContainer>
+                    <Tabs
+                        value={pathname}
+                        indicatorColor='primary'
+                        textColor='primary'
+                        variant='scrollable'
+                        allowScrollButtonsMobile
+                    >
+                        {tabs.map(({ label, path }) => (
+                            <Tab
+                                key={path}
+                                value={path}
+                                label={<TabLink to={path}>{label}</TabLink>}
+                                sx={{ padding: 0 }}
+                            />
+                        ))}
+                    </Tabs>
+                </StyledTabsContainer>
+                <StyledActions>{actions}</StyledActions>
+            </StyledHeader>
+            {showSearch && isSmallScreen ? (
+                <Search initialValue={searchValue} onChange={setSearchValue} />
+            ) : null}
+        </>
+    );
+
     return (
-        <PageContent
-            withTabs
-            isLoading={loading}
-            disableLoading={pathname.endsWith('/access-log')}
-            withStickyFooter
-            header={
-                <>
-                    <StyledHeader>
-                        <StyledTabsContainer>
-                            <Tabs
-                                value={pathname}
-                                indicatorColor='primary'
-                                textColor='primary'
-                                variant='scrollable'
-                                allowScrollButtonsMobile
-                            >
-                                {tabs.map(({ label, path }) => (
-                                    <Tab
-                                        key={path}
-                                        value={path}
-                                        label={
-                                            <TabLink to={path}>{label}</TabLink>
-                                        }
-                                        sx={{ padding: 0 }}
-                                    />
-                                ))}
-                            </Tabs>
-                        </StyledTabsContainer>
-                        <StyledActions>
-                            <Routes>
-                                <Route
-                                    path='inactive'
-                                    element={
-                                        isEnterprise() ? (
-                                            <InactiveUsersHeaderActions />
-                                        ) : null
-                                    }
-                                />
-                                <Route path='access-log' element={null} />
-                                <Route
-                                    path='*'
-                                    element={
-                                        <UsersHeaderActions
-                                            searchValue={searchValue}
-                                            onSearch={setSearchValue}
-                                            isSmallScreen={isSmallScreen}
-                                        />
-                                    }
-                                />
-                            </Routes>
-                        </StyledActions>
-                    </StyledHeader>
-                    <ConditionallyRender
-                        condition={isSmallScreen}
-                        show={
-                            <Routes>
-                                <Route path='inactive' element={null} />
-                                <Route path='access-log' element={null} />
-                                <Route
-                                    path='*'
-                                    element={
-                                        <Search
-                                            initialValue={searchValue}
-                                            onChange={setSearchValue}
-                                        />
-                                    }
-                                />
-                            </Routes>
-                        }
-                    />
-                </>
-            }
-        >
-            <Routes>
-                <Route
-                    index
-                    element={<UsersList searchValue={searchValue} />}
-                />
-                <Route
-                    path='inactive'
-                    element={
+        <Routes>
+            <Route
+                index
+                element={
+                    <PageContent
+                        withTabs
+                        withStickyFooter
+                        header={pageHeader(
+                            <UsersHeaderActions
+                                searchValue={searchValue}
+                                onSearch={setSearchValue}
+                                isSmallScreen={isSmallScreen}
+                            />,
+                            true,
+                        )}
+                        isLoading={loading}
+                    >
+                        <UsersList searchValue={searchValue} />
+                    </PageContent>
+                }
+            />
+            <Route
+                path='inactive'
+                element={
+                    <PageContent
+                        withTabs
+                        withStickyFooter
+                        header={pageHeader(
+                            isEnterprise() ? (
+                                <InactiveUsersHeaderActions />
+                            ) : null,
+                            false,
+                        )}
+                        isLoading={loading}
+                    >
                         <ConditionallyRender
                             condition={isEnterprise()}
                             show={<InactiveUsersListBody />}
@@ -159,12 +142,24 @@ const UsersTabsView = () => {
                                 <PremiumFeature feature='inactive-users' page />
                             }
                         />
-                    }
-                />
-                <Route path='access-log' element={<UserAccessLog />} />
-                <Route path='*' element={<NotFound />} />
-            </Routes>
-        </PageContent>
+                    </PageContent>
+                }
+            />
+            <Route
+                path='access-log'
+                element={
+                    <PageContent
+                        withTabs
+                        withStickyFooter
+                        header={pageHeader(null, false)}
+                        disableLoading
+                    >
+                        <UserAccessLog />
+                    </PageContent>
+                }
+            />
+            <Route path='*' element={<NotFound />} />
+        </Routes>
     );
 };
 


### PR DESCRIPTION
Follow-up to #12580 (alternative to #12586).

Instead of one shared `PageContent` wrapping a `<Routes>`, each route renders its own `<PageContent>` with its own loading scope (the tab strip is rendered into each via a small `pageHeader()` factory, so the visual is unchanged). The Access log's tab uses `disableLoading` since it self-manages, the others pass their own `isLoading`. No shared overlay means nothing can strip a sibling tab's skeleton.

1 file (`UsersTabs.tsx`), +83/−88. Verified: access-log skeleton holds through load, layout (tab strip + card) identical, all tabs render, loaded state clean.