### PR TITLE
fix: reject duplicate strategy parameter names

### DIFF
--- a/src/lib/routes/admin-api/strategy.test.ts
+++ b/src/lib/routes/admin-api/strategy.test.ts
@@ -76,6 +76,32 @@ test('create a new strategy with empty parameters', async () => {
         .expect(201);
 });
 
+test('does not allow duplicate parameter names when creating a strategy', async () => {
+    const { request, base, strategyStore } = await getSetup();
+    const name = 'DuplicateParametersStrategy';
+
+    const { body } = await request
+        .post(`${base}/api/admin/strategies`)
+        .send({
+            name,
+            parameters: [
+                {
+                    name: 'twin',
+                    type: 'string',
+                },
+                {
+                    name: 'twin',
+                    type: 'number',
+                },
+            ],
+        })
+        .expect(400);
+
+    expect(body.name).toBe('BadDataError');
+    expect(body.details[0].message).toContain('contains a duplicate value');
+    expect(await strategyStore.exists(name)).toBe(false);
+});
+
 test('creating strategies is forbidden when disabled by configuration', async () => {
     process.env.UNLEASH_DISABLE_CUSTOM_STRATEGY_CREATION = 'true';
     const { request, base } = await getSetup();
@@ -109,6 +135,44 @@ test('update strategy', async () => {
         .put(`${base}/api/admin/strategies/${name}`)
         .send({ name, parameters: [], description: 'added' })
         .expect(200);
+});
+
+test('does not allow duplicate parameter names when updating a strategy', async () => {
+    const { request, base, strategyStore } = await getSetup();
+    const name = 'DuplicateParametersUpdateStrategy';
+    const originalParameters = [
+        {
+            name: 'region',
+            type: 'string' as const,
+        },
+    ];
+
+    await strategyStore.createStrategy({
+        name,
+        parameters: originalParameters,
+    });
+
+    const { body } = await request
+        .put(`${base}/api/admin/strategies/${name}`)
+        .send({
+            parameters: [
+                {
+                    name: 'quota',
+                    type: 'number',
+                },
+                {
+                    name: 'quota',
+                    type: 'string',
+                },
+            ],
+        })
+        .expect(400);
+
+    expect(body.name).toBe('BadDataError');
+    expect(body.details[0].message).toContain('contains a duplicate value');
+
+    const storedStrategy = await strategyStore.get(name);
+    expect(storedStrategy?.parameters).toEqual(originalParameters);
 });
 
 test('updating strategies is forbidden when disabled by configuration', async () => {

--- a/src/lib/services/strategy-schema.ts
+++ b/src/lib/services/strategy-schema.ts
@@ -20,7 +20,8 @@ const strategySchema = joi
                     description: joi.string().allow(null).allow('').optional(),
                     required: joi.boolean(),
                 }),
-            ),
+            )
+            .unique('name', { ignoreUndefined: true }),
     })
     .options({ allowUnknown: false, stripUnknown: true, abortEarly: false });
 export default strategySchema;


### PR DESCRIPTION
Summary

Custom strategy types could be created or updated with multiple parameters using the same name, even though parameter names are required to be unique.

This change adds validation to reject duplicate parameter names before the strategy is written to the store.

Closes #12563

Approach

Both strategy creation and update already pass through the shared strategySchema validation.

Instead of adding separate checks in the create and update paths, I added the uniqueness rule directly to the existing Joi schema:

.unique('name', { ignoreUndefined: true })

This keeps the validation centralized and covers both create and update operations.

Using name as the uniqueness key also ensures that parameters with the same name but different types are still rejected.

The existing Joi error handling is preserved, so duplicate parameters return the existing 400 BadDataError response format.

Tests

Added regression coverage for both create and update:

duplicate parameter names on create return 400 BadDataError
rejected creates are not persisted
duplicate parameter names on update return 400 BadDataError
rejected updates leave the existing strategy unchanged
valid strategy creation continues to work
Verification
Duplicate parameter names on create → 400 BadDataError
Valid strategy creation → 201 Created
Duplicate parameter names on update → 400 BadDataError
Strategy tests → 20/20 passed
Backend TypeScript build → passed
Biome check → passed
AI assistance disclosure

AI-assisted tools were used during analysis and implementation support. The resulting changes were reviewed manually and verified through the project tests, TypeScript build, linting, and PostgreSQL-backed API behavior.