### PR TITLE
UX Tweak: Reduced spacing at sides of main content

### DIFF
--- a/frontend/src/component/layout/MainLayout/MainLayout.tsx
+++ b/frontend/src/component/layout/MainLayout/MainLayout.tsx
@@ -34,19 +34,19 @@ const MainLayoutContent = styled(Grid)(({ theme }) => ({
     minWidth: 0, // this is a fix for overflowing flex
     maxWidth: `1512px`,
     margin: '0 auto',
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(2),
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
     [theme.breakpoints.up(1856)]: {
         width: '100%',
     },
     [theme.breakpoints.down(1856)]: {
-        marginLeft: theme.spacing(7),
-        marginRight: theme.spacing(7),
+        marginLeft: theme.spacing(3.5),
+        marginRight: theme.spacing(3.5),
     },
     [theme.breakpoints.down('lg')]: {
         maxWidth: `1250px`,
-        paddingLeft: theme.spacing(1),
-        paddingRight: theme.spacing(1),
+        paddingLeft: theme.spacing(0.5),
+        paddingRight: theme.spacing(0.5),
     },
     [theme.breakpoints.down(1024)]: {
         marginLeft: 0,


### PR DESCRIPTION
We have a lot of reduntant spacing in Unleash. The purpose of this PR is to narrow the spacing at the sides of the main content to make a bit more room on smaller screens.

Files changed:
- frontend/src/component/layout/MainLayout/MainLayout.tsx

🤖 Drafted from the UX Tweak extension — please review.