### PR TITLE
perf: avoid OR-join on dependent_features in feature search

### DIFF
--- a/src/lib/features/feature-search/feature-search-store.ts
+++ b/src/lib/features/feature-search/feature-search-store.ts
@@ -150,11 +150,7 @@ class FeatureSearchStore implements IFeatureSearchStore {
 
                 selectColumns = [
                     ...selectColumns,
-                    this.db.raw(`CASE
-                            WHEN dependent_features.parent = features.name THEN 'parent'
-                            WHEN dependent_features.child = features.name THEN 'child'
-                            ELSE null
-                            END AS dependency`),
+                    'feature_dependency.dependency as dependency',
                 ];
 
                 applyQueryParams(query, queryParams);
@@ -219,17 +215,25 @@ class FeatureSearchStore implements IFeatureSearchStore {
                         'feature_segments.feature_name',
                         'features.name',
                     )
-                    .leftJoin('dependent_features', (qb) => {
-                        qb.on(
-                            'dependent_features.parent',
-                            '=',
-                            'features.name',
-                        ).orOn(
-                            'dependent_features.child',
-                            '=',
-                            'features.name',
-                        );
-                    })
+                    .leftJoin(
+                        this.db
+                            .select(
+                                'parent as feature_name',
+                                this.db.raw("'parent' as dependency"),
+                            )
+                            .from('dependent_features')
+                            .unionAll((union) => {
+                                union
+                                    .select(
+                                        'child as feature_name',
+                                        this.db.raw("'child' as dependency"),
+                                    )
+                                    .from('dependent_features');
+                            })
+                            .as('feature_dependency'),
+                        'feature_dependency.feature_name',
+                        'features.name',
+                    )
                     .leftJoin(
                         'users',
                         'users.id',


### PR DESCRIPTION


## Problem

The dependency lookup in the feature search query joins `dependent_features` with an `OR` predicate:

```sql
left join dependent_features
  on dependent_features.parent = features.name
  or dependent_features.child  = features.name
```

Postgres cannot hash an `OR` join condition, and cannot `Memoize` it either, since both need an equality to key on. So it plans a nested loop with a `BitmapOr` index probe per outer row, and re-executes that probe from scratch on every iteration, even when it matches nothing:

```
Bitmap Heap Scan on dependent_features  (actual time=0.020..0.020 rows=0 loops=18000)
  Recheck Cond: ((parent = features.name) OR (child = features.name))
  Buffers: shared hit=217,440
```

Those probes are **93% of the query's total buffer traffic**. Because every one is a cache *hit*, it shows up as CPU load with no disk I/O, invisible if you're watching IOPS.

## Change

Replace the `OR` with a `UNION ALL` derived table so the predicate becomes a plain equality, which the planner satisfies with a merge join. The `CASE` deriving `dependency` is no longer neede, each arm of the union carries its own literal.

## Results

Interleaved rounds, median, measured against current `main`:

| dataset | main | this PR | |
|---|---|---|---|
| 20,000 flags | 4,888 ms | **2,175 ms** | **2.25×** |
| | 233,823 buffers | **12,580** | **18.6× fewer** |
| 1,812 flags | 46.6 ms | 45.9 ms | no change |
| | 2,011 buffers | 2,012 | no change |

**This is a scaling fix, not a broad speedup**, and the small-instance row is the honest part of the story. Below a certain size the planner materialises the tiny `dependent_features` table and loops over it in memory for free, so there is nothing to win. The `BitmapOr` nested loop only appears once the outer row set is large, which is exactly where the query is already struggling. It removes a cliff rather than making everything faster.
