### PR TITLE
fix: hide SSO options on the invitation screen

### DIFF
--- a/frontend/src/component/user/NewUser/NewUser.test.tsx
+++ b/frontend/src/component/user/NewUser/NewUser.test.tsx
@@ -41,17 +41,22 @@ const setupValidInvite = () => {
     });
 };
 
-test('should render SSO options when signing up with an invite link', async () => {
+test('should not render SSO options when signing up with an invite link', async () => {
     setupAuthDetails();
     setupValidInvite();
 
     render(<NewUser />, { route: '/new-user?invite=valid-secret' });
 
     await screen.findByLabelText(/Full name/);
-    expect(screen.getByTestId(`${SSO_LOGIN_BUTTON}-oidc`)).toBeInTheDocument();
     expect(
-        screen.getByTestId(`${SSO_LOGIN_BUTTON}-github`),
-    ).toBeInTheDocument();
+        screen.queryByTestId(`${SSO_LOGIN_BUTTON}-oidc`),
+    ).not.toBeInTheDocument();
+    expect(
+        screen.queryByTestId(`${SSO_LOGIN_BUTTON}-github`),
+    ).not.toBeInTheDocument();
+    expect(
+        screen.queryByText('or sign-up with an email address'),
+    ).not.toBeInTheDocument();
 });
 
 test('should render SSO options for an invite link when password auth is hidden', async () => {

--- a/frontend/src/component/user/NewUser/NewUser.test.tsx
+++ b/frontend/src/component/user/NewUser/NewUser.test.tsx
@@ -1,0 +1,91 @@
+import { expect, test } from 'vitest';
+import { screen } from '@testing-library/react';
+import { SSO_LOGIN_BUTTON } from 'utils/testIds';
+import { NewUser } from './NewUser.tsx';
+import { INVALID_TOKEN_ERROR } from 'hooks/api/getters/useResetPassword/useResetPassword';
+import { testServerSetup, testServerRoute } from 'utils/testServer';
+import { render } from 'utils/testRenderer';
+
+const server = testServerSetup();
+
+const ssoOptions = [
+    { type: 'oidc', message: 'Sign in with Google', path: '/auth/oidc/login' },
+    {
+        type: 'github',
+        message: 'Sign in with GitHub',
+        path: '/auth/github/login',
+    },
+];
+
+const setupAuthDetails = ({
+    defaultHidden = false,
+    options = ssoOptions,
+}: {
+    defaultHidden?: boolean;
+    options?: typeof ssoOptions;
+} = {}) => {
+    testServerRoute(server, '/api/admin/ui-config', {});
+    testServerRoute(server, '/api/admin/user', {
+        type: 'password',
+        path: '/auth/simple/login',
+        message: 'You must sign in in order to use Unleash',
+        defaultHidden,
+        options,
+    });
+};
+
+const setupValidInvite = () => {
+    testServerRoute(server, '/invite/valid-secret/validate', {});
+    testServerRoute(server, '/auth/reset/validate', {
+        name: INVALID_TOKEN_ERROR,
+    });
+};
+
+test('should render SSO options when signing up with an invite link', async () => {
+    setupAuthDetails();
+    setupValidInvite();
+
+    render(<NewUser />, { route: '/new-user?invite=valid-secret' });
+
+    await screen.findByLabelText(/Full name/);
+    expect(screen.getByTestId(`${SSO_LOGIN_BUTTON}-oidc`)).toBeInTheDocument();
+    expect(
+        screen.getByTestId(`${SSO_LOGIN_BUTTON}-github`),
+    ).toBeInTheDocument();
+});
+
+test('should render SSO options for an invite link when password auth is hidden', async () => {
+    setupAuthDetails({ defaultHidden: true });
+    setupValidInvite();
+
+    render(<NewUser />, { route: '/new-user?invite=valid-secret' });
+
+    await screen.findByTestId(`${SSO_LOGIN_BUTTON}-oidc`);
+    expect(screen.queryByLabelText(/Full name/)).not.toBeInTheDocument();
+});
+
+test('should not render SSO options for an invite link when no SSO is configured', async () => {
+    setupAuthDetails({ options: [] });
+    setupValidInvite();
+
+    render(<NewUser />, { route: '/new-user?invite=valid-secret' });
+
+    await screen.findByLabelText(/Full name/);
+    expect(
+        screen.queryByTestId(`${SSO_LOGIN_BUTTON}-oidc`),
+    ).not.toBeInTheDocument();
+});
+
+test('should render SSO options when resetting a password', async () => {
+    setupAuthDetails();
+    testServerRoute(server, '/auth/reset/validate', {
+        email: 'user@getunleash.io',
+    });
+
+    render(<NewUser />, { route: '/new-user?token=valid-token' });
+
+    await screen.findByTestId(`${SSO_LOGIN_BUTTON}-oidc`);
+    expect(
+        screen.getByTestId(`${SSO_LOGIN_BUTTON}-github`),
+    ).toBeInTheDocument();
+});

--- a/frontend/src/component/user/NewUser/NewUser.test.tsx
+++ b/frontend/src/component/user/NewUser/NewUser.test.tsx
@@ -17,20 +17,14 @@ const ssoOptions = [
     },
 ];
 
-const setupAuthDetails = ({
-    defaultHidden = false,
-    options = ssoOptions,
-}: {
-    defaultHidden?: boolean;
-    options?: typeof ssoOptions;
-} = {}) => {
+const setupAuthDetails = (defaultHidden = false) => {
     testServerRoute(server, '/api/admin/ui-config', {});
     testServerRoute(server, '/api/admin/user', {
         type: 'password',
         path: '/auth/simple/login',
         message: 'You must sign in in order to use Unleash',
         defaultHidden,
-        options,
+        options: ssoOptions,
     });
 };
 
@@ -60,25 +54,13 @@ test('should not render SSO options when signing up with an invite link', async 
 });
 
 test('should render SSO options for an invite link when password auth is hidden', async () => {
-    setupAuthDetails({ defaultHidden: true });
+    setupAuthDetails(true);
     setupValidInvite();
 
     render(<NewUser />, { route: '/new-user?invite=valid-secret' });
 
     await screen.findByTestId(`${SSO_LOGIN_BUTTON}-oidc`);
     expect(screen.queryByLabelText(/Full name/)).not.toBeInTheDocument();
-});
-
-test('should not render SSO options for an invite link when no SSO is configured', async () => {
-    setupAuthDetails({ options: [] });
-    setupValidInvite();
-
-    render(<NewUser />, { route: '/new-user?invite=valid-secret' });
-
-    await screen.findByLabelText(/Full name/);
-    expect(
-        screen.queryByTestId(`${SSO_LOGIN_BUTTON}-oidc`),
-    ).not.toBeInTheDocument();
 });
 
 test('should render SSO options when resetting a password', async () => {

--- a/frontend/src/component/user/NewUser/NewUser.tsx
+++ b/frontend/src/component/user/NewUser/NewUser.tsx
@@ -40,6 +40,9 @@ export const NewUser = () => {
     const { resetPassword, loading: isPasswordSubmitting } =
         useAuthResetPasswordApi();
     const passwordDisabled = authDetails?.defaultHidden === true;
+    const showAuthOptions =
+        Boolean(authDetails?.options?.length) &&
+        (!isValidInvite || passwordDisabled);
 
     const onSubmitInvitedUser = async (password: string) => {
         try {
@@ -132,7 +135,7 @@ export const NewUser = () => {
                 .
             </Typography>
             <ConditionallyRender
-                condition={Boolean(authDetails?.options?.length)}
+                condition={showAuthOptions}
                 show={
                     <Box sx={{ mt: 2 }}>
                         <AuthOptions options={authDetails?.options} />
@@ -140,9 +143,7 @@ export const NewUser = () => {
                 }
             />
             <ConditionallyRender
-                condition={
-                    Boolean(authDetails?.options?.length) && !passwordDisabled
-                }
+                condition={showAuthOptions && !passwordDisabled}
                 show={
                     <DividerText
                         text='or sign-up with an email address'


### PR DESCRIPTION
## Changes

- Hide the SSO buttons and the "or sign-up with an email address" divider when the screen was reached via an invite link (`?invite=…`).
- The password-reset flow (`?token=…`) is unchanged.
- On SSO-only instances (`defaultHidden: true`), where the signup form is hidden anyway, the buttons still render — otherwise the screen would be blank.
