### PR TITLE
perf: avoid OR-join on dependent_features in feature search

### DIFF
--- a/src/lib/features/feature-search/feature-search-store.ts
+++ b/src/lib/features/feature-search/feature-search-store.ts
@@ -150,11 +150,7 @@ class FeatureSearchStore implements IFeatureSearchStore {
 
                 selectColumns = [
                     ...selectColumns,
-                    this.db.raw(`CASE
-                            WHEN dependent_features.parent = features.name THEN 'parent'
-                            WHEN dependent_features.child = features.name THEN 'child'
-                            ELSE null
-                            END AS dependency`),
+                    'feature_dependency.dependency as dependency',
                 ];
 
                 applyQueryParams(query, queryParams);
@@ -210,17 +206,25 @@ class FeatureSearchStore implements IFeatureSearchStore {
                         'feature_strategy_segment.segment_id',
                         'segments.id',
                     )
-                    .leftJoin('dependent_features', (qb) => {
-                        qb.on(
-                            'dependent_features.parent',
-                            '=',
-                            'features.name',
-                        ).orOn(
-                            'dependent_features.child',
-                            '=',
-                            'features.name',
-                        );
-                    })
+                    .leftJoin(
+                        this.db
+                            .select(
+                                'parent as feature_name',
+                                this.db.raw("'parent' as dependency"),
+                            )
+                            .from('dependent_features')
+                            .unionAll((union) => {
+                                union
+                                    .select(
+                                        'child as feature_name',
+                                        this.db.raw("'child' as dependency"),
+                                    )
+                                    .from('dependent_features');
+                            })
+                            .as('feature_dependency'),
+                        'feature_dependency.feature_name',
+                        'features.name',
+                    )
                     .leftJoin(
                         'users',
                         'users.id',


### PR DESCRIPTION
## Problem

The dependency lookup in the feature search query (`GET /api/admin/search/features`) joined `dependent_features` with an `OR` predicate:

```sql
left join dependent_features
  on dependent_features.parent = features.name
  or dependent_features.child  = features.name
```

Postgres cannot hash an `OR` join condition, so it falls back to a nested loop with a `BitmapOr` index probe per outer row. 

On a dataset with 18k active flags fanning out to ~45 rows per flag, that is **810,210 probes against a table holding 800 rows**, and those probes accounted for **99.9% of the query's shared buffer hits**. 

```
Bitmap Heap Scan on dependent_features  (actual time=0.016..0.016 rows=0 loops=810210)
  Recheck Cond: ((parent = features.name) OR (child = features.name))
  Buffers: shared hit=9,785,765
```

## Change

Replace the `OR` join with a `UNION ALL` derived table so the predicate becomes a plain equality, which the planner can satisfy with a merge join. The `CASE` that derived `dependency` is no longer needed, the branch is now carried as a literal column in each arm of the union.

## Results

Measured on a seeded dataset of 20k flags (18k active) × 5 environments, 120k strategies, 30k tags, 30k strategy-segments and 800 dependencies:

| | before | after | |
|---|---|---|---|
| shared buffer hits | 9,796,910 | 15,105 | 648× fewer |
| query time | ~16.4s | ~3.6s | 4.5× faster |
