### PR TITLE
fix(frontend-api): update cached frontend settings when updating CORS origins

### DIFF
--- a/src/lib/features/frontend-api/frontend-api-service.test.ts
+++ b/src/lib/features/frontend-api/frontend-api-service.test.ts
@@ -64,3 +64,39 @@ test('frontend api service fetching features from global cache', async () => {
     expect(features).toHaveLength(1);
     expect(createdFrontendRepositoriesCount).toBe(1);
 });
+
+test('setFrontendCorsSettings updates cached frontend settings immediately', async () => {
+    let storedSettings: any = {
+        frontendApiOrigins: ['https://initial.example.com'],
+    };
+    const settingService = {
+        getWithDefault: async () => storedSettings,
+        insert: async (_key: string, value: any) => {
+            storedSettings = value;
+        },
+    };
+
+    const frontendApiService = new FrontendApiService(
+        {
+            getLogger: noLogger,
+            eventBus: new EventEmitter(),
+            frontendApiOrigins: [],
+        } as unknown as Config,
+        { settingService } as any,
+        {} as any,
+    );
+
+    // Populate initial cache
+    const initial = await frontendApiService.getFrontendSettings(true);
+    expect(initial.frontendApiOrigins).toEqual(['https://initial.example.com']);
+
+    // Update CORS settings
+    await frontendApiService.setFrontendCorsSettings(
+        ['https://updated.example.com'],
+        { id: 1, username: 'test-user', ip: '127.0.0.1' },
+    );
+
+    // Cached settings should immediately reflect updated settings
+    const cached = await frontendApiService.getFrontendSettings(true);
+    expect(cached.frontendApiOrigins).toEqual(['https://updated.example.com']);
+});

--- a/src/lib/features/frontend-api/frontend-api-service.ts
+++ b/src/lib/features/frontend-api/frontend-api-service.ts
@@ -249,12 +249,14 @@ export class FrontendApiService {
             throw new BadDataError(error);
         }
         const settings = (await this.getFrontendSettings(false)) || {};
+        const updatedSettings = { ...settings, frontendApiOrigins: value };
         await this.services.settingService.insert(
             frontendSettingsKey,
-            { ...settings, frontendApiOrigins: value },
+            updatedSettings,
             auditUser,
             false,
         );
+        this.cachedFrontendSettings = updatedSettings;
     }
 
     async fetchFrontendSettings(): Promise<FrontendSettings> {


### PR DESCRIPTION
## Summary
Fixes #12561

When `setFrontendCorsSettings` updates CORS origins in the database, it previously left `this.cachedFrontendSettings` with the stale pre-write settings fetched during validation. Consequently, subsequent calls to `getFrontendSettings(true)` (such as in CORS headers middleware) served outdated CORS configuration until the cache expired or was refreshed.

## Changes
- In `FrontendApiService.setFrontendCorsSettings`, assign the updated settings object to `this.cachedFrontendSettings` upon successful write.
- Added unit test in `frontend-api-service.test.ts` verifying that `setFrontendCorsSettings` immediately updates cached settings.