### PR TITLE
Align input fields

### DIFF
--- a/frontend/src/component/common/FormField/FormField.tsx
+++ b/frontend/src/component/common/FormField/FormField.tsx
@@ -27,6 +27,9 @@ const StyledDescription = styled('p')(({ theme }) => ({
 
 const StyledControl = styled('div')(({ theme }) => ({
     marginTop: theme.spacing(1),
+    '& .MuiOutlinedInput-root': {
+        border: `1px solid ${theme.palette.divider}`,
+    },
 }));
 
 const StyledControlAligner = styled('div')(({ theme }) => ({


### PR DESCRIPTION
Feedback from Henning that we should align the input fields in project/flag creation modal with the rest of Unleash to stay consistent

Files changed:
- frontend/src/component/common/FormField/FormField.tsx

🤖 Drafted from the UX Tweak extension — please review.