### PR TITLE
test: raise global vitest timeouts for the frontend suite

### DIFF
--- a/frontend/src/component/changeRequest/ChangeRequest.test.tsx
+++ b/frontend/src/component/changeRequest/ChangeRequest.test.tsx
@@ -304,4 +304,4 @@ test('add flag change to pending change request', async () => {
     fireEvent.click(flag);
 
     await verifyChangeRequestDialog('Enable feature flag test in production');
-}, 10000);
+});

--- a/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.test.tsx
+++ b/frontend/src/component/feature/FeatureToggleList/FeatureToggleListTable.test.tsx
@@ -127,4 +127,4 @@ test('Filter table by project', async () => {
     expect(window.location.href).toContain(
         '?offset=0&columns=&project=IS%3Aproject-b',
     );
-}, 10000);
+});

--- a/frontend/src/component/onboarding/intro/Intro.test.tsx
+++ b/frontend/src/component/onboarding/intro/Intro.test.tsx
@@ -225,7 +225,7 @@ test('walks through the connected story to the showcase', () => {
         screen.getByRole('button', { name: 'Create feature flag' }),
     ).toBeInTheDocument();
     vi.useRealTimers();
-}, 10000);
+});
 
 test('finishes after the three core steps when advanced steps are disabled', () => {
     const onFinish = vi.fn();
@@ -467,7 +467,7 @@ test('keeps metrics live without errors until production is enabled', () => {
     );
     expect(successfulAfterFirstRecoverySample).toBeLessThan(128);
     vi.useRealTimers();
-}, 10000);
+});
 
 test('groups rapid environment events without inventing an incident', () => {
     vi.useFakeTimers();
@@ -1038,7 +1038,7 @@ test('teaches manual recovery before a safeguard automates it', () => {
         }),
     ).not.toBeChecked();
     vi.useRealTimers();
-}, 10000);
+});
 
 test('hands the idle nudge from the toggle to Next once production is on', () => {
     vi.useFakeTimers();

--- a/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.test.tsx
+++ b/frontend/src/component/project/Project/PaginatedProjectFeatureToggles/ProjectFeatureToggles.test.tsx
@@ -98,7 +98,7 @@ test('filters by flag type', async () => {
 
     await screen.findByText('Flag type');
     await screen.findByText('Operational');
-}, 10000);
+});
 
 test('selects project features', async () => {
     setupApi();
@@ -140,7 +140,7 @@ test('selects project features', async () => {
     // deselect a single item
     fireEvent.click(selectFeatureA);
     expect(screen.queryByTestId(BATCH_SELECTED_COUNT)).not.toBeInTheDocument();
-}, 10000);
+});
 
 test('clears the selection when the filters change', async () => {
     setupApi();
@@ -173,7 +173,7 @@ test('clears the selection when the filters change', async () => {
             screen.queryByTestId(BATCH_SELECTED_COUNT),
         ).not.toBeInTheDocument();
     });
-}, 16000);
+});
 
 test('filters by tag', async () => {
     setupApi();
@@ -198,7 +198,7 @@ test('filters by tag', async () => {
 
     await screen.findByText('include');
     expect(await screen.findAllByText('backend:sdk')).toHaveLength(2);
-}, 10000);
+});
 
 test('filters by flag author', async () => {
     setupApi();
@@ -227,7 +227,7 @@ test('filters by flag author', async () => {
     fireEvent.click(authorA);
 
     expect(window.location.href).toContain('createdBy=IS%3A1');
-}, 10000);
+});
 
 test('Project is onboarded', async () => {
     const projectId = 'default';
@@ -249,7 +249,7 @@ test('Project is onboarded', async () => {
         },
     );
     expect(screen.queryByText('Project setup')).not.toBeInTheDocument();
-}, 10000);
+});
 
 test('Project is not onboarded', async () => {
     const projectId = 'default';
@@ -271,7 +271,7 @@ test('Project is not onboarded', async () => {
         },
     );
     await screen.findByText('Project setup');
-}, 10000);
+});
 
 test('renders lifecycle quick filters', async () => {
     setupApi();
@@ -296,7 +296,7 @@ test('renders lifecycle quick filters', async () => {
     await screen.findByText(/Develop/);
     await screen.findByText(/Rollout production/);
     await screen.findByText(/Cleanup/);
-}, 10000);
+});
 
 test('shows onboarding steps when flag is enabled and project is not onboarded', async () => {
     const projectId = 'default';
@@ -317,7 +317,7 @@ test('shows onboarding steps when flag is enabled and project is not onboarded',
         { route: `/projects/${projectId}` },
     );
     await screen.findByText('Project setup');
-}, 10000);
+});
 
 test('shows revive and delete actions for archived flags', async () => {
     setupApi();
@@ -375,7 +375,7 @@ test('shows revive and delete actions for archived flags', async () => {
     expect(
         screen.queryByRole('menuitem', { name: 'Clone' }),
     ).not.toBeInTheDocument();
-}, 10000);
+});
 
 test('shows archived batch actions when every selected flag is archived', async () => {
     setupApi();
@@ -435,7 +435,7 @@ test('shows archived batch actions when every selected flag is archived', async 
     expect(
         within(batchActions).queryByRole('button', { name: 'Revive' }),
     ).not.toBeInTheDocument();
-}, 10000);
+});
 
 test('rewrites legacy archived view URLs to the archived lifecycle filter', async () => {
     setupApi();
@@ -460,4 +460,4 @@ test('rewrites legacy archived view URLs to the archived lifecycle filter', asyn
         expect(window.location.href).not.toContain('archived=IS%3Atrue');
         expect(window.location.href).toContain('lifecycle=IS%3Aarchived');
     });
-}, 10000);
+});

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -22,6 +22,8 @@ const vitestConfig = vitestDefineConfig({
         globals: true,
         setupFiles: 'src/setupTests.ts',
         environment: 'jsdom',
+        testTimeout: 30_000,
+        hookTimeout: 30_000,
         exclude: [...configDefaults.exclude, '**/cypress/**'],
         server: {
             deps: {


### PR DESCRIPTION
The frontend suite ran on vitest's 5s default timeout, with 17 hand-rolled per-test overrides (`}, 10000)` / `}, 16000)`) sprinkled across the slowest tests. Under parallel-worker load on CI those ceilings were routinely crossed, producing timeout failures unrelated to whatever change was under test.

## Changes

- Set `testTimeout: 30_000` and `hookTimeout: 30_000` in `frontend/vite.config.mts`.
- Remove all 17 per-test timeout overrides. Every one of them was *below* the new global, so leaving them in place would have kept exactly the slowest tests failing.
